### PR TITLE
Fix .clang-format for newer versions of clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,24 +20,25 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
+BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Allman
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
@@ -84,7 +85,7 @@ ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 20
 PenaltyBreakBeforeFirstCallParameter: 1000
-PenaltyBreakComment: 300
+PenaltyBreakComment: 120
 PenaltyBreakFirstLessLess: 125
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 10

--- a/media/server/ipc/include/IMediaKeysCapabilitiesModuleService.h
+++ b/media/server/ipc/include/IMediaKeysCapabilitiesModuleService.h
@@ -30,7 +30,8 @@ namespace firebolt::rialto::server::ipc
 class IMediaKeysCapabilitiesModuleService;
 
 /**
- * @brief IMediaKeysCapabilitiesModuleService factory class, returns a concrete implementation of IMediaKeysCapabilitiesModuleService
+ * @brief IMediaKeysCapabilitiesModuleService factory class, returns a concrete implementation of
+ * IMediaKeysCapabilitiesModuleService
  */
 class IMediaKeysCapabilitiesModuleServiceFactory
 {

--- a/media/server/main/include/DataReaderV1.h
+++ b/media/server/main/include/DataReaderV1.h
@@ -41,8 +41,8 @@ class DataReaderV1 : public IDataReader
         std::uint32_t streamId;      /* stream id (unique ID for ES, as defined in attachSource()) */
         std::uint32_t extraDataSize; /* extraData size */
         std::uint8_t extraData[32];  /* buffer containing extradata */
-        std::uint32_t
-            mediaKeysId; /* Identifier of MediaKeys instance to use for decryption. If 0 use any CDM containing the MKS ID */
+        std::uint32_t mediaKeysId;   /* Identifier of MediaKeys instance to use for decryption. If 0 use any CDM
+                                        containing the MKS ID */
         std::uint32_t mediaKeySessionIdentifierOffset; /* Offset to the location of the MediaKeySessionIdentifier */
         std::uint32_t mediaKeySessionIdentifierLength; /* Length of the MediaKeySessionIdentifier */
         std::uint32_t initVectorOffset;                /* Offset to the location of the initialization vector */


### PR DESCRIPTION
- Fixes .clang-format file which used some custom `BraceWrapping` and had 'BreakBeforeBraces: Allman'. This does not work as per clang-format documentation. In order to use 'BraceWrapping' we have to set 'BreakBeforeBraces: Custom', then customise 'BraceWrapping' as we wish.

- Fixes 'PenaltyBreakComment: 120' to conform with 'Line length'[1].

Tested using:
 - $ clang --version | head -n1 clang version 14.0.5 (Fedora 14.0.5-1.fc36)

 - $ clang-format-10 --version clang-format version 10.0.0-4ubuntu1~18.04.2

[1] https://wiki.rdkcentral.com/display/ASP/Rialto+Coding+Guidelines

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>