### PR TITLE
Set codec data

### DIFF
--- a/media/client/ipc/source/MediaPipelineIpc.cpp
+++ b/media/client/ipc/source/MediaPipelineIpc.cpp
@@ -201,7 +201,10 @@ bool MediaPipelineIpc::attachSource(const std::unique_ptr<IMediaPipeline::MediaS
     request.set_mime_type(source->getMimeType());
     request.set_segment_alignment(convertSegmentAlignment(source->getSegmentAlignment()));
 
-    request.set_codec_data(source->getCodecData().data(), source->getCodecData().size());
+    if (source->getCodecData())
+    {
+        request.set_codec_data(source->getCodecData()->data(), source->getCodecData()->size());
+    }
     request.set_stream_format(convertStreamFormat(source->getStreamFormat()));
 
     if (configType == SourceConfigType::VIDEO_DOLBY_VISION)

--- a/media/common/source/MediaFrameWriterV2.cpp
+++ b/media/common/source/MediaFrameWriterV2.cpp
@@ -132,6 +132,10 @@ MediaSegmentMetadata MediaFrameWriterV2::buildMetadata(const std::unique_ptr<IMe
     {
         metadata.set_segment_alignment(convertSegmentAlignment(data->getSegmentAlignment()));
     }
+    if (data->getCodecData())
+    {
+        metadata.set_codec_data(std::string(data->getCodecData()->begin(), data->getCodecData()->end()));
+    }
     if (data->isEncrypted())
     {
         metadata.set_media_key_session_id(data->getMediaKeySessionId());

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -136,7 +136,7 @@ public:
         /**
          * @brief Gets the codec data
          */
-        const std::vector<uint8_t> &getCodecData() const { return m_codecData; }
+        const CodecData &getCodecData() const { return m_codecData; }
 
         /**
          * @brief Gets the stream format
@@ -158,7 +158,7 @@ public:
                              const std::string &mimeType = std::string(),
                              SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                              StreamFormat streamFormat = StreamFormat::UNDEFINED,
-                             const std::vector<uint8_t> &codecData = std::vector<uint8_t>())
+                             const CodecData &codecData = CodecData())
             : m_id(id), m_configType(configType), m_mimeType(mimeType), m_alignment(alignment),
               m_streamFormat(streamFormat), m_codecData(codecData)
         {
@@ -191,7 +191,7 @@ public:
         /**
          * @brief Additional data for decoder
          */
-        std::vector<uint8_t> m_codecData;
+        CodecData m_codecData;
     };
 
     /**
@@ -214,8 +214,7 @@ public:
          */
         MediaSourceAudio(int32_t id, const std::string &mimeType, const AudioConfig &audioConfig = AudioConfig(),
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
-                         StreamFormat streamFormat = StreamFormat::UNDEFINED,
-                         const std::vector<uint8_t> &codecData = std::vector<uint8_t>())
+                         StreamFormat streamFormat = StreamFormat::UNDEFINED, const CodecData &codecData = CodecData())
             : MediaSource(id, SourceConfigType::AUDIO, mimeType, alignment, streamFormat, codecData),
               m_audioConfig(audioConfig)
         {
@@ -259,8 +258,7 @@ public:
          */
         MediaSourceVideo(int32_t id, const std::string &mimeType,
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
-                         StreamFormat streamFormat = StreamFormat::UNDEFINED,
-                         const std::vector<uint8_t> &codecData = std::vector<uint8_t>())
+                         StreamFormat streamFormat = StreamFormat::UNDEFINED, const CodecData &codecData = CodecData())
             : MediaSource(id, SourceConfigType::VIDEO, mimeType, alignment, streamFormat, codecData)
         {
         }
@@ -282,8 +280,7 @@ public:
          */
         MediaSourceVideo(int32_t id, SourceConfigType sourceConfigType, const std::string &mimeType,
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
-                         StreamFormat streamFormat = StreamFormat::UNDEFINED,
-                         const std::vector<uint8_t> &codecData = std::vector<uint8_t>())
+                         StreamFormat streamFormat = StreamFormat::UNDEFINED, const CodecData &codecData = CodecData())
             : MediaSource(id, sourceConfigType, mimeType, alignment, streamFormat, codecData)
         {
         }
