### PR TITLE
NeedMediaData timer fix

### DIFF
--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -662,6 +662,7 @@ bool MediaPipelineServerInternal::notifyNeedMediaData(MediaSourceType mediaSourc
 
 bool MediaPipelineServerInternal::notifyNeedMediaDataInternal(MediaSourceType mediaSourceType)
 {
+    m_needMediaDataTimers.erase(mediaSourceType);
     m_shmBuffer->clearData(m_sessionId, mediaSourceType);
     NeedMediaData event{m_mediaPipelineClient, *m_activeRequests, *m_shmBuffer, m_sessionId, mediaSourceType};
     if (!event.send())


### PR DESCRIPTION
Summary: Cancel NeedMediaData timer when new event is sent
Type: Fix
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Luke Williamson
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: RIALTO-9