### PR TITLE
Fixed the issue in which ipcChannel could use eventThread's callbacks…

### DIFF
--- a/media/client/ipc/source/MediaPipelineIpc.cpp
+++ b/media/client/ipc/source/MediaPipelineIpc.cpp
@@ -90,11 +90,11 @@ MediaPipelineIpc::~MediaPipelineIpc()
     // destroy media player session
     destroySession();
 
-    // destroy the thread processing async notifications
-    m_eventThread.reset();
-
     // detach the Ipc channel
     detachChannel();
+
+    // destroy the thread processing async notifications
+    m_eventThread.reset();
 }
 
 bool MediaPipelineIpc::createRpcStubs()


### PR DESCRIPTION
… when they were already destroyed