### PR TITLE
No available samples timer

### DIFF
--- a/common/source/Timer.cpp
+++ b/common/source/Timer.cpp
@@ -69,6 +69,7 @@ Timer::Timer(const std::chrono::milliseconds &timeout, const std::function<void(
                     }
                 }
             } while (timerType == TimerType::PERIODIC && m_active);
+            m_active = false;
         });
 }
 

--- a/media/server/main/CMakeLists.txt
+++ b/media/server/main/CMakeLists.txt
@@ -63,6 +63,7 @@ target_include_directories(
         $<TARGET_PROPERTY:RialtoServerCommon,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoPlayerCommon,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoServerOcdm,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:RialtoCommon,INTERFACE_INCLUDE_DIRECTORIES>
         )
 
 set_target_properties(
@@ -84,6 +85,7 @@ target_link_libraries(
         RialtoLogging
         RialtoServerGstPlayer
         RialtoServerOcdm
+        RialtoCommon
 
         Threads::Threads
         protobuf::libprotobuf

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -318,8 +318,8 @@ protected:
     bool notifyNeedMediaDataInternal(MediaSourceType mediaSourceType);
 
     /**
-     * @brief Schedules resending of NeedMediaData, when haveData with incorrect status is received, only to be called
-     *        on the main thread.
+     * @brief Schedules resending of NeedMediaData after a short delay. Used when no segments were received in the
+     * haveData() call to prevent a storm of needData()/haveData() calls, only to be called on the main thread.
      *
      * @param[in] mediaSourceType    : The media source type.
      */

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -318,7 +318,8 @@ protected:
     bool notifyNeedMediaDataInternal(MediaSourceType mediaSourceType);
 
     /**
-     * @brief Schedules resending of NeedMediaData, when haveData with incorrect status is received
+     * @brief Schedules resending of NeedMediaData, when haveData with incorrect status is received, only to be called
+     *        on the main thread.
      *
      * @param[in] mediaSourceType    : The media source type.
      */

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -25,6 +25,8 @@
 #include "IGstPlayer.h"
 #include "IMainThread.h"
 #include "IMediaPipelineServerInternal.h"
+#include "ITimer.h"
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -80,6 +82,7 @@ public:
                                 const std::shared_ptr<IGstPlayerFactory> &gstPlayerFactory, int sessionId,
                                 const std::shared_ptr<ISharedMemoryBuffer> &shmBuffer,
                                 const std::shared_ptr<IMainThreadFactory> &mainThreadFactory,
+                                std::shared_ptr<common::ITimerFactory> timerFactory,
                                 std::unique_ptr<IDataReaderFactory> &&dataReaderFactory,
                                 std::unique_ptr<IActiveRequests> &&activeRequests, IDecryptionService &decryptionService);
 
@@ -172,6 +175,11 @@ protected:
     std::unique_ptr<IDataReaderFactory> m_dataReaderFactory;
 
     /**
+     * @brief Factory creating timers
+     */
+    std::shared_ptr<common::ITimerFactory> m_timerFactory;
+
+    /**
      * @brief Object containing all active NeedDataRequests
      */
     std::unique_ptr<IActiveRequests> m_activeRequests;
@@ -185,6 +193,11 @@ protected:
      * @brief Decryption service
      */
     IDecryptionService &m_decryptionService;
+
+    /**
+     * @brief Map containing scheduled need media data requests.
+     */
+    std::map<MediaSourceType, std::unique_ptr<firebolt::rialto::common::ITimer>> m_needMediaDataTimers;
 
     /**
      * @brief Load internally, only to be called on the main thread.
@@ -303,6 +316,13 @@ protected:
      * @param[in] mediaSourceType    : The media source type.
      */
     bool notifyNeedMediaDataInternal(MediaSourceType mediaSourceType);
+
+    /**
+     * @brief Schedules resending of NeedMediaData, when haveData with incorrect status is received
+     *
+     * @param[in] mediaSourceType    : The media source type.
+     */
+    void scheduleNotifyNeedMediaData(MediaSourceType mediaSourceType);
 };
 
 }; // namespace firebolt::rialto::server

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -26,9 +26,9 @@
 #include "IMainThread.h"
 #include "IMediaPipelineServerInternal.h"
 #include "ITimer.h"
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace firebolt::rialto::server
@@ -197,7 +197,7 @@ protected:
     /**
      * @brief Map containing scheduled need media data requests.
      */
