### PR TITLE
Fix some compilation errors

### DIFF
--- a/ipc/client/source/BlockingClosure.cpp
+++ b/ipc/client/source/BlockingClosure.cpp
@@ -90,7 +90,7 @@ void BlockingClosurePoll::wait()
     }
 }
 
-BlockingClosureSemaphore::BlockingClosureSemaphore() : m_sem{0}
+BlockingClosureSemaphore::BlockingClosureSemaphore() : m_sem{{0}}
 {
     sem_init(&m_sem, 0, 0);
 }

--- a/ipc/client/source/IpcChannelImpl.cpp
+++ b/ipc/client/source/IpcChannelImpl.cpp
@@ -598,7 +598,7 @@ void ChannelImpl::processWakeEvent()
  */
 void ChannelImpl::updateTimeoutTimer()
 {
-    struct itimerspec ts = {0};
+    struct itimerspec ts = {{0}};
 
     // if no method calls then just disarm the timer
     if (!m_methodCalls.empty())

--- a/media/common/include/MediaFrameWriterV1.h
+++ b/media/common/include/MediaFrameWriterV1.h
@@ -60,7 +60,7 @@ public:
      *
      * @retval number of written frames
      */
-    uint32_t getNumFrames() { return m_numFrames; }
+    uint32_t getNumFrames() override { return m_numFrames; }
 
     /**
      * @brief The version of metadata this object shall write.

--- a/media/common/include/MediaFrameWriterV2.h
+++ b/media/common/include/MediaFrameWriterV2.h
@@ -61,7 +61,7 @@ public:
      *
      * @retval number of written frames
      */
-    uint32_t getNumFrames() { return m_numFrames; }
+    uint32_t getNumFrames() override { return m_numFrames; }
 
 private:
     /**

--- a/media/server/gstplayer/include/GstWrapper.h
+++ b/media/server/gstplayer/include/GstWrapper.h
@@ -157,7 +157,7 @@ public:
         return gst_element_get_static_pad(element, name);
     }
 
-    gboolean gstElementQueryPosition(GstElement *element, GstFormat format, gint64 *cur)
+    gboolean gstElementQueryPosition(GstElement *element, GstFormat format, gint64 *cur) override
     {
         return gst_element_query_position(element, format, cur);
     }
@@ -176,7 +176,7 @@ public:
     gboolean gstElementAddPad(GstElement *element, GstPad *pad) override { return gst_element_add_pad(element, pad); }
 
     gboolean gstElementSeek(GstElement *element, gdouble rate, GstFormat format, GstSeekFlags flags,
-                            GstSeekType start_type, gint64 start, GstSeekType stop_type, gint64 stop)
+                            GstSeekType start_type, gint64 start, GstSeekType stop_type, gint64 stop) override
     {
         return gst_element_seek(element, rate, format, flags, start_type, start, stop_type, stop);
     }
@@ -271,7 +271,7 @@ public:
 
     const gchar *gstFormatGetName(GstFormat format) const override { return gst_format_get_name(format); }
 
-    GstSegment *gstSegmentNew() const { return gst_segment_new(); }
+    GstSegment *gstSegmentNew() const override { return gst_segment_new(); }
 
     void gstSegmentInit(GstSegment *segment, GstFormat format) const override { gst_segment_init(segment, format); }
 
@@ -286,7 +286,7 @@ public:
 
     GstStructure *gstStructureNew(const gchar *name, const gchar *firstfield, ...) const override;
 
-    void gstByteWriterInitWithData(GstByteWriter *writer, guint8 *data, guint size, gboolean initialized) const
+    void gstByteWriterInitWithData(GstByteWriter *writer, guint8 *data, guint size, gboolean initialized) const override
     {
         return gst_byte_writer_init_with_data(writer, data, size, initialized);
     }

--- a/media/server/gstplayer/include/tasks/SetPosition.h
+++ b/media/server/gstplayer/include/tasks/SetPosition.h
@@ -40,7 +40,6 @@ public:
 
 private:
     PlayerContext &m_context;
-    IGstPlayerPrivate &m_player;
     IGstPlayerClient *m_gstPlayerClient;
     std::shared_ptr<IGstWrapper> m_gstWrapper;
     std::int64_t m_position;

--- a/media/server/gstplayer/include/tasks/Shutdown.h
+++ b/media/server/gstplayer/include/tasks/Shutdown.h
@@ -25,7 +25,7 @@
 
 namespace firebolt::rialto::server
 {
-struct IGstPlayerPrivate;
+class IGstPlayerPrivate;
 } // namespace firebolt::rialto::server
 
 namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/tasks/FinishSetupSource.cpp
+++ b/media/server/gstplayer/source/tasks/FinishSetupSource.cpp
@@ -88,7 +88,7 @@ FinishSetupSource::~FinishSetupSource()
 void FinishSetupSource::execute() const
 {
     RIALTO_SERVER_LOG_DEBUG("Executing FinishSetupSource");
-    GstAppSrcCallbacks callbacks = {appSrcNeedData, appSrcEnoughData, appSrcSeekData, nullptr};
+    GstAppSrcCallbacks callbacks = {appSrcNeedData, appSrcEnoughData, appSrcSeekData, {nullptr}};
 
     auto elem = m_context.streamInfo.find(firebolt::rialto::MediaSourceType::AUDIO);
     if (elem != m_context.streamInfo.end())

--- a/media/server/gstplayer/source/tasks/SetPosition.cpp
+++ b/media/server/gstplayer/source/tasks/SetPosition.cpp
@@ -29,7 +29,7 @@ namespace firebolt::rialto::server
 {
 SetPosition::SetPosition(PlayerContext &context, IGstPlayerPrivate &player, IGstPlayerClient *client,
                          std::shared_ptr<IGstWrapper> gstWrapper, std::int64_t position)
-    : m_context{context}, m_player{player}, m_gstPlayerClient{client}, m_gstWrapper{gstWrapper}, m_position{position}
+    : m_context{context}, m_gstPlayerClient{client}, m_gstWrapper{gstWrapper}, m_position{position}
 {
     RIALTO_SERVER_LOG_DEBUG("Constructing SetPosition");
 }

--- a/media/server/ipc/source/MediaPipelineModuleService.cpp
+++ b/media/server/ipc/source/MediaPipelineModuleService.cpp
@@ -109,10 +109,6 @@ firebolt::rialto::StreamFormat convertStreamFormat(const firebolt::rialto::Attac
 {
     switch (streamFormat)
     {
-    case firebolt::rialto::AttachSourceRequest_SegmentAlignment_ALIGNMENT_UNDEFINED:
-    {
-        return firebolt::rialto::StreamFormat::UNDEFINED;
-    }
     case firebolt::rialto::AttachSourceRequest_StreamFormat_STREAM_FORMAT_RAW:
     {
         return firebolt::rialto::StreamFormat::RAW;
@@ -125,9 +121,9 @@ firebolt::rialto::StreamFormat convertStreamFormat(const firebolt::rialto::Attac
     {
         return firebolt::rialto::StreamFormat::BYTE_STREAM;
     }
+    default:
+        return firebolt::rialto::StreamFormat::UNDEFINED;
     }
-
-    return firebolt::rialto::StreamFormat::UNDEFINED;
 }
 
 } // namespace

--- a/media/server/main/source/SharedMemoryBuffer.cpp
+++ b/media/server/main/source/SharedMemoryBuffer.cpp
@@ -156,7 +156,7 @@ bool SharedMemoryBuffer::mapPartition(int sessionId)
         return true;
     }
     auto freePartition = std::find_if(m_partitions.begin(), m_partitions.end(),
-                                      [sessionId](const auto &p) { return p.sessionId == NO_SESSION_ASSIGNED; });
+                                      [](const auto &p) { return p.sessionId == NO_SESSION_ASSIGNED; });
     if (freePartition == m_partitions.end())
     {
         RIALTO_SERVER_LOG_ERROR("Failed to map Shm partition for session: %d. No free partition available.", sessionId);

--- a/tests/media/server/gstplayer/player/tasksTests/AttachSamplesTest.cpp
+++ b/tests/media/server/gstplayer/player/tasksTests/AttachSamplesTest.cpp
@@ -33,7 +33,6 @@ namespace
 constexpr auto audioSourceId{static_cast<std::int32_t>(firebolt::rialto::MediaSourceType::AUDIO)};
 constexpr auto videoSourceId{static_cast<std::int32_t>(firebolt::rialto::MediaSourceType::VIDEO)};
 constexpr gint64 itHappenedInThePast = 1238450934;
-constexpr gint64 currentTimestamp = 2340538204;
 constexpr gint64 itWillHappenInTheFuture = 3823530248;
 constexpr int64_t duration{9000000000};
 constexpr int32_t sampleRate{13};

--- a/tests/media/server/gstplayer/player/tasksTests/ReadShmDataAndAttachSamplesTest.cpp
+++ b/tests/media/server/gstplayer/player/tasksTests/ReadShmDataAndAttachSamplesTest.cpp
@@ -35,7 +35,6 @@ namespace
 constexpr auto audioSourceId{static_cast<std::int32_t>(firebolt::rialto::MediaSourceType::AUDIO)};
 constexpr auto videoSourceId{static_cast<std::int32_t>(firebolt::rialto::MediaSourceType::VIDEO)};
 constexpr gint64 itHappenedInThePast = 1238450934;
-constexpr gint64 currentTimestamp = 2340538204;
 constexpr gint64 itWillHappenInTheFuture = 3823530248;
 constexpr int64_t duration{9000000000};
 constexpr int32_t sampleRate{13};

--- a/tests/media/server/main/dataReader/DataReaderV2Tests.cpp
+++ b/tests/media/server/main/dataReader/DataReaderV2Tests.cpp
@@ -46,7 +46,6 @@ constexpr int32_t kNumberOfChannels{4};
 std::vector<uint8_t> kMediaData{'T', 'E', 'S', 'T', '_', 'M', 'E', 'D', 'I', 'A'};
 std::uint32_t kNumFrames{1};
 const std::vector<uint8_t> kExtraData{1, 2, 3, 4};
-constexpr uint32_t kMediaKeysId{54354};
 const int32_t kMksId{43};
 const std::vector<uint8_t> kKeyId{9, 2, 6, 2, 0, 1};
 const std::vector<uint8_t> kInitVector{34, 53, 54, 62, 56};

--- a/tests/media/server/main/mediaKeysCapabilities/KeySystemsTest.cpp
+++ b/tests/media/server/main/mediaKeysCapabilities/KeySystemsTest.cpp
@@ -22,6 +22,7 @@
 #include "OcdmMock.h"
 #include "OcdmSystemFactoryMock.h"
 #include "OcdmSystemMock.h"
+#include <array>
 #include <gtest/gtest.h>
 
 using namespace firebolt::rialto;

--- a/tests/media/server/main/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
+++ b/tests/media/server/main/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
@@ -50,7 +50,7 @@ public:
     void failToCreateMediaPipelineCapabilities()
     {
         EXPECT_CALL(*m_gstCapabilitiesFactoryMock, createGstCapabilities())
-            .WillOnce(Return(ByMove(std::move(std::unique_ptr<firebolt::rialto::server::IGstCapabilities>()))));
+            .WillOnce(Return(ByMove(std::unique_ptr<firebolt::rialto::server::IGstCapabilities>())));
 
         EXPECT_THROW(m_sut = std::make_unique<MediaPipelineCapabilities>(m_gstCapabilitiesFactoryMock),
                      std::runtime_error);

--- a/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
+++ b/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
@@ -32,7 +32,6 @@ constexpr std::uint32_t metadataOffset{1024};
 constexpr int requestId{0};
 constexpr int maxFrames{24};
 constexpr int maxMetadataBytes{2500};
-constexpr int maxMediaBytes{7337532};
 } // namespace
 
 namespace firebolt::rialto

--- a/tests/media/server/main/sharedMemoryBuffer/SharedMemoryBufferTestsFixture.cpp
+++ b/tests/media/server/main/sharedMemoryBuffer/SharedMemoryBufferTestsFixture.cpp
@@ -21,7 +21,6 @@
 
 namespace
 {
-constexpr int maxPlaybacks{1};
 constexpr std::uint32_t audioBufferLen{1 * 1024 * 1024}; // 1MB
 constexpr std::uint32_t videoBufferLen{7 * 1024 * 1024}; // 7MB
 } // namespace

--- a/tests/media/server/mocks/gstplayer/GstWrapperMock.h
+++ b/tests/media/server/mocks/gstplayer/GstWrapperMock.h
@@ -180,7 +180,7 @@ public:
         va_end(args);
     }
 
-    GstStructure *gstStructureNew(const gchar *name, const gchar *firstfield, ...) const
+    GstStructure *gstStructureNew(const gchar *name, const gchar *firstfield, ...) const override
     {
         GstStructure *structure{nullptr};
         va_list args;


### PR DESCRIPTION
Fixes the following compilation errors:

 rialto/ipc/client/source/IpcChannelImpl.cpp:601:29:
 error: suggest braces around initialization of subobject
  [-Werror,-Wmissing-braces]
    struct itimerspec ts = {0};
                            ^
                            {}

 rialto/media/server/main/source/SharedMemoryBuffer.cpp:159:40:
 error: lambda capture 'sessionId' is not used
  [-Werror,-Wunused-lambda-capture]
   [sessionId](const auto &p) { return p.sessionId == NO_SESSION_ASSIGNED; });
    ^~~~~~~~~

 rialto/media/common/include/MediaFrameWriterV2.h:64:14:
  error: 'getNumFrames' overrides a member function but is not marked 'override'
   [-Werror,-Winconsistent-missing-override]
    uint32_t getNumFrames() { return m_numFrames; }
             ^

 rialto/media/server/gstplayer/source/tasks/FinishSetupSource.cpp:91:87:
  error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
   GstAppSrcCallbacks callbacks = {appSrcNeedData, appSrcEnoughData, appSrcSeekData,
    nullptr};
    ^~~~~~~
    {      }

 rialto/media/server/gstplayer/include/tasks/Shutdown.h:28:1:
  error: struct 'IGstPlayerPrivate' was previously declared as a class;
   this is valid, but may result in linker errors under the Microsoft C++ ABI
   [-Werror,-Wmismatched-tags]
   struct IGstPlayerPrivate;
   ^
  media/server/gstplayer/include/IGstPlayerPrivate.h:29:7: note: previous use is here
  class IGstPlayerPrivate
  ^

  media/server/gstplayer/include/tasks/SetPosition.h:43:24:
   error: private field 'm_player' is not used [-Werror,-Wunused-private-field]
    IGstPlayerPrivate &m_player;
                       ^

 media/server/gstplayer/include/GstWrapper.h:289:10:
  error: 'gstByteWriterInitWithData' overrides a member function but is not marked
  'override' [-Werror,-Winconsistent-missing-override]
  void gstByteWriterInitWithData(GstByteWriter *writer, guint8 *data, ...
       ^

 media/server/gstplayer/include/IGstWrapper.h:716:18: note: overridden virtual function
    virtual void gstByteWriterInitWithData(GstByteWriter *writer, guint8 *data, ...
                 ^

 tests/media/server/main/dataReader/DataReaderV2Tests.cpp:49:20:
  error: unused variable 'kMediaKeysId' [-Werror,-Wunused-const-variable]
   constexpr uint32_t kMediaKeysId{54354};
                      ^
 tests/media/server/main/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp:53:37:
  error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
   .WillOnce(Return(ByMove(std::move(std::unique_ptr<firebolt::rialto::server::IGstCapabilities>()))));
                           ^

 rialto/rialto/tests/media/server/main/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp:53:37:
  note: remove std::move call here
   .WillOnce(Return(ByMove(std::move(std::unique_ptr<firebolt::rialto::server::IGstCapabilities>()))));
                           ^~~~~~~~~~                                                             ~

  tests/media/server/main/mediaKeysCapabilities/KeySystemsTest.cpp:47:38: error:
   implicit instantiation of undefined template 'std::array<std::basic_string<char>, 3>'
    const std::array<std::string, 3> m_supportedKeySystems{"com.widevine.alpha", "com.microsoft.playready",
                                     ^

  tests/media/server/main/sharedMemoryBuffer/SharedMemoryBufferTestsFixture.cpp:24:15:
   error: unused variable 'maxPlaybacks' [-Werror,-Wunused-const-variable]
   constexpr int maxPlaybacks{1};
                 ^
  tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp:35:15:
   error: unused variable 'maxMediaBytes' [-Werror,-Wunused-const-variable]
   constexpr int maxMediaBytes{7337532};
                 ^

  rialto/tests/media/server/gstplayer/player/tasksTests/AttachSamplesTest.cpp:36:18:
   error: unused variable 'currentTimestamp' [-Werror,-Wunused-const-variable]
    constexpr gint64 currentTimestamp = 2340538204;
                     ^

  tests/media/server/gstplayer/player/tasksTests/ReadShmDataAndAttachSamplesTest.cpp:38:18:
   error: unused variable 'currentTimestamp' [-Werror,-Wunused-const-variable]
    constexpr gint64 currentTimestamp = 2340538204;
                     ^

  tests/media/server/mocks/gstplayer/GstWrapperMock.h:181:19:
   error: 'gstStructureNew' overrides a member function but is not marked 'override'
    [-Werror,-Winconsistent-missing-override]
     GstStructure *gstStructureNew(const gchar *name, const gchar *firstfield, ...) const
                   ^

  media/server/ipc/source/MediaPipelineModuleService.cpp:112:10: error:
   comparison of different enumeration types in switch statement
   ('firebolt::rialto::AttachSourceRequest_StreamFormat' and
    'firebolt::rialto::AttachSourceRequest_SegmentAlignment') [-Werror, -Wenum-compare-switch]
    case firebolt::rialto::AttachSourceRequest_SegmentAlignment_ALIGNMENT_UNDEFINED:
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--
Summary: Fix some compilation errors
Type: fix
Owner: Damian Wrobel
Test Plan: Unit Tests