### PR TITLE
REFPLTV-1627: RPI 4 64 Bit Build Broken

### DIFF
--- a/media/public/include/IWebAudioPlayer.h
+++ b/media/public/include/IWebAudioPlayer.h
@@ -137,7 +137,7 @@ public:
      *
      * @retval true on success.
      */
-    virtual bool getBufferAvailable(uint32_t &availableFrames, std::shared_ptr<WebAudioShmInfo> &webAudioShmInfo) = 0;
+    virtual bool getBufferAvailable(uintptr_t &availableFrames, std::shared_ptr<WebAudioShmInfo> &webAudioShmInfo) = 0;
 
     /**
      * @brief Get the delay frames.

--- a/media/server/wrappers/source/RdkGstreamerUtilsWrapper.cpp
+++ b/media/server/wrappers/source/RdkGstreamerUtilsWrapper.cpp
@@ -54,8 +54,8 @@ bool RdkGstreamerUtilsWrapper::performAudioTrackCodecChannelSwitch(
     rdk_gstreamer_utils::AudioAttributes *rdkAudioAttributes{
         reinterpret_cast<rdk_gstreamer_utils::AudioAttributes *>(audioAttr)};
     return rdk_gstreamer_utils::performAudioTrackCodecChannelSwitch(rdkPlaybackGroup, sampleAttr, rdkAudioAttributes,
-                                                                    status, ui32Delay, audioChangeTargetPts,
-                                                                    currentDispPts, audioChangeStage, appsrcCaps,
+                                                                    status, ui32Delay, (rdk_gstreamer_utils::llong*) audioChangeTargetPts,
+                                                                   (rdk_gstreamer_utils::llong*) currentDispPts, audioChangeStage, appsrcCaps,
                                                                     audioaac, svpEnabled, aSrc, ret);
 }
 } // namespace firebolt::rialto::server


### PR DESCRIPTION
Reason for change: Fixed build issue for rialto for RPI 4 64 bit hybrid build.

Test Procedure: RPI 4 64 Bit Build for rialto should be successful.

Risks: Low