@@ -309,7 +306,7 @@ public:
         MediaSourceVideoDolbyVision(int32_t id, const std::string &mimeType, int32_t dolbyVisionProfile,
                                     SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                                     StreamFormat streamFormat = StreamFormat::UNDEFINED,
-                                    const std::vector<uint8_t> &codecData = std::vector<uint8_t>())
+                                    const CodecData &codecData = CodecData())
             : MediaSourceVideo(id, SourceConfigType::VIDEO_DOLBY_VISION, mimeType, alignment, streamFormat, codecData),
               m_dolbyVisionProfile(dolbyVisionProfile)
         {

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -136,7 +136,7 @@ public:
         /**
          * @brief Gets the codec data
          */
-        const CodecData &getCodecData() const { return m_codecData; }
+        const std::shared_ptr<std::vector<std::uint8_t>> &getCodecData() const { return m_codecData; }
 
         /**
          * @brief Gets the stream format
@@ -158,7 +158,7 @@ public:
                              const std::string &mimeType = std::string(),
                              SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                              StreamFormat streamFormat = StreamFormat::UNDEFINED,
-                             const CodecData &codecData = CodecData())
+                             const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
             : m_id(id), m_configType(configType), m_mimeType(mimeType), m_alignment(alignment),
               m_streamFormat(streamFormat), m_codecData(codecData)
         {
@@ -191,7 +191,7 @@ public:
         /**
          * @brief Additional data for decoder
          */
-        CodecData m_codecData;
+        std::shared_ptr<std::vector<std::uint8_t>> m_codecData;
     };
 
     /**
@@ -214,7 +214,8 @@ public:
          */
         MediaSourceAudio(int32_t id, const std::string &mimeType, const AudioConfig &audioConfig = AudioConfig(),
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
-                         StreamFormat streamFormat = StreamFormat::UNDEFINED, const CodecData &codecData = CodecData())
+                         StreamFormat streamFormat = StreamFormat::UNDEFINED,
+                         const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
             : MediaSource(id, SourceConfigType::AUDIO, mimeType, alignment, streamFormat, codecData),
               m_audioConfig(audioConfig)
         {
@@ -258,7 +259,8 @@ public:
          */
         MediaSourceVideo(int32_t id, const std::string &mimeType,
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
-                         StreamFormat streamFormat = StreamFormat::UNDEFINED, const CodecData &codecData = CodecData())
+                         StreamFormat streamFormat = StreamFormat::UNDEFINED,
+                         const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
             : MediaSource(id, SourceConfigType::VIDEO, mimeType, alignment, streamFormat, codecData)
         {
         }
@@ -280,7 +282,8 @@ public:
          */
         MediaSourceVideo(int32_t id, SourceConfigType sourceConfigType, const std::string &mimeType,
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
-                         StreamFormat streamFormat = StreamFormat::UNDEFINED, const CodecData &codecData = CodecData())
+                         StreamFormat streamFormat = StreamFormat::UNDEFINED,
+                         const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
             : MediaSource(id, sourceConfigType, mimeType, alignment, streamFormat, codecData)
         {
         }
@@ -306,7 +309,7 @@ public:
         MediaSourceVideoDolbyVision(int32_t id, const std::string &mimeType, int32_t dolbyVisionProfile,
                                     SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                                     StreamFormat streamFormat = StreamFormat::UNDEFINED,
-                                    const CodecData &codecData = CodecData())
+                                    const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
             : MediaSourceVideo(id, SourceConfigType::VIDEO_DOLBY_VISION, mimeType, alignment, streamFormat, codecData),
               m_dolbyVisionProfile(dolbyVisionProfile)
         {
@@ -470,7 +473,7 @@ public:
          *
          * @retval the codec data
          */
-        const CodecData &getCodecData() const { return m_codecData; }
+        const std::shared_ptr<std::vector<std::uint8_t>> &getCodecData() const { return m_codecData; }
 
     protected:
         /**
@@ -506,7 +509,7 @@ public:
         /**
          * @brief Additional data for decoder
          */
-        CodecData m_codecData;
+        std::shared_ptr<std::vector<std::uint8_t>> m_codecData;
 
         /**
          * @brief The data
@@ -594,7 +597,7 @@ public:
          *
          * @param[in] codecData  The updated codec data for the source
          */
-        void setCodecData(const CodecData &codecData) { m_codecData = codecData; }
+        void setCodecData(const std::shared_ptr<std::vector<std::uint8_t>> &codecData) { m_codecData = codecData; }
 
         /**
          * @brief Sets the encrypted flag.

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -588,7 +588,7 @@ public:
         void setSegmentAlignment(const SegmentAlignment &alignment) { m_alignment = alignment; }
 
         /**
-         * @brief Sets new codec_data for the source.
+         * @brief Sets new codec_data for the segment.
          *
          * @note Should only be called if the codec data changes
          *

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -341,7 +341,6 @@ public:
          * @param[in] type          : The source type.
          * @param[in] timeStamp     : The timestamp in nanoseconds.
          * @param[in] duration      : The duration in nanoseconds.
-         * @param[in] codecData     : The additional data for decoder
          */
         MediaSegment(int32_t sourceId = 0, MediaSourceType type = MediaSourceType::UNKNOWN, int64_t timeStamp = 0,
                      int64_t duration = 0)

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -344,9 +344,9 @@ public:
          * @param[in] codecData     : The additional data for decoder
          */
         MediaSegment(int32_t sourceId = 0, MediaSourceType type = MediaSourceType::UNKNOWN, int64_t timeStamp = 0,
-                     int64_t duration = 0, const CodecData &codecData = CodecData())
+                     int64_t duration = 0)
             : m_sourceId(sourceId), m_type(type), m_data(nullptr), m_dataLength(0u), m_timeStamp(timeStamp),
-              m_duration(duration), m_codecData{codecData},
+              m_duration(duration),
               m_encrypted(false), m_mediaKeySessionId{0}, m_initWithLast15{0}, m_alignment{SegmentAlignment::UNDEFINED}
         {
         }
@@ -589,6 +589,15 @@ public:
         void setSegmentAlignment(const SegmentAlignment &alignment) { m_alignment = alignment; }
 
         /**
+         * @brief Sets new codec_data for the source.
+         *
+         * @note Should only be called if the codec data changes
+         *
+         * @param[in] codecData  The updated codec data for the source
+         */
+        void setCodecData(const CodecData &codecData) { m_codecData = codecData; }
+
+        /**
          * @brief Sets the encrypted flag.
          *
          * @param[in] encrypted : Set true to indicated encrypted data.
@@ -654,11 +663,10 @@ public:
          * @param[in] duration         : The duration in nanoseconds.
          * @param[in] sampleRate       : The sample rate in samples per second.
          * @param[in] numberOfChannels : The number of audio channels.
-         * @param[in] codecData        : The additional data for decoder
          */
         MediaSegmentAudio(int32_t sourceId = 0, int64_t timeStamp = 0, int64_t duration = 0, int32_t sampleRate = 0,
-                          int32_t numberOfChannels = 0, const CodecData &codecData = CodecData())
-            : MediaSegment(sourceId, MediaSourceType::AUDIO, timeStamp, duration, codecData), m_sampleRate(sampleRate),
+                          int32_t numberOfChannels = 0)
+            : MediaSegment(sourceId, MediaSourceType::AUDIO, timeStamp, duration), m_sampleRate(sampleRate),
               m_numberOfChannels(numberOfChannels)
         {
         }
@@ -735,12 +743,10 @@ public:
          * @param[in] duration  : The duration in nanoseconds.
          * @param[in] width     : The video width in pixels.
          * @param[in] height    : The video height in pixels.
-         * @param[in] codecData : The additional data for decoder
          */
         MediaSegmentVideo(int32_t sourceId = 0, int64_t timeStamp = 0, int64_t duration = 0, int32_t width = 0,
-                          int32_t height = 0, const CodecData &codecData = CodecData())
-            : MediaSegment(sourceId, MediaSourceType::VIDEO, timeStamp, duration, codecData), m_width(width),
-              m_height(height)
+                          int32_t height = 0)
+            : MediaSegment(sourceId, MediaSourceType::VIDEO, timeStamp, duration), m_width(width), m_height(height)
         {
         }
 

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -341,11 +341,12 @@ public:
          * @param[in] type          : The source type.
          * @param[in] timeStamp     : The timestamp in nanoseconds.
          * @param[in] duration      : The duration in nanoseconds.
+         * @param[in] codecData     : The additional data for decoder
          */
         MediaSegment(int32_t sourceId = 0, MediaSourceType type = MediaSourceType::UNKNOWN, int64_t timeStamp = 0,
-                     int64_t duration = 0)
+                     int64_t duration = 0, const CodecData &codecData = CodecData())
             : m_sourceId(sourceId), m_type(type), m_data(nullptr), m_dataLength(0u), m_timeStamp(timeStamp),
-              m_duration(duration),
+              m_duration(duration), m_codecData{codecData},
               m_encrypted(false), m_mediaKeySessionId{0}, m_initWithLast15{0}, m_alignment{SegmentAlignment::UNDEFINED}
         {
         }
@@ -465,6 +466,13 @@ public:
          */
         const SegmentAlignment getSegmentAlignment() const { return m_alignment; }
 
+        /**
+         * @brief Gets the codec data
+         *
+         * @retval the codec data
+         */
+        const CodecData &getCodecData() const { return m_codecData; }
+
     protected:
         /**
          * @brief The source id.
@@ -495,6 +503,11 @@ public:
          * @brief The duration.
          */
         int64_t m_duration;
+
+        /**
+         * @brief Additional data for decoder
+         */
+        CodecData m_codecData;
 
         /**
          * @brief The data
@@ -641,10 +654,11 @@ public:
          * @param[in] duration         : The duration in nanoseconds.
          * @param[in] sampleRate       : The sample rate in samples per second.
          * @param[in] numberOfChannels : The number of audio channels.
+         * @param[in] codecData        : The additional data for decoder
          */
         MediaSegmentAudio(int32_t sourceId = 0, int64_t timeStamp = 0, int64_t duration = 0, int32_t sampleRate = 0,
-                          int32_t numberOfChannels = 0)
-            : MediaSegment(sourceId, MediaSourceType::AUDIO, timeStamp, duration), m_sampleRate(sampleRate),
+                          int32_t numberOfChannels = 0, const CodecData &codecData = CodecData())
+            : MediaSegment(sourceId, MediaSourceType::AUDIO, timeStamp, duration, codecData), m_sampleRate(sampleRate),
               m_numberOfChannels(numberOfChannels)
         {
         }
