### PR TITLE
GStreamer Logs forwarding

### DIFF
--- a/logging/include/RialtoLogging.h
+++ b/logging/include/RialtoLogging.h
@@ -39,6 +39,8 @@ extern "C"
         RIALTO_DEBUG_LEVEL_MILESTONE = (1u << 3),
         RIALTO_DEBUG_LEVEL_INFO = (1u << 4),
         RIALTO_DEBUG_LEVEL_DEBUG = (1u << 5),
+        RIALTO_DEBUG_LEVEL_EXTERNAL =
+            (1u << 6), // Level controlled by an external variable, like e.g. GST_DEBUG. Keep it as last level.
 
         RIALTO_DEBUG_LEVEL_DEFAULT = (RIALTO_DEBUG_LEVEL_FATAL | RIALTO_DEBUG_LEVEL_ERROR | RIALTO_DEBUG_LEVEL_WARNING |
                                       RIALTO_DEBUG_LEVEL_MILESTONE)
@@ -55,6 +57,7 @@ extern "C"
         RIALTO_COMPONENT_IPC,
         RIALTO_COMPONENT_SERVER_MANAGER,
         RIALTO_COMPONENT_COMMON,
+        RIALTO_COMPONENT_EXTERNAL, // External component, like e.g. GStreamer. Keep it as last component.
         RIALTO_COMPONENT_LAST,
     };
 
@@ -118,6 +121,12 @@ extern "C"
     {                                                                                                                  \
         rialtoLogPrintf(component, RIALTO_DEBUG_LEVEL_DEBUG, __FILE__, __FUNCTION__, __LINE__, fmt, ##args);           \
     } while (false)
+#define RIALTO_LOG_EXTERNAL(fmt, args...)                                                                              \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        rialtoLogPrintf(RIALTO_COMPONENT_EXTERNAL, RIALTO_DEBUG_LEVEL_EXTERNAL, __FILE__, __FUNCTION__, __LINE__, fmt, \
+                        ##args);                                                                                       \
+    } while (false)
 
 #ifdef __cplusplus
 }
@@ -168,6 +177,13 @@ RIALTO_DEBUG_LEVEL getLogLevels(RIALTO_COMPONENT component);
 using LogHandler = std::function<void(RIALTO_DEBUG_LEVEL level, const char *file, int line, const char *function,
                                       const char *message, std::size_t messageLen)>;
 RialtoLoggingStatus setLogHandler(RIALTO_COMPONENT component, LogHandler handler);
+
+/**
+ * @brief Checks if rialto logs to console.
+ *
+ * @retval: Returns true, if rialto is logging to console
+ */
+bool isConsoleLoggingEnabled();
 
 } // namespace firebolt::rialto::logging
 

