### PR TITLE
Stop using deprecated g_memdup()

### DIFF
--- a/media/server/gstplayer/include/IGstWrapper.h
+++ b/media/server/gstplayer/include/IGstWrapper.h
@@ -755,7 +755,7 @@ public:
      *
      * @retval pointer to the new caps
      */
-    virtual GstCaps *gstCodecUtilsOpusCreateCapsFromHeader(gconstpointer data, gsize size) const = 0;
+    virtual GstCaps *gstCodecUtilsOpusCreateCapsFromHeader(gconstpointer data, guint size) const = 0;
 
     /**
      * @brief Checks if all caps represented by subset are in superset.

--- a/tests/media/server/mocks/gstplayer/GstWrapperMock.h
+++ b/tests/media/server/mocks/gstplayer/GstWrapperMock.h
@@ -115,7 +115,7 @@ public:
     MOCK_METHOD(gboolean, gstByteWriterPutUint16Be, (GstByteWriter * writer, guint16 val), (const, override));
     MOCK_METHOD(gboolean, gstByteWriterPutUint32Be, (GstByteWriter * writer, guint32 val), (const, override));
     MOCK_METHOD(GstBuffer *, gstBufferNewWrapped, (gpointer data, gsize size), (const, override));
-    MOCK_METHOD(GstCaps *, gstCodecUtilsOpusCreateCapsFromHeader, (gconstpointer data, gsize size), (const, override));
+    MOCK_METHOD(GstCaps *, gstCodecUtilsOpusCreateCapsFromHeader, (gconstpointer data, guint size), (const, override));
     MOCK_METHOD(gboolean, gstCapsIsSubset, (const GstCaps *subset, const GstCaps *superset), (const));
     MOCK_METHOD(gboolean, gstCapsIsStrictlyEqual, (const GstCaps *caps1, const GstCaps *caps2), (const));
     MOCK_METHOD(gboolean, gstCapsCanIntersect, (const GstCaps *caps1, const GstCaps *caps2), (const));


### PR DESCRIPTION
Fixes the following build error:

 rialto/media/server/gstplayer/source/GstWrapper.cpp:20:
 rialto/media/server/gstplayer/include/GstWrapper.h:
 In member function ‘virtual GstCaps* firebolt::rialto::server::
 GstWrapper::gstCodecUtilsOpusCreateCapsFromHeader(gconstpointer, gsize) const’:
 rialto/media/server/gstplayer/include/GstWrapper.h:308:57:
 error: ‘void* g_memdup(gconstpointer, guint)’ is deprecated:
 Use 'g_memdup2' instead [-Werror=deprecated-declarations]
  308 |         GstBuffer *tmp = gst_buffer_new_wrapped(g_memdup(data, size), size);
      |                                                 ~~~~~~~~^~~~~~~~~~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>

--
Summary: Stop using deprecated g_memdup()
Type: fix
Owner: Damian Wrobel
Test Plan: Unit Tests
Dependencies and Impacts: None