### PR TITLE
Add versioning for shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 
 cmake_minimum_required( VERSION 3.10 )
-project( Rialto LANGUAGES C CXX VERSION 1.0 )
+project( Rialto LANGUAGES C CXX VERSION 1.0.0 )
 
 if ( COVERAGE_ENABLED )
     add_compile_options(-coverage)

--- a/media/client/main/CMakeLists.txt
+++ b/media/client/main/CMakeLists.txt
@@ -67,7 +67,8 @@ target_include_directories(
 set_target_properties(
         RialtoClient
         PROPERTIES LINK_FLAGS "-Wl,--unresolved-symbols=report-all"
-
+                   SOVERSION  ${PROJECT_VERSION_MAJOR}
+                   VERSION    ${CMAKE_PROJECT_VERSION}
         )
 
 target_link_libraries(

--- a/serverManager/service/CMakeLists.txt
+++ b/serverManager/service/CMakeLists.txt
@@ -27,7 +27,10 @@ add_library (
 set_target_properties (
         RialtoServerManager
         PROPERTIES LINK_FLAGS "-Wl,--unresolved-symbols=report-all"
+                   SOVERSION  ${PROJECT_VERSION_MAJOR}
+                   VERSION    ${CMAKE_PROJECT_VERSION}
 )
+
 target_include_directories (
         RialtoServerManager
         PUBLIC


### PR DESCRIPTION
Adds versioning for shared libraries to avoid linking with development version of shared library (.so).

Additionaly, it would let us introduce incompatible changes to the API in a controlled way.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
--
Summary: Add versioning for shared libraries
Type: Fix
Owner: Damian Wrobel
Test Plan: Unit Tests