### PR TITLE
 Add web audio player public header files to cmake public files list

### DIFF
--- a/media/public/CMakeLists.txt
+++ b/media/public/CMakeLists.txt
@@ -45,6 +45,8 @@ set (
         include/IRialtoControl.h
         include/MediaCommon.h
         include/RialtoControlCommon.h
+        include/IWebAudioPlayer.h
+        include/IWebAudioPlayerClient.h
 )
 
 install (


### PR DESCRIPTION
Summary:  Add web audio player public header files to cmake public files list.
Type: Fix
Test Plan: Manual tests