### PR TITLE
GstWrapper/GlibWrapper excluded from coverage report

### DIFF
--- a/build_ut.py
+++ b/build_ut.py
@@ -241,7 +241,8 @@ def AddValgrind(suite, outputToFile, outputToXml):
 
 def generateCoverageReport(outputDir, resultsFile):
     lcovCmd = ["lcov", "--capture", "--directory", ".", "--output-file", "coverage.info", "--exclude", "/usr/*",
-               "--exclude", "*build/*", "--exclude", "*tests/*"]
+               "--exclude", "*build/*", "--exclude", "*tests/*", "--exclude", "*GstWrapper*", "--exclude",
+               "*GlibWrapper*"]
     if resultsFile:
         lcovStatus = runcmd(lcovCmd, cwd=os.getcwd() + '/' + outputDir, stdout=resultsFile, stderr=subprocess.STDOUT)
     else:


### PR DESCRIPTION
Summary: Gst/Glib Wrappers excluded from coverage report generation
Type: Feature
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Luke Williamson
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: RIALTO-33