### PR TITLE
NeedMediaData with smaller numFrames in prerolling state

### DIFF
--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -202,6 +202,11 @@ protected:
     IDecryptionService &m_decryptionService;
 
     /**
+     * @brief Current playback state
+     */
+    PlaybackState m_currentPlaybackState;
+
+    /**
      * @brief Map containing scheduled need media data requests.
      */
     std::unordered_map<MediaSourceType, std::unique_ptr<firebolt::rialto::common::ITimer>> m_needMediaDataTimers;

--- a/media/server/main/include/NeedMediaData.h
+++ b/media/server/main/include/NeedMediaData.h
@@ -34,7 +34,7 @@ class NeedMediaData
 public:
     NeedMediaData(std::weak_ptr<IMediaPipelineClient> client, IActiveRequests &activeRequests,
                   const ISharedMemoryBuffer &shmBuffer, int sessionId, MediaSourceType mediaSourceType,
-                  std::int32_t sourceId);
+                  std::int32_t sourceId, PlaybackState currentPlaybackState);
     ~NeedMediaData() = default;
 
     bool send() const;

--- a/media/server/main/include/ShmUtils.h
+++ b/media/server/main/include/ShmUtils.h
@@ -25,7 +25,8 @@
 
 namespace firebolt::rialto::server
 {
-constexpr std::uint32_t maxFrames{24};
+constexpr std::uint32_t kPrerollNumFrames{1};
+constexpr std::uint32_t kMaxFrames{24};
 constexpr std::uint32_t getMaxMetadataBytes()
 {
     // The Rialto Server must size the metadata regions to be at least the following size:
@@ -34,7 +35,7 @@ constexpr std::uint32_t getMaxMetadataBytes()
 
     // Metadata V2 contains version only, so maximum metadata size is size of MetadataV1
     std::uint32_t maxMetadataStructSize = common::METADATA_V1_SIZE_PER_FRAME_BYTES;
-    return common::VERSION_SIZE_BYTES + maxFrames * maxMetadataStructSize;
+    return common::VERSION_SIZE_BYTES + kMaxFrames * maxMetadataStructSize;
 }
 } // namespace firebolt::rialto::server
 

