### PR TITLE
Fix linking RialtoServer for UnitTests

### DIFF
--- a/media/server/CMakeLists.txt
+++ b/media/server/CMakeLists.txt
@@ -54,6 +54,10 @@ set_target_properties(
         PROPERTIES LINK_FLAGS "-Wl,--unresolved-symbols=report-all"
 )
 
+if( CMAKE_BUILD_FLAG STREQUAL "UnitTests" )
+        set( RialtoServerStubsLibs RialtoServerStubs )
+endif()
+
 target_link_libraries(
         RialtoServer
 
@@ -61,6 +65,7 @@ target_link_libraries(
         RialtoServerIpc
         RialtoServerMain
         RialtoServerService
+        ${RialtoServerStubsLibs}
 )
 
 install(


### PR DESCRIPTION
Fixes linking error:
[ 81%] Linking CXX executable RialtoServer
/usr/bin/ld: main/libRialtoServerMain.a(MediaKeysServerInternal.cpp.o):
  in function `firebolt::rialto::server::MediaKeysServerInternalFactory::
    createMediaKeysServerInternal(std::__cxx11::basic_string<char,
      std::char_traits<char>, std::allocator<char> > const&) const':
rialto/media/server/main/source/MediaKeysServerInternal.cpp:70:
  undefined reference to `firebolt::rialto::server::IOcdmSystemFactory::createFactory()'
/usr/bin/ld: main/libRialtoServerMain.a(MediaKeysCapabilities.cpp.o):
  in function `firebolt::rialto::MediaKeysCapabilitiesFactory::
  getMediaKeysCapabilities() const':
rialto/media/server/main/source/MediaKeysCapabilities.cpp:76: undefined reference to `firebolt::rialto::server::IOcdmSystemFactory::createFactory()' /usr/bin/ld: rialto/media/server/main/source/MediaKeysCapabilities.cpp:75:
  undefined reference to `firebolt::rialto::server::IOcdmFactory::createFactory()'

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>