### PR TITLE
Add options to disable compiling some components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ endif()
 # Import protobuf package
 find_package( Protobuf REQUIRED )
 
+# Options to disable building some of the components
+option(ENABLE_SERVER "Enable building RialtoServer" ON)
+option(ENABLE_SERVER_MANAGER "Enable building RialtoServerManagerSim" ON)
+
 # Include the new IPC library components
 add_subdirectory( ipc )
 
@@ -52,8 +56,10 @@ add_subdirectory( ipc )
 add_subdirectory( common )
 add_subdirectory( media )
 add_subdirectory( logging )
-add_subdirectory( serverManager )
 
+if( ENABLE_SERVER_MANAGER )
+    add_subdirectory( serverManager )
+endif()
 
 # Config and target for building the unit tests
 if( CMAKE_BUILD_FLAG STREQUAL "UnitTests" )

--- a/media/CMakeLists.txt
+++ b/media/CMakeLists.txt
@@ -25,4 +25,7 @@ include( CheckCXXCompilerFlag )
 add_subdirectory(public)
 add_subdirectory(common)
 add_subdirectory(client)
-add_subdirectory(server)
+
+if( ENABLE_SERVER )
+    add_subdirectory(server)
+endif()


### PR DESCRIPTION
Adds the following options to disable compilation of some of the components:

  $ cmake -LH  2>&1 | grep -B 1 ENABLE_
  --
  // Enable building RialtoServer
  ENABLE_SERVER:BOOL=ON
  --
  // Enable building RialtoServerManagerSim
  ENABLE_SERVER_MANAGER:BOOL=ON

To keep backward compatibility all components are build by default.

--
Summary: Add options to disable compiling some components
Type: feature
Owner: Damian Wrobel
Test Plan: None
Dependencies and Impacts: None