--- a/media/server/main/source/NeedMediaData.cpp
+++ b/media/server/main/source/NeedMediaData.cpp
@@ -28,10 +28,15 @@ namespace firebolt::rialto::server
 {
 NeedMediaData::NeedMediaData(std::weak_ptr<IMediaPipelineClient> client, IActiveRequests &activeRequests,
                              const ISharedMemoryBuffer &shmBuffer, int sessionId, MediaSourceType mediaSourceType,
-                             std::int32_t sourceId)
-    : m_client{client}, m_activeRequests{activeRequests}, m_mediaSourceType{mediaSourceType}, m_frameCount{maxFrames},
+                             std::int32_t sourceId, PlaybackState currentPlaybackState)
+    : m_client{client}, m_activeRequests{activeRequests}, m_mediaSourceType{mediaSourceType}, m_frameCount{kMaxFrames},
       m_sourceId{sourceId}
 {
+    if (PlaybackState::PLAYING != currentPlaybackState)
+    {
+        RIALTO_SERVER_LOG_DEBUG("Pipeline in prerolling state. Sending smaller frame count");
+        m_frameCount = kPrerollNumFrames;
+    }
     if (MediaSourceType::AUDIO != mediaSourceType && MediaSourceType::VIDEO != mediaSourceType)
     {
         RIALTO_SERVER_LOG_ERROR("Unable to initialize NeedMediaData - unknown mediaSourceType");

--- a/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
+++ b/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
@@ -28,7 +28,7 @@ using ::testing::Throw;
 class RialtoServerMediaPipelineHaveDataTest : public MediaPipelineTestBase
 {
 protected:
-    const uint32_t m_kNumFrames{24};
+    const uint32_t m_kNumFrames{1};
     const uint32_t m_kNeedDataRequestId{0};
     const std::chrono::milliseconds m_kNeedMediaDataResendTimeout{100};
 

--- a/tests/media/server/main/needMediaData/NeedMediaDataTests.cpp
+++ b/tests/media/server/main/needMediaData/NeedMediaDataTests.cpp
@@ -25,8 +25,14 @@ TEST_F(NeedMediaDataTests, shouldNotSendInvalidMessage)
     needMediaDataWillNotBeSent();
 }
 
-TEST_F(NeedMediaDataTests, shouldSendMessage)
+TEST_F(NeedMediaDataTests, shouldSendMessageInPlayingState)
 {
-    initialize();
-    needMediaDataWillBeSent();
+    initialize(firebolt::rialto::PlaybackState::PLAYING);
+    needMediaDataWillBeSentInPlayingState();
+}
+
+TEST_F(NeedMediaDataTests, shouldSendMessageInPrerollingState)
+{
+    initialize(firebolt::rialto::PlaybackState::PAUSED);
+    needMediaDataWillBeSentBelowPlayingState();
 }

--- a/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
+++ b/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
@@ -24,14 +24,15 @@ using testing::Return;
 
 namespace
 {
-constexpr int sessionId{0};
-constexpr firebolt::rialto::MediaSourceType validMediaSourceType{firebolt::rialto::MediaSourceType::VIDEO};
-constexpr int sourceId = 1;
-constexpr std::uint32_t bufferLen{7 * 1024 * 1024};
-constexpr std::uint32_t metadataOffset{1024};
-constexpr int requestId{0};
-constexpr int maxFrames{24};
-constexpr int maxMetadataBytes{2500};
+constexpr int kSessionId{0};
+constexpr firebolt::rialto::MediaSourceType kValidMediaSourceType{firebolt::rialto::MediaSourceType::VIDEO};
+constexpr int kSourceId{1};
+constexpr std::uint32_t kBufferLen{7 * 1024 * 1024};
+constexpr std::uint32_t kMetadataOffset{1024};
+constexpr int kRequestId{0};
+constexpr int kPrerollingNumFrames{1};
+constexpr int kMaxFrames{24};
+constexpr int kMaxMetadataBytes{2500};
 } // namespace
 
 namespace firebolt::rialto
@@ -54,37 +55,50 @@ NeedMediaDataTests::NeedMediaDataTests()
 {
 }
 
-void NeedMediaDataTests::initialize()
+void NeedMediaDataTests::initialize(firebolt::rialto::PlaybackState playbackState)
 {
     EXPECT_CALL(shmBufferMock, getMaxDataLen(firebolt::rialto::server::ISharedMemoryBuffer::MediaPlaybackType::GENERIC,
-                                             sessionId, validMediaSourceType))
-        .WillOnce(Return(bufferLen));
+                                             kSessionId, kValidMediaSourceType))
+        .WillOnce(Return(kBufferLen));
     EXPECT_CALL(shmBufferMock, getDataOffset(firebolt::rialto::server::ISharedMemoryBuffer::MediaPlaybackType::GENERIC,
-                                             sessionId, validMediaSourceType))
-        .WillOnce(Return(metadataOffset));
+                                             kSessionId, kValidMediaSourceType))
+        .WillOnce(Return(kMetadataOffset));
     m_sut = std::make_unique<firebolt::rialto::server::NeedMediaData>(m_clientMock, activeRequestsMock, shmBufferMock,
-                                                                      sessionId, validMediaSourceType, sourceId,
-                                                                      firebolt::rialto::PlaybackState::PLAYING);
+                                                                      kSessionId, kValidMediaSourceType, kSourceId,
+                                                                      playbackState);
 }
 
 void NeedMediaDataTests::initializeWithWrongType()
 {
     m_sut =
         std::make_unique<firebolt::rialto::server::NeedMediaData>(m_clientMock, activeRequestsMock, shmBufferMock,
-                                                                  sessionId, firebolt::rialto::MediaSourceType::UNKNOWN,
-                                                                  sourceId, firebolt::rialto::PlaybackState::PLAYING);
+                                                                  kSessionId, firebolt::rialto::MediaSourceType::UNKNOWN,
+                                                                  kSourceId, firebolt::rialto::PlaybackState::PLAYING);
 }
 