@@ -721,10 +735,12 @@ public:
          * @param[in] duration  : The duration in nanoseconds.
          * @param[in] width     : The video width in pixels.
          * @param[in] height    : The video height in pixels.
+         * @param[in] codecData : The additional data for decoder
          */
         MediaSegmentVideo(int32_t sourceId = 0, int64_t timeStamp = 0, int64_t duration = 0, int32_t width = 0,
-                          int32_t height = 0)
-            : MediaSegment(sourceId, MediaSourceType::VIDEO, timeStamp, duration), m_width(width), m_height(height)
+                          int32_t height = 0, const CodecData &codecData = CodecData())
+            : MediaSegment(sourceId, MediaSourceType::VIDEO, timeStamp, duration, codecData), m_width(width),
+              m_height(height)
         {
         }
 

--- a/media/public/include/MediaCommon.h
+++ b/media/public/include/MediaCommon.h
@@ -338,11 +338,44 @@ enum class WebAudioPlayerState
 class CodecData
 {
 public:
+    /**
+     * @brief Default constructor.
+     */
     CodecData() : m_present{false}, m_data{} {}
+
+    /**
+     * @brief Constructor with data initialisation
+     *
+     * @param[in]  data   : Additional data for decoder.
+     */
     explicit CodecData(const std::vector<uint8_t> &data) : m_present{true}, m_data{data} {}
+
+    /**
+     * @brief Conversion to bool operator
+     *
+     * @retval true if CodecData object is initialized
+     */
     operator bool() const { return m_present; }
+
+    /**
+     * @brief arrow operator
+     *
+     * @retval Pointer to data vector
+     */
     const std::vector<uint8_t> *const operator->() const { return &m_data; }
+
+    /**
+     * @brief star operator
+     *
+     * @retval Reference to data vector
+     */
     const std::vector<uint8_t> &operator*() const { return m_data; }
+
+    /**
+     * @brief Equals operator
+     *
+     * @retval True if CodecData objects are equal
+     */
     bool operator==(const CodecData &other) const { return m_present == other.m_present && m_data == other.m_data; }
 
 private:

--- a/media/public/include/MediaCommon.h
+++ b/media/public/include/MediaCommon.h
@@ -331,57 +331,6 @@ enum class WebAudioPlayerState
     END_OF_STREAM, /**< The player has got to the end of playback. */
     FAILURE        /**< The player failed to set playback state. */
 };
-
-/**
- * @brief Additional data for decoder.
- */
-class CodecData
-{
-public:
-    /**
-     * @brief Default constructor.
-     */
-    CodecData() : m_present{false}, m_data{} {}
-
-    /**
-     * @brief Constructor with data initialisation
-     *
-     * @param[in]  data   : Additional data for decoder.
-     */
-    explicit CodecData(const std::vector<uint8_t> &data) : m_present{true}, m_data{data} {}
-
-    /**
-     * @brief Conversion to bool operator
-     *
-     * @retval true if CodecData object is initialized
-     */
-    operator bool() const { return m_present; }
-
-    /**
-     * @brief arrow operator
-     *
-     * @retval Pointer to data vector
-     */
-    const std::vector<uint8_t> *const operator->() const { return &m_data; }
-
-    /**
-     * @brief star operator
-     *
-     * @retval Reference to data vector
-     */
-    const std::vector<uint8_t> &operator*() const { return m_data; }
-
-    /**
-     * @brief Equals operator
-     *
-     * @retval True if CodecData objects are equal
-     */
-    bool operator==(const CodecData &other) const { return m_present == other.m_present && m_data == other.m_data; }
-
-private:
-    bool m_present;
-    std::vector<uint8_t> m_data;
-};
 } // namespace firebolt::rialto
 
 #endif // FIREBOLT_RIALTO_MEDIA_COMMON_H_

--- a/media/public/include/MediaCommon.h
+++ b/media/public/include/MediaCommon.h
@@ -332,6 +332,23 @@ enum class WebAudioPlayerState
     FAILURE        /**< The player failed to set playback state. */
 };
 
+/**
+ * @brief Additional data for decoder.
+ */
+class CodecData
+{
+public:
+    CodecData() : m_present{false}, m_data{} {}
+    explicit CodecData(const std::vector<uint8_t> &data) : m_present{true}, m_data{data} {}
+    operator bool() const { return m_present; }
+    const std::vector<uint8_t> *const operator->() const { return &m_data; }
+    const std::vector<uint8_t> &operator*() const { return m_data; }
+    bool operator==(const CodecData &other) const { return m_present == other.m_present && m_data == other.m_data; }
+
+private:
+    bool m_present;
+    std::vector<uint8_t> m_data;
+};
 } // namespace firebolt::rialto
 
 #endif // FIREBOLT_RIALTO_MEDIA_COMMON_H_

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -122,8 +122,10 @@ private:
     GstBuffer *createBuffer(const IMediaPipeline::MediaSegment &mediaSegment) const override;
     void attachAudioData() override;
     void attachVideoData() override;
-    void updateAudioCaps(int32_t rate, int32_t channels, const CodecData &codecData) override;
-    void updateVideoCaps(int32_t width, int32_t height, const CodecData &codecData) override;
+    void updateAudioCaps(int32_t rate, int32_t channels,
+                         const std::shared_ptr<std::vector<std::uint8_t>> &codecData) override;
+    void updateVideoCaps(int32_t width, int32_t height,
+                         const std::shared_ptr<std::vector<std::uint8_t>> &codecData) override;
     bool changePipelineState(GstState newState) override;
     void startPositionReportingAndCheckAudioUnderflowTimer() override;
     void stopPositionReportingAndCheckAudioUnderflowTimer() override;

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -122,8 +122,8 @@ private:
     GstBuffer *createBuffer(const IMediaPipeline::MediaSegment &mediaSegment) const override;
     void attachAudioData() override;
     void attachVideoData() override;
