### PR TITLE
Do not stop the dispatcher thread on EOS

### DIFF
--- a/media/server/gstplayer/source/GstDispatcherThread.cpp
+++ b/media/server/gstplayer/source/GstDispatcherThread.cpp
@@ -96,7 +96,6 @@ void GstDispatcherThread::gstBusEventHandler(GstElement *pipeline)
                     }
                     break;
                 }
-                case GST_MESSAGE_EOS:
                 case GST_MESSAGE_ERROR:
                 {
                     m_isGstreamerDispatcherActive = false;


### PR DESCRIPTION
Summary: Do not stop the dispatcher thread after handling an EOS. This fixes the issue of when an EOS is reached, the pipeline could no longer be used.
Type: Feature
Test Plan: Unittests, Youtube Certification Tests
Jira: RIALTO-10