-    std::map<MediaSourceType, std::unique_ptr<firebolt::rialto::common::ITimer>> m_needMediaDataTimers;
+    std::unordered_map<MediaSourceType, std::unique_ptr<firebolt::rialto::common::ITimer>> m_needMediaDataTimers;
 
     /**
      * @brief Load internally, only to be called on the main thread.

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -693,14 +693,18 @@ void MediaPipelineServerInternal::scheduleNotifyNeedMediaData(MediaSourceType me
         m_timerFactory->createTimer(kNeedMediaDataResendTime,
                                     [this, mediaSourceType]()
                                     {
-                                        if (!notifyNeedMediaData(mediaSourceType))
-                                        {
-                                            RIALTO_SERVER_LOG_WARN(
-                                                "Scheduled Need media data sending failed. Scheduling again...");
-                                            m_mainThread->enqueueTask(m_mainThreadClientId, [this, mediaSourceType]()
-                                                                      { scheduleNotifyNeedMediaData(mediaSourceType); });
-                                        }
+                                        m_mainThread->enqueueTask(m_mainThreadClientId,
+                                                                  [this, mediaSourceType]()
+                                                                  {
+                                                                      m_needMediaDataTimers.erase(mediaSourceType);
+                                                                      if (!notifyNeedMediaDataInternal(mediaSourceType))
+                                                                      {
+                                                                          RIALTO_SERVER_LOG_WARN(
+                                                                              "Scheduled Need media data sending "
+                                                                              "failed. Scheduling again...");
+                                                                          scheduleNotifyNeedMediaData(mediaSourceType);
+                                                                      }
+                                                                  });
                                     });
 }
-
 }; // namespace firebolt::rialto::server

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -28,7 +28,7 @@
 
 namespace
 {
-constexpr std::chrono::milliseconds kNeedMediaDataResendTime{100};
+constexpr std::chrono::milliseconds kNeedMediaDataResendTimeMs{100};
 const char *toString(const firebolt::rialto::MediaSourceStatus &status)
 {
     switch (status)
@@ -690,7 +690,7 @@ void MediaPipelineServerInternal::scheduleNotifyNeedMediaData(MediaSourceType me
         return;
     }
     m_needMediaDataTimers[mediaSourceType] =
-        m_timerFactory->createTimer(kNeedMediaDataResendTime,
+        m_timerFactory->createTimer(kNeedMediaDataResendTimeMs,
                                     [this, mediaSourceType]()
                                     {
                                         m_mainThread->enqueueTask(m_mainThreadClientId,

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -28,6 +28,7 @@
 
 namespace
 {
+constexpr std::chrono::milliseconds kNeedMediaDataResendTime{100};
 const char *toString(const firebolt::rialto::MediaSourceStatus &status)
 {
     switch (status)
@@ -105,6 +106,7 @@ std::unique_ptr<server::IMediaPipelineServerInternal> MediaPipelineServerInterna
             std::make_unique<server::MediaPipelineServerInternal>(sharedClient, videoRequirements,
                                                                   server::IGstPlayerFactory::getFactory(), sessionId,
                                                                   shmBuffer, server::IMainThreadFactory::createFactory(),
+                                                                  common::ITimerFactory::getFactory(),
                                                                   std::make_unique<DataReaderFactory>(),
                                                                   std::make_unique<ActiveRequests>(), decryptionService);
     }
@@ -120,11 +122,11 @@ MediaPipelineServerInternal::MediaPipelineServerInternal(
     std::shared_ptr<IMediaPipelineClient> client, const VideoRequirements &videoRequirements,
     const std::shared_ptr<IGstPlayerFactory> &gstPlayerFactory, int sessionId,
     const std::shared_ptr<ISharedMemoryBuffer> &shmBuffer, const std::shared_ptr<IMainThreadFactory> &mainThreadFactory,
-    std::unique_ptr<IDataReaderFactory> &&dataReaderFactory, std::unique_ptr<IActiveRequests> &&activeRequests,
-    IDecryptionService &decryptionService)
+    std::shared_ptr<common::ITimerFactory> timerFactory, std::unique_ptr<IDataReaderFactory> &&dataReaderFactory,
+    std::unique_ptr<IActiveRequests> &&activeRequests, IDecryptionService &decryptionService)
     : m_mediaPipelineClient(client), m_kGstPlayerFactory(gstPlayerFactory), m_kVideoRequirements(videoRequirements),
       m_sessionId{sessionId}, m_shmBuffer{shmBuffer}, m_dataReaderFactory{std::move(dataReaderFactory)},
-      m_activeRequests{std::move(activeRequests)}, m_decryptionService{decryptionService}
+      m_timerFactory{timerFactory}, m_activeRequests{std::move(activeRequests)}, m_decryptionService{decryptionService}
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
 
@@ -161,6 +163,13 @@ MediaPipelineServerInternal::~MediaPipelineServerInternal()
 
     auto task = [&]()
     {
+        for (const auto &timer : m_needMediaDataTimers)
+        {
+            if (timer.second && timer.second->isActive())
+            {
+                timer.second->cancel();
+            }
+        }
         if (!m_shmBuffer->unmapPartition(m_sessionId))
         {
             RIALTO_SERVER_LOG_ERROR("Unable to unmap shm partition");
@@ -440,7 +449,8 @@ bool MediaPipelineServerInternal::haveDataInternal(MediaSourceStatus status, uin
         RIALTO_SERVER_LOG_WARN("Data request for needDataRequestId: %u received with wrong status: %s",
                                needDataRequestId, toString(status));
         m_activeRequests->erase(needDataRequestId);
-        return notifyNeedMediaDataInternal(mediaSourceType); // Resend NeedMediaData
+        scheduleNotifyNeedMediaData(mediaSourceType);
+        return true;
     }
 
     try
@@ -505,7 +515,8 @@ bool MediaPipelineServerInternal::haveDataInternal(MediaSourceStatus status, uin
     if (status != MediaSourceStatus::OK && status != MediaSourceStatus::EOS)
     {
         RIALTO_SERVER_LOG_WARN("Data request for needDataRequestId: %u received with wrong status", needDataRequestId);
-        return notifyNeedMediaDataInternal(mediaSourceType); // Resend NeedMediaData
+        scheduleNotifyNeedMediaData(mediaSourceType);
+        return true;
     }
     uint8_t *buffer = m_shmBuffer->getBuffer();
     if (!buffer)
@@ -667,6 +678,29 @@ void MediaPipelineServerInternal::notifyQos(MediaSourceType mediaSourceType, con
     };
 
     m_mainThread->enqueueTask(m_mainThreadClientId, task);
+}
+
+void MediaPipelineServerInternal::scheduleNotifyNeedMediaData(MediaSourceType mediaSourceType)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+    auto timer = m_needMediaDataTimers.find(mediaSourceType);
+    if (m_needMediaDataTimers.end() != timer && timer->second && timer->second->isActive())
+    {
+        RIALTO_SERVER_LOG_DEBUG("Skip scheduling need media data - it is already scheduled");
+        return;
+    }
+    m_needMediaDataTimers[mediaSourceType] =
+        m_timerFactory->createTimer(kNeedMediaDataResendTime,
+                                    [this, mediaSourceType]()
+                                    {
+                                        if (!notifyNeedMediaData(mediaSourceType))
+                                        {
+                                            RIALTO_SERVER_LOG_WARN(
+                                                "Scheduled Need media data sending failed. Scheduling again...");
+                                            m_mainThread->enqueueTask(m_mainThreadClientId, [this, mediaSourceType]()
+                                                                      { scheduleNotifyNeedMediaData(mediaSourceType); });
+                                        }
+                                    });
 }
 
 }; // namespace firebolt::rialto::server

--- a/tests/media/server/main/CMakeLists.txt
+++ b/tests/media/server/main/CMakeLists.txt
@@ -99,6 +99,7 @@ target_include_directories(
         $<TARGET_PROPERTY:RialtoPlayerCommonMocks,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoPlayerPublicMocks,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoCommonMisc,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:RialtoCommonMocks,INTERFACE_INCLUDE_DIRECTORIES>
 
         # Test Bases
         mediaKeys/base

--- a/tests/media/server/main/mediaPipeline/CreateTest.cpp
+++ b/tests/media/server/main/mediaPipeline/CreateTest.cpp
@@ -35,8 +35,8 @@ TEST_F(RialtoServerCreateMediaPipelineTest, Create)
     EXPECT_NO_THROW(
         m_mediaPipeline =
             std::make_unique<MediaPipelineServerInternal>(m_mediaPipelineClientMock, m_videoReq, m_gstPlayerFactoryMock,
-                                                          m_kSessionId, m_sharedMemoryBufferMock,
-                                                          m_mainThreadFactoryMock, std::move(m_dataReaderFactory),
+                                                          m_kSessionId, m_sharedMemoryBufferMock, m_mainThreadFactoryMock,
+                                                          m_timerFactoryMock, std::move(m_dataReaderFactory),
                                                           std::move(m_activeRequests), m_decryptionServiceMock););
     EXPECT_NE(m_mediaPipeline, nullptr);
 

--- a/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
+++ b/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
@@ -213,7 +213,6 @@ TEST_F(RialtoServerMediaPipelineHaveDataTest, ServerInternalHaveDataSuccessWithR
     ASSERT_TRUE(m_activeRequestsMock);
     EXPECT_CALL(*m_activeRequestsMock, getType(m_kNeedDataRequestId)).WillOnce(Return(mediaSourceType));
     EXPECT_CALL(*m_activeRequestsMock, erase(m_kNeedDataRequestId));
-    EXPECT_CALL(*m_timerMock, isActive()).WillOnce(Return(false));
     EXPECT_CALL(*m_timerFactoryMock, createTimer(m_kNeedMediaDataResendTimeout, _, _))
         .WillOnce(Invoke(
             [&](const std::chrono::milliseconds &timeout, const std::function<void()> &callback,
@@ -232,7 +231,7 @@ TEST_F(RialtoServerMediaPipelineHaveDataTest, ServerInternalHaveDataSuccessWithR
     EXPECT_CALL(*m_activeRequestsMock, insert(mediaSourceType, _)).WillOnce(Return(0));
     EXPECT_CALL(*m_mediaPipelineClientMock,
                 notifyNeedMediaData(sourceId, m_kNumFrames, 0, _)); // params tested in NeedMediaDataTests
-    mainThreadWillEnqueueTaskAndWait();
+    mainThreadWillEnqueueTask();
     resendCallback();
 }
 

--- a/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
+++ b/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
@@ -33,7 +33,9 @@ MediaPipelineTestBase::MediaPipelineTestBase()
       m_activeRequests{std::make_unique<StrictMock<ActiveRequestsMock>>()},
       m_activeRequestsMock{static_cast<StrictMock<ActiveRequestsMock> *>(m_activeRequests.get())},
       m_mainThreadFactoryMock{std::make_shared<StrictMock<MainThreadFactoryMock>>()},
-      m_mainThreadMock{std::make_shared<StrictMock<MainThreadMock>>()}
+      m_mainThreadMock{std::make_shared<StrictMock<MainThreadMock>>()},
+      m_timerFactoryMock{std::make_shared<StrictMock<TimerFactoryMock>>()}, m_timerMock{
+                                                                                std::make_unique<StrictMock<TimerMock>>()}
 {
 }
 
@@ -48,8 +50,8 @@ void MediaPipelineTestBase::createMediaPipeline()
     EXPECT_NO_THROW(
         m_mediaPipeline =
             std::make_unique<MediaPipelineServerInternal>(m_mediaPipelineClientMock, m_videoReq, m_gstPlayerFactoryMock,
-                                                          m_kSessionId, m_sharedMemoryBufferMock,
-                                                          m_mainThreadFactoryMock, std::move(m_dataReaderFactory),
+                                                          m_kSessionId, m_sharedMemoryBufferMock, m_mainThreadFactoryMock,
+                                                          m_timerFactoryMock, std::move(m_dataReaderFactory),
                                                           std::move(m_activeRequests), m_decryptionServiceMock););
     EXPECT_NE(m_mediaPipeline, nullptr);
 }

--- a/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.h
+++ b/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.h
@@ -33,6 +33,8 @@
 #include "MediaPipelineServerInternal.h"
 #include "MediaSourceUtil.h"
 #include "SharedMemoryBufferMock.h"
+#include "TimerFactoryMock.h"
+#include "TimerMock.h"
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -72,6 +74,8 @@ protected:
     StrictMock<ActiveRequestsMock> *m_activeRequestsMock;
     std::shared_ptr<StrictMock<MainThreadFactoryMock>> m_mainThreadFactoryMock;
     std::shared_ptr<StrictMock<MainThreadMock>> m_mainThreadMock;
+    std::shared_ptr<StrictMock<TimerFactoryMock>> m_timerFactoryMock;
+    std::unique_ptr<StrictMock<TimerMock>> m_timerMock;
     StrictMock<DecryptionServiceMock> m_decryptionServiceMock;
 
     // Common variables


### PR DESCRIPTION
Summary: Added NeedMediaData timer to prevent HaveData with NO_AVAILABLE_SAMPLES flood
Type: Feature
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Stuart Pett
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: RIALTO-9