-    void updateAudioCaps(int32_t rate, int32_t channels) override;
-    void updateVideoCaps(int32_t width, int32_t height) override;
+    void updateAudioCaps(int32_t rate, int32_t channels, const CodecData &codecData) override;
+    void updateVideoCaps(int32_t width, int32_t height, const CodecData &codecData) override;
     bool changePipelineState(GstState newState) override;
     void startPositionReportingAndCheckAudioUnderflowTimer() override;
     void stopPositionReportingAndCheckAudioUnderflowTimer() override;

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -36,6 +36,7 @@
 #include <IMediaPipeline.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace firebolt::rialto::server
 {

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -23,6 +23,8 @@
 #include "IMediaPipeline.h"
 #include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
+#include <memory>
+#include <vector>
 
 namespace firebolt::rialto::server
 {

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -100,12 +100,12 @@ public:
     /**
      * @brief Checks the new audio mediaSegment metadata and updates the caps accordingly.
      */
-    virtual void updateAudioCaps(int32_t rate, int32_t channels) = 0;
+    virtual void updateAudioCaps(int32_t rate, int32_t channels, const CodecData &codecData) = 0;
 
     /**
      * @brief Checks the new video mediaSegment metadata and updates the caps accordingly.
      */
-    virtual void updateVideoCaps(int32_t width, int32_t height) = 0;
+    virtual void updateVideoCaps(int32_t width, int32_t height, const CodecData &codecData) = 0;
 
     /**
      * @brief Changes pipeline state.

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -100,12 +100,14 @@ public:
     /**
      * @brief Checks the new audio mediaSegment metadata and updates the caps accordingly.
      */
-    virtual void updateAudioCaps(int32_t rate, int32_t channels, const CodecData &codecData) = 0;
+    virtual void updateAudioCaps(int32_t rate, int32_t channels,
+                                 const std::shared_ptr<std::vector<std::uint8_t>> &codecData) = 0;
 
     /**
      * @brief Checks the new video mediaSegment metadata and updates the caps accordingly.
      */
-    virtual void updateVideoCaps(int32_t width, int32_t height, const CodecData &codecData) = 0;
+    virtual void updateVideoCaps(int32_t width, int32_t height,
+                                 const std::shared_ptr<std::vector<std::uint8_t>> &codecData) = 0;
 
     /**
      * @brief Changes pipeline state.

--- a/media/server/gstplayer/include/tasks/generic/AttachSamples.h
+++ b/media/server/gstplayer/include/tasks/generic/AttachSamples.h
@@ -43,12 +43,14 @@ private:
         GstBuffer *buffer;
         int32_t rate;
         int32_t channels;
+        CodecData codecData;
     };
     struct VideoData
     {
         GstBuffer *buffer;
         int32_t width;
         int32_t height;
+        CodecData codecData;
     };
 
     GenericPlayerContext &m_context;

--- a/media/server/gstplayer/include/tasks/generic/AttachSamples.h
+++ b/media/server/gstplayer/include/tasks/generic/AttachSamples.h
@@ -25,6 +25,7 @@
 #include "IMediaPipeline.h"
 #include "IPlayerTask.h"
 #include <gst/gst.h>
+#include <memory>
 #include <vector>
 
 namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/include/tasks/generic/AttachSamples.h
+++ b/media/server/gstplayer/include/tasks/generic/AttachSamples.h
@@ -43,14 +43,14 @@ private:
         GstBuffer *buffer;
         int32_t rate;
         int32_t channels;
-        CodecData codecData;
+        std::shared_ptr<std::vector<std::uint8_t>> codecData;
     };
     struct VideoData
     {
         GstBuffer *buffer;
         int32_t width;
         int32_t height;
-        CodecData codecData;
+        std::shared_ptr<std::vector<std::uint8_t>> codecData;
     };
 
     GenericPlayerContext &m_context;

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -542,7 +542,8 @@ void GstGenericPlayer::attachVideoData()
     }
 }
 
-void GstGenericPlayer::updateAudioCaps(int32_t rate, int32_t channels, const CodecData &codecData)
+void GstGenericPlayer::updateAudioCaps(int32_t rate, int32_t channels,
+                                       const std::shared_ptr<std::vector<std::uint8_t>> &codecData)
 {
     if (!m_context.audioAppSrc)
     {
@@ -586,7 +587,8 @@ void GstGenericPlayer::updateAudioCaps(int32_t rate, int32_t channels, const Cod
     }
 }
 
-void GstGenericPlayer::updateVideoCaps(int32_t width, int32_t height, const CodecData &codecData)
+void GstGenericPlayer::updateVideoCaps(int32_t width, int32_t height,
+                                       const std::shared_ptr<std::vector<std::uint8_t>> &codecData)
 {
     if (!m_context.videoAppSrc)
     {

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -542,7 +542,7 @@ void GstGenericPlayer::attachVideoData()
     }
 }
 
-void GstGenericPlayer::updateAudioCaps(int32_t rate, int32_t channels)
+void GstGenericPlayer::updateAudioCaps(int32_t rate, int32_t channels, const CodecData &codecData)
 {
     if (!m_context.audioAppSrc)
     {
@@ -569,6 +569,14 @@ void GstGenericPlayer::updateAudioCaps(int32_t rate, int32_t channels)
             m_gstWrapper->gstCapsSetSimple(newCaps, "channels", G_TYPE_INT, channels, NULL);
             capsChanged = true;
         }
+        if (codecData)
+        {
+            gpointer memory = m_glibWrapper->gMemdup(codecData->data(), codecData->size());
+            GstBuffer *buf = m_gstWrapper->gstBufferNewWrapped(memory, codecData->size());
+            m_gstWrapper->gstCapsSetSimple(newCaps, "codec_data", GST_TYPE_BUFFER, buf, nullptr);
+            m_gstWrapper->gstBufferUnref(buf);
+            capsChanged = true;
+        }
         if (capsChanged)
         {
             m_gstWrapper->gstAppSrcSetCaps(GST_APP_SRC(m_context.audioAppSrc), newCaps);
@@ -578,7 +586,7 @@ void GstGenericPlayer::updateAudioCaps(int32_t rate, int32_t channels)
     }
 }
 
-void GstGenericPlayer::updateVideoCaps(int32_t width, int32_t height)
+void GstGenericPlayer::updateVideoCaps(int32_t width, int32_t height, const CodecData &codecData)
 {
     if (!m_context.videoAppSrc)
     {
@@ -595,6 +603,13 @@ void GstGenericPlayer::updateVideoCaps(int32_t width, int32_t height)
         GstCaps *newCaps = m_gstWrapper->gstCapsCopy(currentCaps);
 
         m_gstWrapper->gstCapsSetSimple(newCaps, "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, NULL);
+        if (codecData)
+        {
+            gpointer memory = m_glibWrapper->gMemdup(codecData->data(), codecData->size());
+            GstBuffer *buf = m_gstWrapper->gstBufferNewWrapped(memory, codecData->size());
+            m_gstWrapper->gstCapsSetSimple(newCaps, "codec_data", GST_TYPE_BUFFER, buf, nullptr);
+            m_gstWrapper->gstBufferUnref(buf);
+        }
 
         m_gstWrapper->gstAppSrcSetCaps(GST_APP_SRC(m_context.videoAppSrc), newCaps);
 

--- a/media/server/gstplayer/source/tasks/generic/AttachSamples.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSamples.cpp
@@ -38,7 +38,8 @@ AttachSamples::AttachSamples(GenericPlayerContext &context, IGstGenericPlayerPri
             {
                 IMediaPipeline::MediaSegmentVideo &videoSegment =
                     dynamic_cast<IMediaPipeline::MediaSegmentVideo &>(*mediaSegment);
-                VideoData videoData = {gstBuffer, videoSegment.getWidth(), videoSegment.getHeight()};
+                VideoData videoData = {gstBuffer, videoSegment.getWidth(), videoSegment.getHeight(),
+                                       videoSegment.getCodecData()};
                 m_videoData.push_back(videoData);
             }
             catch (const std::exception &e)
@@ -52,7 +53,8 @@ AttachSamples::AttachSamples(GenericPlayerContext &context, IGstGenericPlayerPri
             {
                 IMediaPipeline::MediaSegmentAudio &audioSegment =
                     dynamic_cast<IMediaPipeline::MediaSegmentAudio &>(*mediaSegment);
-                AudioData audioData = {gstBuffer, audioSegment.getSampleRate(), audioSegment.getNumberOfChannels()};
+                AudioData audioData = {gstBuffer, audioSegment.getSampleRate(), audioSegment.getNumberOfChannels(),
+                                       audioSegment.getCodecData()};
                 m_audioData.push_back(audioData);
             }
             catch (const std::exception &e)
@@ -73,14 +75,14 @@ void AttachSamples::execute() const
     RIALTO_SERVER_LOG_DEBUG("Executing AttachSamples");
     for (AudioData audioData : m_audioData)
     {
-        m_player.updateAudioCaps(audioData.rate, audioData.channels);
+        m_player.updateAudioCaps(audioData.rate, audioData.channels, audioData.codecData);
 
         m_context.audioBuffers.push_back(audioData.buffer);
         m_player.attachAudioData();
     }
     for (VideoData videoData : m_videoData)
     {
-        m_player.updateVideoCaps(videoData.width, videoData.height);
+        m_player.updateVideoCaps(videoData.width, videoData.height, videoData.codecData);
 
         m_context.videoBuffers.push_back(videoData.buffer);
         m_player.attachVideoData();

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -80,11 +80,11 @@ protected:
 
     void addCodecDataToCaps(GstCaps *caps) const
     {
-        const std::vector<uint8_t> &codecData = m_attachedSource.getCodecData();
-        if (!codecData.empty())
+        const CodecData &codecData = m_attachedSource.getCodecData();
+        if (codecData)
         {
-            gpointer memory = m_glibWrapper->gMemdup(codecData.data(), codecData.size());
-            GstBuffer *buf = m_gstWrapper->gstBufferNewWrapped(memory, codecData.size());
+            gpointer memory = m_glibWrapper->gMemdup(codecData->data(), codecData->size());
+            GstBuffer *buf = m_gstWrapper->gstBufferNewWrapped(memory, codecData->size());
             m_gstWrapper->gstCapsSetSimple(caps, "codec_data", GST_TYPE_BUFFER, buf, nullptr);
             m_gstWrapper->gstBufferUnref(buf);
         }

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -80,7 +80,7 @@ protected:
 
     void addCodecDataToCaps(GstCaps *caps) const
     {
-        const CodecData &codecData = m_attachedSource.getCodecData();
+        const std::shared_ptr<std::vector<std::uint8_t>> &codecData = m_attachedSource.getCodecData();
         if (codecData)
         {
             gpointer memory = m_glibWrapper->gMemdup(codecData->data(), codecData->size());

--- a/media/server/gstplayer/source/tasks/generic/ReadShmDataAndAttachSamples.cpp
+++ b/media/server/gstplayer/source/tasks/generic/ReadShmDataAndAttachSamples.cpp
@@ -53,7 +53,7 @@ void ReadShmDataAndAttachSamples::execute() const
             {
                 IMediaPipeline::MediaSegmentVideo &videoSegment =
                     dynamic_cast<IMediaPipeline::MediaSegmentVideo &>(*mediaSegment);
-                m_player.updateVideoCaps(videoSegment.getWidth(), videoSegment.getHeight());
+                m_player.updateVideoCaps(videoSegment.getWidth(), videoSegment.getHeight(), videoSegment.getCodecData());
             }
             catch (const std::exception &e)
             {
@@ -69,7 +69,8 @@ void ReadShmDataAndAttachSamples::execute() const
             {
                 IMediaPipeline::MediaSegmentAudio &audioSegment =
                     dynamic_cast<IMediaPipeline::MediaSegmentAudio &>(*mediaSegment);
-                m_player.updateAudioCaps(audioSegment.getSampleRate(), audioSegment.getNumberOfChannels());
+                m_player.updateAudioCaps(audioSegment.getSampleRate(), audioSegment.getNumberOfChannels(),
+                                         audioSegment.getCodecData());
             }
             catch (const std::exception &e)
             {

--- a/media/server/ipc/source/MediaPipelineModuleService.cpp
+++ b/media/server/ipc/source/MediaPipelineModuleService.cpp
@@ -321,8 +321,12 @@ void MediaPipelineModuleService::attachSource(::google::protobuf::RpcController 
 {
     RIALTO_SERVER_LOG_DEBUG("mime_type: %s", request->mime_type().c_str());
 
-    auto codecDataProto = request->codec_data();
-    std::vector<uint8_t> codecData(codecDataProto.begin(), codecDataProto.end());
+    CodecData codecData{};
+    if (request->has_codec_data())
+    {
+        auto codecDataProto = request->codec_data();
+        codecData = CodecData{{codecDataProto.begin(), codecDataProto.end()}};
+    }
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource;
     firebolt::rialto::SourceConfigType configType = convertConfigType(request->config_type());
 

--- a/media/server/ipc/source/MediaPipelineModuleService.cpp
+++ b/media/server/ipc/source/MediaPipelineModuleService.cpp
@@ -321,11 +321,11 @@ void MediaPipelineModuleService::attachSource(::google::protobuf::RpcController 
 {
     RIALTO_SERVER_LOG_DEBUG("mime_type: %s", request->mime_type().c_str());
 
-    CodecData codecData{};
+    std::shared_ptr<std::vector<std::uint8_t>> codecData{};
     if (request->has_codec_data())
     {
         auto codecDataProto = request->codec_data();
-        codecData = CodecData{{codecDataProto.begin(), codecDataProto.end()}};
+        codecData = std::make_shared<std::vector<std::uint8_t>>(codecDataProto.begin(), codecDataProto.end());
     }
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource;
     firebolt::rialto::SourceConfigType configType = convertConfigType(request->config_type());

--- a/media/server/main/source/DataReaderV2.cpp
+++ b/media/server/main/source/DataReaderV2.cpp
@@ -91,6 +91,10 @@ createSegment(const firebolt::rialto::MediaSegmentMetadata &metadata, const fire
     {
         segment->setExtraData(std::vector<uint8_t>(metadata.extra_data().begin(), metadata.extra_data().end()));
     }
+    if (metadata.has_codec_data())
+    {
+        segment->setCodecData(firebolt::rialto::CodecData({metadata.codec_data().begin(), metadata.codec_data().end()}));
+    }
 
     // Read encryption data
     if (metadata.has_media_key_session_id() || metadata.has_key_id() || metadata.has_init_vector() ||

--- a/media/server/main/source/DataReaderV2.cpp
+++ b/media/server/main/source/DataReaderV2.cpp
@@ -93,7 +93,8 @@ createSegment(const firebolt::rialto::MediaSegmentMetadata &metadata, const fire
     }
     if (metadata.has_codec_data())
     {
-        segment->setCodecData(firebolt::rialto::CodecData({metadata.codec_data().begin(), metadata.codec_data().end()}));
+        segment->setCodecData(
+            std::make_shared<std::vector<uint8_t>>(metadata.codec_data().begin(), metadata.codec_data().end()));
     }
 
     // Read encryption data

--- a/proto/mediapipelinemodule.proto
+++ b/proto/mediapipelinemodule.proto
@@ -138,7 +138,7 @@ message AttachSourceRequest {
     required string mime_type = 3;
     required SegmentAlignment segment_alignment    = 4; /* Segment alignment can be specified for H264/H265, will use NAL if not set */
     optional AudioConfig audio_config    = 5;
-    required bytes codec_data = 6;
+    optional bytes codec_data = 6;
     required StreamFormat stream_format = 7;
     optional uint32 dolby_vision_profile = 8;
 }

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -49,4 +49,5 @@ message MediaSegmentMetadata {
     optional uint32           init_with_last_15    = 14;      /* initWithLast15 value for decryption */
     repeated SubsamplePair    sub_sample_info      = 15;      /* If present, use gather/scatter decryption based on this list of clear/encrypted byte lengths. */
                                                               /* If not present and content is encrypted then entire media segment needs decryption.           */
+    optional bytes            codec_data           = 16;      /* Buffer containing updated codec data for video segments */
 }

--- a/tests/media/common/mediaFrameWriterV2/WriteFrameTest.cpp
+++ b/tests/media/common/mediaFrameWriterV2/WriteFrameTest.cpp
@@ -39,6 +39,7 @@ constexpr int32_t kNumberOfChannels{3};
 constexpr int32_t kWidth{1024};
 constexpr int32_t kHeight{768};
 const std::vector<uint8_t> kExtraData{1, 2, 3, 4};
+const std::vector<uint8_t> kCodecData{4, 3, 2, 1};
 const int32_t kMksId{43};
 const std::vector<uint8_t> kKeyId{9, 2, 6, 2, 0, 1};
 const std::vector<uint8_t> kInitVector{34, 53, 54, 62, 56};
@@ -71,6 +72,7 @@ void addOptionalData(std::unique_ptr<IMediaPipeline::MediaSegment> &segment)
 {
     segment->setSegmentAlignment(SegmentAlignment::NAL);
     segment->setExtraData(kExtraData);
+    segment->setCodecData(CodecData(kCodecData));
 }
 
 void addEncryptionData(std::unique_ptr<IMediaPipeline::MediaSegment> &segment)
@@ -111,6 +113,7 @@ void checkOptionalMetadataNotPresent(const MediaSegmentMetadata &metadata)
 {
     EXPECT_FALSE(metadata.has_segment_alignment());
     EXPECT_FALSE(metadata.has_extra_data());
+    EXPECT_FALSE(metadata.has_codec_data());
 }
 
 void checkOptionalMetadataPresent(const MediaSegmentMetadata &metadata)
@@ -119,6 +122,8 @@ void checkOptionalMetadataPresent(const MediaSegmentMetadata &metadata)
     EXPECT_EQ(metadata.segment_alignment(), MediaSegmentMetadata_SegmentAlignment_ALIGNMENT_NAL);
     EXPECT_TRUE(metadata.has_extra_data());
     EXPECT_EQ(metadata.extra_data(), std::string(kExtraData.begin(), kExtraData.end()));
+    EXPECT_TRUE(metadata.has_codec_data());
+    EXPECT_EQ(metadata.codec_data(), std::string(kCodecData.begin(), kCodecData.end()));
 }
 
 void checkEncryptionMetadataNotPresent(const MediaSegmentMetadata &metadata)