--- a/logging/source/EnvVariableParser.cpp
+++ b/logging/source/EnvVariableParser.cpp
@@ -181,6 +181,10 @@ void EnvVariableParser::configureRialtoConsoleLog()
 
 RIALTO_DEBUG_LEVEL EnvVariableParser::getLevel(const RIALTO_COMPONENT &component) const
 {
+    if (RIALTO_COMPONENT_EXTERNAL == component)
+    {
+        return RIALTO_DEBUG_LEVEL_EXTERNAL;
+    }
     auto levelIter = m_debugLevels.find(component);
     if (levelIter == m_debugLevels.end())
         return RIALTO_DEBUG_LEVEL_DEFAULT;

--- a/media/server/gstplayer/CMakeLists.txt
+++ b/media/server/gstplayer/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(
         source/WorkerThread.cpp
         source/GstCapabilities.cpp
         source/GstDecryptor.cpp
+        source/GstLogForwarding.cpp
         )
 
 target_include_directories(

--- a/media/server/gstplayer/include/GstLogForwarding.h
+++ b/media/server/gstplayer/include/GstLogForwarding.h
@@ -1,0 +1,28 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBOLT_RIALTO_SERVER_GST_LOG_FORWARDING_H_
+#define FIREBOLT_RIALTO_SERVER_GST_LOG_FORWARDING_H_
+
+namespace firebolt::rialto::server
+{
+void enableGstLogForwarding();
+} // namespace firebolt::rialto::server
+
+#endif // FIREBOLT_RIALTO_SERVER_GST_LOG_FORWARDING_H_

--- a/media/server/gstplayer/source/GstLogForwarding.cpp
+++ b/media/server/gstplayer/source/GstLogForwarding.cpp
@@ -1,0 +1,96 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GstLogForwarding.h"
+#include "RialtoLogging.h"
+#include <gst/gst.h>
+#include <sstream>
+
+namespace
+{
+void gstreamerLogFunction(GstDebugCategory *category, GstDebugLevel level, const gchar *file, const gchar *function,
+                          gint line, GObject *object, GstDebugMessage *message, gpointer data)
+{
+    std::stringstream ss;
+    switch (level)
+    {
+    case GST_LEVEL_NONE:
+    case GST_LEVEL_ERROR:
+    {
+        ss << "ERR: ";
+        break;
+    }
+    case GST_LEVEL_WARNING:
+    {
+        ss << "WRN: ";
+        break;
+    }
+    case GST_LEVEL_FIXME:
+    {
+        ss << "FIXME: ";
+        break;
+    }
+    case GST_LEVEL_INFO:
+    {
+        ss << "NFO: ";
+        break;
+    }
+    case GST_LEVEL_DEBUG:
+    {
+        ss << "DBG: ";
+        break;
+    }
+    case GST_LEVEL_LOG:
+    {
+        ss << "LOG: ";
+        break;
+    }
+    case GST_LEVEL_TRACE:
+    {
+        ss << "TRACE: ";
+        break;
+    }
+    case GST_LEVEL_MEMDUMP:
+    {
+        ss << "MEMDUMP: ";
+        break;
+    }
+    case GST_LEVEL_COUNT:
+    {
+        ss << "COUNT: ";
+        break;
+    }
+    default:
+    {
+        break;
+    }
+    }
+    ss << "M:" << file << " F:" << function << ":" << line << ": " << gst_debug_message_get(message);
+    RIALTO_LOG_EXTERNAL("%s", ss.str().c_str());
+}
+} // namespace
+
+namespace firebolt::rialto::server
+{
+void enableGstLogForwarding()
+{
+    gst_debug_remove_log_function(gst_debug_log_default);
+    gst_debug_add_log_function(gstreamerLogFunction, nullptr, nullptr);
+}
+} // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstLogForwarding.cpp
+++ b/media/server/gstplayer/source/GstLogForwarding.cpp
@@ -81,7 +81,23 @@ void gstreamerLogFunction(GstDebugCategory *category, GstDebugLevel level, const
         break;
     }
     }
-    ss << "M:" << file << " F:" << function << ":" << line << ": " << gst_debug_message_get(message);
+    ss << "M:" << file << " F:" << function << ":" << line;
+    if (object)
+    {
+        if (GST_IS_OBJECT(object) && GST_OBJECT_NAME(object))
+        {
+            ss << " <" << GST_OBJECT_NAME(object) << ">";
+        }
+        else if (G_IS_OBJECT(object))
+        {
+            ss << " <" << G_OBJECT_TYPE_NAME(object) << "@" << static_cast<void *>(object) << ">";
+        }
+        else
+        {
+            ss << " <" << static_cast<void *>(object) << ">";
+        }
+    }
+    ss << ": " << gst_debug_message_get(message);
     RIALTO_LOG_EXTERNAL("%s", ss.str().c_str());
 }
 } // namespace

--- a/media/server/gstplayer/source/GstPlayer.cpp
+++ b/media/server/gstplayer/source/GstPlayer.cpp
@@ -19,6 +19,7 @@
 
 #include "GstPlayer.h"
 #include "GstDispatcherThread.h"
+#include "GstLogForwarding.h"
 #include "ITimer.h"
 #include "RialtoServerLogging.h"
 #include "WorkerThread.h"
@@ -124,6 +125,8 @@ bool IGstPlayer::initalise(int argc, char **argv)
         gstWrapper->gstRegistryRemovePlugin(gstWrapper->gstRegistryGet(), rialtoPlugin);
         gstWrapper->gstObjectUnref(rialtoPlugin);
     }
+
+    enableGstLogForwarding();
 
     return true;
 }

--- a/serverManager/common/source/SessionServerApp.cpp
+++ b/serverManager/common/source/SessionServerApp.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "SessionServerApp.h"
+#include "RialtoLogging.h"
 #include "RialtoServerManagerLogging.h"
 #include "SessionServerAppManager.h"
 #include "Utils.h"