-void NeedMediaDataTests::needMediaDataWillBeSent()
+void NeedMediaDataTests::needMediaDataWillBeSentInPlayingState()
 {
     std::shared_ptr<firebolt::rialto::MediaPlayerShmInfo> expectedShmInfo{
         std::make_shared<firebolt::rialto::MediaPlayerShmInfo>()};
-    expectedShmInfo->maxMetadataBytes = maxMetadataBytes;
-    expectedShmInfo->metadataOffset = metadataOffset;
-    expectedShmInfo->mediaDataOffset = metadataOffset + maxMetadataBytes;
+    expectedShmInfo->maxMetadataBytes = kMaxMetadataBytes;
+    expectedShmInfo->metadataOffset = kMetadataOffset;
+    expectedShmInfo->mediaDataOffset = kMetadataOffset + kMaxMetadataBytes;
     ASSERT_TRUE(m_sut);
-    EXPECT_CALL(activeRequestsMock, insert(validMediaSourceType, _)).WillOnce(Return(requestId));
-    EXPECT_CALL(*m_clientMock, notifyNeedMediaData(sourceId, maxFrames, requestId, expectedShmInfo));
+    EXPECT_CALL(activeRequestsMock, insert(kValidMediaSourceType, _)).WillOnce(Return(kRequestId));
+    EXPECT_CALL(*m_clientMock, notifyNeedMediaData(kSourceId, kMaxFrames, kRequestId, expectedShmInfo));
+    EXPECT_TRUE(m_sut->send());
+}
+
+void NeedMediaDataTests::needMediaDataWillBeSentBelowPlayingState()
+{
+    std::shared_ptr<firebolt::rialto::MediaPlayerShmInfo> expectedShmInfo{
+        std::make_shared<firebolt::rialto::MediaPlayerShmInfo>()};
+    expectedShmInfo->maxMetadataBytes = kMaxMetadataBytes;
+    expectedShmInfo->metadataOffset = kMetadataOffset;
+    expectedShmInfo->mediaDataOffset = kMetadataOffset + kMaxMetadataBytes;
+    ASSERT_TRUE(m_sut);
+    EXPECT_CALL(activeRequestsMock, insert(kValidMediaSourceType, _)).WillOnce(Return(kRequestId));
+    EXPECT_CALL(*m_clientMock, notifyNeedMediaData(kSourceId, kPrerollingNumFrames, kRequestId, expectedShmInfo));
     EXPECT_TRUE(m_sut->send());
 }
 

--- a/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
+++ b/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
@@ -63,15 +63,16 @@ void NeedMediaDataTests::initialize()
                                              sessionId, validMediaSourceType))
         .WillOnce(Return(metadataOffset));
     m_sut = std::make_unique<firebolt::rialto::server::NeedMediaData>(m_clientMock, activeRequestsMock, shmBufferMock,
-                                                                      sessionId, validMediaSourceType, sourceId);
+                                                                      sessionId, validMediaSourceType, sourceId,
+                                                                      firebolt::rialto::PlaybackState::PLAYING);
 }
 
 void NeedMediaDataTests::initializeWithWrongType()
 {
-    m_sut = std::make_unique<firebolt::rialto::server::NeedMediaData>(m_clientMock, activeRequestsMock, shmBufferMock,
-                                                                      sessionId,
-                                                                      firebolt::rialto::MediaSourceType::UNKNOWN,
-                                                                      sourceId);
+    m_sut =
+        std::make_unique<firebolt::rialto::server::NeedMediaData>(m_clientMock, activeRequestsMock, shmBufferMock,
+                                                                  sessionId, firebolt::rialto::MediaSourceType::UNKNOWN,
+                                                                  sourceId, firebolt::rialto::PlaybackState::PLAYING);
 }
 
 void NeedMediaDataTests::needMediaDataWillBeSent()

--- a/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.h
+++ b/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.h
@@ -21,6 +21,7 @@
 #define NEED_MEDIA_DATA_TESTS_FIXTURE_H_
 
 #include "ActiveRequestsMock.h"
+#include "MediaCommon.h"
 #include "MediaPipelineClientMock.h"
 #include "NeedMediaData.h"
 #include "SharedMemoryBufferMock.h"
@@ -35,10 +36,11 @@ public:
     NeedMediaDataTests();
     ~NeedMediaDataTests() override = default;
 
-    void initialize();
+    void initialize(firebolt::rialto::PlaybackState playbackState);
     void initializeWithWrongType();
 
-    void needMediaDataWillBeSent();
+    void needMediaDataWillBeSentInPlayingState();
+    void needMediaDataWillBeSentBelowPlayingState();
     void needMediaDataWillNotBeSent();
 
 private:


### PR DESCRIPTION
Summary: NeedMediaData with smaller numFrames in prerolling state
Type: Fix
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Stuart Pett
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: RIALTO-5, RIALTO-25