--- a/tests/media/common/mediaFrameWriterV2/WriteFrameTest.cpp
+++ b/tests/media/common/mediaFrameWriterV2/WriteFrameTest.cpp
@@ -72,7 +72,7 @@ void addOptionalData(std::unique_ptr<IMediaPipeline::MediaSegment> &segment)
 {
     segment->setSegmentAlignment(SegmentAlignment::NAL);
     segment->setExtraData(kExtraData);
-    segment->setCodecData(CodecData(kCodecData));
+    segment->setCodecData(std::make_shared<std::vector<std::uint8_t>>(kCodecData));
 }
 
 void addEncryptionData(std::unique_ptr<IMediaPipeline::MediaSegment> &segment)

--- a/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -48,8 +48,9 @@ constexpr uint32_t kInitWithLast15{1};
 constexpr size_t kNumClearBytes{3};
 constexpr size_t kNumEncryptedBytes{5};
 constexpr VideoRequirements m_videoReq{kMinPrimaryVideoWidth, kMinPrimaryVideoHeight};
-const firebolt::rialto::CodecData kEmptyCodecData{};
-const firebolt::rialto::CodecData kCodecData{{4, 3, 2, 1}};
+const std::shared_ptr<std::vector<std::uint8_t>> kEmptyCodecData{};
+const std::shared_ptr<std::vector<std::uint8_t>> kCodecData{
+    std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{1, 2, 3, 4})};
 } // namespace
 
 bool operator==(const GstRialtoProtectionData &lhs, const GstRialtoProtectionData &rhs)