@@ -225,18 +226,21 @@ bool SessionServerApp::spawnSessionServer()
         int newSocket = dup(m_socks[0]);
         close(m_socks[0]);
         m_socks[0] = newSocket;
-        int devNull = open("/dev/null", O_RDWR, 0);
-        if (devNull < 0)
+        if (!firebolt::rialto::logging::isConsoleLoggingEnabled())
         {
-            _exit(EXIT_FAILURE);
-        }
-        dup2(devNull, STDIN_FILENO);
-        dup2(devNull, STDOUT_FILENO);
-        dup2(devNull, STDERR_FILENO);
-        if (devNull > STDERR_FILENO)
-        {
-            close(devNull);
-            devNull = -1;
+            int devNull = open("/dev/null", O_RDWR, 0);
+            if (devNull < 0)
+            {
+                _exit(EXIT_FAILURE);
+            }
+            dup2(devNull, STDIN_FILENO);
+            dup2(devNull, STDOUT_FILENO);
+            dup2(devNull, STDERR_FILENO);
+            if (devNull > STDERR_FILENO)
+            {
+                close(devNull);
+                devNull = -1;
+            }
         }
         const std::string appName{getSessionServerPath()};
         const std::string appMgmtSocketStr{std::to_string(m_socks[0])};

--- a/tests/logging/unittests/EnvVariableParserTest.cpp
+++ b/tests/logging/unittests/EnvVariableParserTest.cpp
@@ -34,11 +34,13 @@ TEST_F(EnvVariableParserTest, SetDefaultForAllComponentsWhenEnvVariableNotSet)
 {
     unsetenv("RIALTO_DEBUG");
     EnvVariableParser parser;
-    for (uint32_t i = RIALTO_COMPONENT_DEFAULT; i < RIALTO_COMPONENT_LAST; i++)
+    for (uint32_t i = RIALTO_COMPONENT_DEFAULT; i < RIALTO_COMPONENT_EXTERNAL; i++)
     {
         RIALTO_COMPONENT component = static_cast<RIALTO_COMPONENT>(i);
         EXPECT_EQ(RIALTO_DEBUG_LEVEL_DEFAULT, parser.getLevel(component));
     }
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, SetErrorForAllComponentsUsingIntValue)
@@ -46,11 +48,13 @@ TEST_F(EnvVariableParserTest, SetErrorForAllComponentsUsingIntValue)
     const RIALTO_DEBUG_LEVEL expectedLevel = RIALTO_DEBUG_LEVEL(RIALTO_DEBUG_LEVEL_FATAL | RIALTO_DEBUG_LEVEL_ERROR);
     setenv("RIALTO_DEBUG", "1", 1);
     EnvVariableParser parser;
-    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_LAST; i++)
+    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_EXTERNAL; i++)
     {
         RIALTO_COMPONENT component = static_cast<RIALTO_COMPONENT>(i);
         EXPECT_EQ(expectedLevel, parser.getLevel(component));
     }
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, SetErrorForAllComponentsUsingStringValue)
@@ -58,11 +62,13 @@ TEST_F(EnvVariableParserTest, SetErrorForAllComponentsUsingStringValue)
     const RIALTO_DEBUG_LEVEL expectedLevel = RIALTO_DEBUG_LEVEL(RIALTO_DEBUG_LEVEL_FATAL | RIALTO_DEBUG_LEVEL_ERROR);
     setenv("RIALTO_DEBUG", "*:1", 1);
     EnvVariableParser parser;
-    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_LAST; i++)
+    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_EXTERNAL; i++)
     {
         RIALTO_COMPONENT component = static_cast<RIALTO_COMPONENT>(i);
         EXPECT_EQ(expectedLevel, parser.getLevel(component));
     }
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, SetFakeComponentShouldNotCauseError)
@@ -70,11 +76,13 @@ TEST_F(EnvVariableParserTest, SetFakeComponentShouldNotCauseError)
     const RIALTO_DEBUG_LEVEL expectedLevel = RIALTO_DEBUG_LEVEL(RIALTO_DEBUG_LEVEL_FATAL | RIALTO_DEBUG_LEVEL_ERROR);
     setenv("RIALTO_DEBUG", "*:1;fakecomponent:3", 1);
     EnvVariableParser parser;