--- a/tests/media/server/gstplayer/genericPlayer/common/Matchers.h
+++ b/tests/media/server/gstplayer/genericPlayer/common/Matchers.h
@@ -42,4 +42,17 @@ MATCHER(NotNullMatcher, "")
     return nullptr != arg;
 }
 
+MATCHER_P(arrayMatcher, vec, "")
+{
+    const uint8_t *array = static_cast<const uint8_t *>(arg);
+    for (unsigned int i = 0; i < vec.size(); ++i)
+    {
+        if (vec[i] != array[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 #endif // FIREBOLT_RIALTO_SERVER_MATCHERS_H_

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSamplesTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSamplesTest.cpp
@@ -39,8 +39,9 @@ constexpr int32_t sampleRate{13};
 constexpr int32_t numberOfChannels{4};
 constexpr int32_t width{1024};
 constexpr int32_t height{768};
-const firebolt::rialto::CodecData emptyCodecData{};
-const firebolt::rialto::CodecData codecData{{1, 2, 3, 4}};
+const std::shared_ptr<std::vector<std::uint8_t>> emptyCodecData{};
+const std::shared_ptr<std::vector<std::uint8_t>> codecData{
+    std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{1, 2, 3, 4})};
 
 firebolt::rialto::IMediaPipeline::MediaSegmentVector buildAudioSamples()
 {

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
@@ -122,7 +122,8 @@ TEST_F(AttachSourceTest, shouldAttachVideoSource)
 {
     gpointer memory = nullptr;
     GstBuffer buf;
-    firebolt::rialto::CodecData codecData{{'T', 'E', 'S', 'T'}};
+    std::shared_ptr<std::vector<std::uint8_t>> codecData{
+        std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{'T', 'E', 'S', 'T'})};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
         std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264",
                                                                              firebolt::rialto::SegmentAlignment::AU,
@@ -153,7 +154,7 @@ TEST_F(AttachSourceTest, shouldAttachVideoSourceEmptyCodecData)
 {
     gpointer memory = nullptr;
     GstBuffer buf;
-    firebolt::rialto::CodecData codecData{{}};
+    std::shared_ptr<std::vector<std::uint8_t>> codecData{std::make_shared<std::vector<std::uint8_t>>()};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
         std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264",
                                                                              firebolt::rialto::SegmentAlignment::AU,
@@ -307,7 +308,8 @@ TEST_F(AttachSourceTest, shouldAttachVideoDolbyVisionSource)
     gpointer memory = nullptr;
     int32_t dolbyVisionProfile = 5;
     GstBuffer buf;
-    firebolt::rialto::CodecData codecData{{'T', 'E', 'S', 'T'}};
+    std::shared_ptr<std::vector<std::uint8_t>> codecData{
+        std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{'T', 'E', 'S', 'T'})};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source = std::make_unique<
         firebolt::rialto::IMediaPipeline::MediaSourceVideoDolbyVision>(-1, "video/h265", dolbyVisionProfile,
                                                                        firebolt::rialto::SegmentAlignment::AU,

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
@@ -35,19 +35,6 @@ using testing::Return;
 using testing::StrEq;
 using testing::StrictMock;
 
-MATCHER_P(arrayMatcher, vec, "")
-{
-    const uint8_t *array = static_cast<const uint8_t *>(arg);
-    for (unsigned int i = 0; i < vec.size(); ++i)
-    {
-        if (vec[i] != array[i])
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
 class AttachSourceTest : public testing::Test
 {
 protected:

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/ReadShmDataAndAttachSamplesTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/ReadShmDataAndAttachSamplesTest.cpp
@@ -41,6 +41,8 @@ constexpr int32_t sampleRate{13};
 constexpr int32_t numberOfChannels{4};
 constexpr int32_t width{1024};
 constexpr int32_t height{768};
+const firebolt::rialto::CodecData emptyCodecData{};
+const firebolt::rialto::CodecData codecData{{1, 2, 3, 4}};
 
 firebolt::rialto::IMediaPipeline::MediaSegmentVector buildAudioSamples()
 {
@@ -51,6 +53,7 @@ firebolt::rialto::IMediaPipeline::MediaSegmentVector buildAudioSamples()
     dataVec.emplace_back(
         std::make_unique<firebolt::rialto::IMediaPipeline::MediaSegmentAudio>(audioSourceId, itWillHappenInTheFuture,
                                                                               duration, sampleRate, numberOfChannels));
+    dataVec.back()->setCodecData(codecData);
     return dataVec;
 }
 
@@ -63,6 +66,7 @@ firebolt::rialto::IMediaPipeline::MediaSegmentVector buildVideoSamples()
     dataVec.emplace_back(std::make_unique<firebolt::rialto::IMediaPipeline::MediaSegmentVideo>(videoSourceId,
                                                                                                itWillHappenInTheFuture,
                                                                                                duration, width, height));
+    dataVec.back()->setCodecData(codecData);
     return dataVec;
 }
 } // namespace
@@ -82,7 +86,8 @@ TEST_F(ReadShmDataAndAttachSamplesTest, shouldAttachAllAudioSamples)
     firebolt::rialto::IMediaPipeline::MediaSegmentVector dataVec = buildAudioSamples();
     EXPECT_CALL(*m_dataReader, readData()).WillOnce(Return(ByMove(std::move(dataVec))));
     EXPECT_CALL(m_gstPlayer, createBuffer(_)).Times(2).WillRepeatedly(Return(&m_gstBuffer));
-    EXPECT_CALL(m_gstPlayer, updateAudioCaps(sampleRate, numberOfChannels)).Times(2);
+    EXPECT_CALL(m_gstPlayer, updateAudioCaps(sampleRate, numberOfChannels, emptyCodecData));
+    EXPECT_CALL(m_gstPlayer, updateAudioCaps(sampleRate, numberOfChannels, codecData));
     EXPECT_CALL(m_gstPlayer, attachAudioData()).Times(2);
     EXPECT_CALL(m_gstPlayer, notifyNeedMediaData(true, false));
     firebolt::rialto::server::tasks::generic::ReadShmDataAndAttachSamples task{m_context, m_gstPlayer, m_dataReader};
@@ -95,7 +100,8 @@ TEST_F(ReadShmDataAndAttachSamplesTest, shouldAttachAllVideoSamples)
     firebolt::rialto::IMediaPipeline::MediaSegmentVector dataVec = buildVideoSamples();
     EXPECT_CALL(*m_dataReader, readData()).WillOnce(Return(ByMove(std::move(dataVec))));
     EXPECT_CALL(m_gstPlayer, createBuffer(_)).Times(2).WillRepeatedly(Return(&m_gstBuffer));
-    EXPECT_CALL(m_gstPlayer, updateVideoCaps(width, height)).Times(2);
+    EXPECT_CALL(m_gstPlayer, updateVideoCaps(width, height, emptyCodecData));
+    EXPECT_CALL(m_gstPlayer, updateVideoCaps(width, height, codecData));
     EXPECT_CALL(m_gstPlayer, attachVideoData()).Times(2);
     EXPECT_CALL(m_gstPlayer, notifyNeedMediaData(false, true));
     firebolt::rialto::server::tasks::generic::ReadShmDataAndAttachSamples task{m_context, m_gstPlayer, m_dataReader};

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/ReadShmDataAndAttachSamplesTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/ReadShmDataAndAttachSamplesTest.cpp
@@ -41,8 +41,9 @@ constexpr int32_t sampleRate{13};
 constexpr int32_t numberOfChannels{4};
 constexpr int32_t width{1024};
 constexpr int32_t height{768};
-const firebolt::rialto::CodecData emptyCodecData{};
-const firebolt::rialto::CodecData codecData{{1, 2, 3, 4}};
+const std::shared_ptr<std::vector<std::uint8_t>> emptyCodecData{};
+const std::shared_ptr<std::vector<std::uint8_t>> codecData{
+    std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{1, 2, 3, 4})};
 
 firebolt::rialto::IMediaPipeline::MediaSegmentVector buildAudioSamples()
 {

--- a/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
+++ b/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
@@ -44,7 +44,7 @@ const std::string mimeType{"exampleMimeType"};
 constexpr uint32_t numberOfChannels{6};
 constexpr uint32_t sampleRate{48000};
 const std::string codecSpecificConfigStr("1243567");
-std::vector<uint8_t> codecData{'T', 'E', 'S', 'T'};
+const firebolt::rialto::CodecData codecData{{'T', 'E', 'S', 'T'}};
 const std::string url{"https://example.url.com"};
 constexpr int64_t position{2000000000};
 constexpr std::uint32_t requestId{2};
@@ -660,7 +660,7 @@ void MediaPipelineModuleServiceTests::sendAttachAudioSourceWithAdditionalDataReq
     request.mutable_audio_config()->set_number_of_channels(numberOfChannels);
     request.mutable_audio_config()->set_sample_rate(sampleRate);
     request.mutable_audio_config()->set_codec_specific_config(codecSpecificConfigStr);
-    request.set_codec_data(codecData.data(), codecData.size());
+    request.set_codec_data(codecData->data(), codecData->size());
     request.set_stream_format(convertStreamFormat(firebolt::rialto::StreamFormat::RAW));
 
     m_service->attachSource(m_controllerMock.get(), &request, &response, m_closureMock.get());

--- a/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
+++ b/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
@@ -44,7 +44,8 @@ const std::string mimeType{"exampleMimeType"};
 constexpr uint32_t numberOfChannels{6};
 constexpr uint32_t sampleRate{48000};
 const std::string codecSpecificConfigStr("1243567");
-const firebolt::rialto::CodecData codecData{{'T', 'E', 'S', 'T'}};
+const std::shared_ptr<std::vector<std::uint8_t>> codecData{
+    std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{'T', 'E', 'S', 'T'})};
 const std::string url{"https://example.url.com"};
 constexpr int64_t position{2000000000};
 constexpr std::uint32_t requestId{2};
@@ -68,9 +69,18 @@ constexpr double volume{0.7};
 MATCHER_P(AttachedSourceMatcher, source, "")
 {
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> &src = source.get();
+    bool codecDataEqual = false;
+    if (arg->getCodecData() && src->getCodecData())
+    {
+        codecDataEqual = *(arg->getCodecData()) == *(src->getCodecData());
+    }
+    else
+    {
+        codecDataEqual = arg->getCodecData() == src->getCodecData();
+    }
     bool baseCompare = arg->getConfigType() == src->getConfigType() && arg->getMimeType() == src->getMimeType() &&
-                       arg->getSegmentAlignment() == src->getSegmentAlignment() &&
-                       arg->getCodecData() == src->getCodecData() && arg->getStreamFormat() == src->getStreamFormat();
+                       arg->getSegmentAlignment() == src->getSegmentAlignment() && codecDataEqual &&
+                       arg->getStreamFormat() == src->getStreamFormat();
 
     bool extraCompare = true;
 

--- a/tests/media/server/main/dataReader/DataReaderV2Tests.cpp
+++ b/tests/media/server/main/dataReader/DataReaderV2Tests.cpp
@@ -46,6 +46,7 @@ constexpr int32_t kNumberOfChannels{4};
 std::vector<uint8_t> kMediaData{'T', 'E', 'S', 'T', '_', 'M', 'E', 'D', 'I', 'A'};
 std::uint32_t kNumFrames{1};
 const std::vector<uint8_t> kExtraData{1, 2, 3, 4};
+const firebolt::rialto::CodecData kCodecData{{4, 3, 2, 1}};
 const int32_t kMksId{43};
 const std::vector<uint8_t> kKeyId{9, 2, 6, 2, 0, 1};
 const std::vector<uint8_t> kInitVector{34, 53, 54, 62, 56};
@@ -98,6 +99,7 @@ public:
     {
         EXPECT_EQ(m_segment->getExtraData(), kExtraData);
         EXPECT_EQ(m_segment->getSegmentAlignment(), kSegmentAlignment);
+        EXPECT_EQ(m_segment->getCodecData(), kCodecData);
         return *this;
     }
 
@@ -105,6 +107,7 @@ public:
     {
         EXPECT_TRUE(m_segment->getExtraData().empty());
         EXPECT_EQ(m_segment->getSegmentAlignment(), firebolt::rialto::SegmentAlignment::UNDEFINED);
+        EXPECT_FALSE(m_segment->getCodecData());
         return *this;
     }
 
@@ -159,6 +162,7 @@ public:
     {
         m_segment->setExtraData(kExtraData);
         m_segment->setSegmentAlignment(kSegmentAlignment);
+        m_segment->setCodecData(kCodecData);
         return *this;
     }
 

--- a/tests/media/server/main/dataReader/DataReaderV2Tests.cpp
+++ b/tests/media/server/main/dataReader/DataReaderV2Tests.cpp
@@ -46,7 +46,8 @@ constexpr int32_t kNumberOfChannels{4};
 std::vector<uint8_t> kMediaData{'T', 'E', 'S', 'T', '_', 'M', 'E', 'D', 'I', 'A'};
 std::uint32_t kNumFrames{1};
 const std::vector<uint8_t> kExtraData{1, 2, 3, 4};
-const firebolt::rialto::CodecData kCodecData{{4, 3, 2, 1}};
+const std::shared_ptr<std::vector<std::uint8_t>> kCodecData{
+    std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{4, 3, 2, 1})};
 const int32_t kMksId{43};
 const std::vector<uint8_t> kKeyId{9, 2, 6, 2, 0, 1};
 const std::vector<uint8_t> kInitVector{34, 53, 54, 62, 56};
@@ -99,7 +100,8 @@ public:
     {
         EXPECT_EQ(m_segment->getExtraData(), kExtraData);
         EXPECT_EQ(m_segment->getSegmentAlignment(), kSegmentAlignment);
-        EXPECT_EQ(m_segment->getCodecData(), kCodecData);
+        EXPECT_TRUE(m_segment->getCodecData());
+        EXPECT_EQ(*(m_segment->getCodecData()), *kCodecData);
         return *this;
     }
 

--- a/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -39,8 +39,8 @@ public:
     MOCK_METHOD(GstBuffer *, createBuffer, (const IMediaPipeline::MediaSegment &mediaSegment), (const, override));
     MOCK_METHOD(void, attachAudioData, (), (override));
     MOCK_METHOD(void, attachVideoData, (), (override));
-    MOCK_METHOD(void, updateAudioCaps, (int32_t rate, int32_t channels), (override));
-    MOCK_METHOD(void, updateVideoCaps, (int32_t width, int32_t height), (override));
+    MOCK_METHOD(void, updateAudioCaps, (int32_t rate, int32_t channels, const CodecData &codecData), (override));
+    MOCK_METHOD(void, updateVideoCaps, (int32_t width, int32_t height, const CodecData &codecData), (override));
     MOCK_METHOD(bool, changePipelineState, (GstState newState), (override));
     MOCK_METHOD(void, startPositionReportingAndCheckAudioUnderflowTimer, (), (override));
     MOCK_METHOD(void, stopPositionReportingAndCheckAudioUnderflowTimer, (), (override));

--- a/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -22,6 +22,8 @@
 
 #include "IGstGenericPlayerPrivate.h"
 #include <gmock/gmock.h>
+#include <memory>
+#include <vector>
 
 namespace firebolt::rialto::server
 {

--- a/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -39,8 +39,11 @@ public:
     MOCK_METHOD(GstBuffer *, createBuffer, (const IMediaPipeline::MediaSegment &mediaSegment), (const, override));
     MOCK_METHOD(void, attachAudioData, (), (override));
     MOCK_METHOD(void, attachVideoData, (), (override));
-    MOCK_METHOD(void, updateAudioCaps, (int32_t rate, int32_t channels, const CodecData &codecData), (override));
-    MOCK_METHOD(void, updateVideoCaps, (int32_t width, int32_t height, const CodecData &codecData), (override));
+    MOCK_METHOD(void, updateAudioCaps,
+                (int32_t rate, int32_t channels, const std::shared_ptr<std::vector<std::uint8_t>> &codecData),
+                (override));
+    MOCK_METHOD(void, updateVideoCaps,
+                (int32_t width, int32_t height, const std::shared_ptr<std::vector<std::uint8_t>> &codecData), (override));
     MOCK_METHOD(bool, changePipelineState, (GstState newState), (override));
     MOCK_METHOD(void, startPositionReportingAndCheckAudioUnderflowTimer, (), (override));
     MOCK_METHOD(void, stopPositionReportingAndCheckAudioUnderflowTimer, (), (override));


### PR DESCRIPTION
Summary: SetCodecData API added
Type: Fix
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Stuart Pett
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: RIALTO-66