-    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_LAST; i++)
+    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_EXTERNAL; i++)
     {
         RIALTO_COMPONENT component = static_cast<RIALTO_COMPONENT>(i);
         EXPECT_EQ(expectedLevel, parser.getLevel(component));
     }
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, SetWithSyntaxErrorShouldNotCauseError)
@@ -82,11 +90,13 @@ TEST_F(EnvVariableParserTest, SetWithSyntaxErrorShouldNotCauseError)
     const RIALTO_DEBUG_LEVEL expectedLevel = RIALTO_DEBUG_LEVEL(RIALTO_DEBUG_LEVEL_FATAL | RIALTO_DEBUG_LEVEL_ERROR);
     setenv("RIALTO_DEBUG", "*:1;syntaxError1;syntax:error:2;ipc:error3;sessionserver=4", 1);
     EnvVariableParser parser;
-    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_LAST; i++)
+    for (uint32_t i = RIALTO_COMPONENT_CLIENT; i < RIALTO_COMPONENT_EXTERNAL; i++)
     {
         RIALTO_COMPONENT component = static_cast<RIALTO_COMPONENT>(i);
         EXPECT_EQ(expectedLevel, parser.getLevel(component));
     }
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, SetFatalAndErrorForIpcDefaultForRest)
@@ -99,6 +109,8 @@ TEST_F(EnvVariableParserTest, SetFatalAndErrorForIpcDefaultForRest)
     EXPECT_EQ(expectedLevel, parser.getLevel(RIALTO_COMPONENT_IPC));
     EXPECT_EQ(RIALTO_DEBUG_LEVEL_DEFAULT, parser.getLevel(RIALTO_COMPONENT_SERVER_MANAGER));
     EXPECT_EQ(RIALTO_DEBUG_LEVEL_DEFAULT, parser.getLevel(RIALTO_COMPONENT_COMMON));
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, SetFatalAndErrorForIpcFatalForRestVersion1)
@@ -111,6 +123,8 @@ TEST_F(EnvVariableParserTest, SetFatalAndErrorForIpcFatalForRestVersion1)
     EXPECT_EQ(expectedLevel, parser.getLevel(RIALTO_COMPONENT_IPC));
     EXPECT_EQ(RIALTO_DEBUG_LEVEL_FATAL, parser.getLevel(RIALTO_COMPONENT_SERVER_MANAGER));
     EXPECT_EQ(RIALTO_DEBUG_LEVEL_FATAL, parser.getLevel(RIALTO_COMPONENT_COMMON));
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, SetFatalAndErrorForIpcFatalForRestVersion2)
@@ -123,6 +137,8 @@ TEST_F(EnvVariableParserTest, SetFatalAndErrorForIpcFatalForRestVersion2)
     EXPECT_EQ(expectedLevel, parser.getLevel(RIALTO_COMPONENT_IPC));
     EXPECT_EQ(RIALTO_DEBUG_LEVEL_FATAL, parser.getLevel(RIALTO_COMPONENT_SERVER_MANAGER));
     EXPECT_EQ(RIALTO_DEBUG_LEVEL_FATAL, parser.getLevel(RIALTO_COMPONENT_COMMON));
+    // External component log level should not by affected by RIALTO_DEBUG flag
+    EXPECT_EQ(RIALTO_DEBUG_LEVEL_EXTERNAL, parser.getLevel(RIALTO_COMPONENT_EXTERNAL));
 }
 
 TEST_F(EnvVariableParserTest, LogToConsoleDisabledWhenNoVarSet)

--- a/tests/serverManager/unittests/common/UtilsTests.cpp
+++ b/tests/serverManager/unittests/common/UtilsTests.cpp
@@ -66,7 +66,7 @@ TEST(UtilsTest, ShouldSetLocalLogLevels)
     setLocalLogLevels(loggingLevels);
 
     int expectedPrints{1};
-    for (uint32_t i = RIALTO_COMPONENT_DEFAULT; i < RIALTO_COMPONENT_LAST; i++)
+    for (uint32_t i = RIALTO_COMPONENT_DEFAULT; i < RIALTO_COMPONENT_EXTERNAL; i++)
     {
         int counter{0};
         RIALTO_COMPONENT component = static_cast<RIALTO_COMPONENT>(i);


### PR DESCRIPTION
Summary: GStreamer logs forwarded to rialto server logger.
Type: Feature
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Stuart Pett
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: RIALTO-47