### PR TITLE
Custom socket names support

### DIFF
--- a/common/public/SessionServerCommon.h
+++ b/common/public/SessionServerCommon.h
@@ -21,6 +21,7 @@
 #define FIREBOLT_RIALTO_COMMON_SESSION_SERVER_COMMON_H_
 
 #include <stdint.h>
+#include <string>
 
 namespace firebolt::rialto::common
 {
@@ -49,6 +50,21 @@ struct MaxResourceCapabilitites
 {
     int maxPlaybacks;
     int maxWebAudioPlayers;
+};
+
+/**
+ * @brief Configuration data for an application
+ */
+struct AppConfig
+{
+    std::string clientIpcSocketName; /**< Socket name that Rialto client should connect to */
+    /*
+     * @note Socket name can take the following forms:
+     *    - Empty string, in which case Rialto server will automatically allocate the socket name, e.g. "/tmp/rialto-12"
+     *    - Full path, such as "/foo/bar", in which case Rialto will use this name for the socket
+     *    - Socket name, such as "bar", in which case Rialto will create the named socket in the default dir, e.g.
+     * "/tmp/bar" In all cases the name can be retrieved with getAppConnectionInfo()
+     */
 };
 
 } // namespace firebolt::rialto::common

--- a/serverManager/common/include/ISessionServerAppManager.h
+++ b/serverManager/common/include/ISessionServerAppManager.h
@@ -38,6 +38,8 @@ public:
     ISessionServerAppManager &operator=(const ISessionServerAppManager &) = delete;
     ISessionServerAppManager &operator=(ISessionServerAppManager &&) = delete;
 
+    virtual bool initiateApplication(const std::string &appId, const firebolt::rialto::common::SessionServerState &state,
+                                     const firebolt::rialto::common::AppConfig &appConfig) = 0;
     virtual bool setSessionServerState(const std::string &appId,
                                        const firebolt::rialto::common::SessionServerState &newState) = 0;
     virtual void onSessionServerStateChanged(const std::string &appId,

--- a/serverManager/common/source/ISessionServerAppFactory.h
+++ b/serverManager/common/source/ISessionServerAppFactory.h
@@ -37,6 +37,7 @@ public:
 
     virtual std::unique_ptr<ISessionServerApp> create(const std::string &appId,
                                                       const firebolt::rialto::common::SessionServerState &initialState,
+                                                      const firebolt::rialto::common::AppConfig &appConfig,
                                                       SessionServerAppManager &sessionServerAppManager) const = 0;
 };
 } // namespace rialto::servermanager::common

--- a/serverManager/common/source/SessionServerApp.h
+++ b/serverManager/common/source/SessionServerApp.h
@@ -38,6 +38,7 @@ class SessionServerApp : public ISessionServerApp
 {
 public:
     SessionServerApp(const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState,
+                     const firebolt::rialto::common::AppConfig &appConfig,
                      SessionServerAppManager &sessionServerAppManager,
                      const std::list<std::string> &environmentVariables);
     virtual ~SessionServerApp();

--- a/serverManager/common/source/SessionServerAppFactory.cpp
+++ b/serverManager/common/source/SessionServerAppFactory.cpp
@@ -29,10 +29,9 @@ SessionServerAppFactory::SessionServerAppFactory(const std::list<std::string> &e
 {
 }
 
-std::unique_ptr<ISessionServerApp>
-SessionServerAppFactory::create(const std::string &appId,
-                                const firebolt::rialto::common::SessionServerState &initialState,
-                                SessionServerAppManager &sessionServerAppManager) const
+std::unique_ptr<ISessionServerApp> SessionServerAppFactory::create(
+    const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState,
+    const firebolt::rialto::common::AppConfig &appConfig, SessionServerAppManager &sessionServerAppManager) const
 {
     return std::make_unique<SessionServerApp>(appId, initialState, sessionServerAppManager, m_kEnvironmentVariables);
 }

--- a/serverManager/common/source/SessionServerAppFactory.cpp
+++ b/serverManager/common/source/SessionServerAppFactory.cpp
@@ -33,6 +33,7 @@ std::unique_ptr<ISessionServerApp> SessionServerAppFactory::create(
     const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState,
     const firebolt::rialto::common::AppConfig &appConfig, SessionServerAppManager &sessionServerAppManager) const
 {
-    return std::make_unique<SessionServerApp>(appId, initialState, sessionServerAppManager, m_kEnvironmentVariables);
+    return std::make_unique<SessionServerApp>(appId, initialState, appConfig, sessionServerAppManager,
+                                              m_kEnvironmentVariables);
 }
 } // namespace rialto::servermanager::common

--- a/serverManager/common/source/SessionServerAppFactory.h
+++ b/serverManager/common/source/SessionServerAppFactory.h
@@ -35,6 +35,7 @@ public:
 
     std::unique_ptr<ISessionServerApp> create(const std::string &appId,
                                               const firebolt::rialto::common::SessionServerState &initialState,
+                                              const firebolt::rialto::common::AppConfig &appConfig,
                                               SessionServerAppManager &sessionServerAppManager) const override;
 
 private:

--- a/serverManager/common/source/SessionServerAppManager.cpp
+++ b/serverManager/common/source/SessionServerAppManager.cpp
@@ -46,6 +46,13 @@ SessionServerAppManager::~SessionServerAppManager()
     m_eventThread.reset();
 }
 
+bool SessionServerAppManager::initiateApplication(const std::string &appId,
+                                                  const firebolt::rialto::common::SessionServerState &state,
+                                                  const firebolt::rialto::common::AppConfig &appConfig)
+{
+    return false;
+}
+
 bool SessionServerAppManager::setSessionServerState(const std::string &appId,
                                                     const firebolt::rialto::common::SessionServerState &newState)
 {

--- a/serverManager/common/source/SessionServerAppManager.cpp
+++ b/serverManager/common/source/SessionServerAppManager.cpp
@@ -54,7 +54,7 @@ bool SessionServerAppManager::initiateApplication(const std::string &appId,
                                    toString(state));
     if (state != firebolt::rialto::common::SessionServerState::NOT_RUNNING && !isSessionServerLaunched(appId))
     {
-        return addSessionServer(appId, state);
+        return addSessionServer(appId, state, appConfig);
     }
     RIALTO_SERVER_MANAGER_LOG_ERROR("Initialization of %s failed.", appId.c_str());
     return false;
@@ -107,10 +107,11 @@ bool SessionServerAppManager::setLogLevels(const service::LoggingLevels &logLeve
 }
 
 bool SessionServerAppManager::addSessionServer(const std::string &appId,
-                                               const firebolt::rialto::common::SessionServerState &initialState)
+                                               const firebolt::rialto::common::SessionServerState &initialState,
+                                               const firebolt::rialto::common::AppConfig &appConfig)
 {
     RIALTO_SERVER_MANAGER_LOG_INFO("RialtoServerManager tries to launch %s", appId.c_str());
-    if (!launchSessionServer(appId, initialState))
+    if (!launchSessionServer(appId, initialState, appConfig))
     {
         RIALTO_SERVER_MANAGER_LOG_ERROR("RialtoServerManager unable to launch %s", appId.c_str());
         return false;
@@ -157,10 +158,11 @@ void SessionServerAppManager::cancelSessionServerStartupTimer(const std::string 
 }
 
 bool SessionServerAppManager::launchSessionServer(const std::string &appId,
-                                                  const firebolt::rialto::common::SessionServerState &initialState)
+                                                  const firebolt::rialto::common::SessionServerState &initialState,
+                                                  const firebolt::rialto::common::AppConfig &appConfig)
 {
     std::unique_lock<std::mutex> lock{m_sessionServerAppsMutex};
-    auto app = m_sessionServerAppFactory->create(appId, initialState, *this);
+    auto app = m_sessionServerAppFactory->create(appId, initialState, appConfig, *this);
     if (app->launch())
     {
         m_sessionServerApps.insert(std::make_pair(appId, std::move(app)));

--- a/serverManager/common/source/SessionServerAppManager.cpp
+++ b/serverManager/common/source/SessionServerAppManager.cpp
@@ -50,6 +50,13 @@ bool SessionServerAppManager::initiateApplication(const std::string &appId,
                                                   const firebolt::rialto::common::SessionServerState &state,
                                                   const firebolt::rialto::common::AppConfig &appConfig)
 {
+    RIALTO_SERVER_MANAGER_LOG_INFO("RialtoServerManager requests to launch %s with initial state: %s", appId.c_str(),
+                                   toString(state));
+    if (state != firebolt::rialto::common::SessionServerState::NOT_RUNNING && !isSessionServerLaunched(appId))
+    {
+        return addSessionServer(appId, state);
+    }
+    RIALTO_SERVER_MANAGER_LOG_ERROR("Initialization of %s failed.", appId.c_str());
     return false;
 }
 
@@ -58,21 +65,13 @@ bool SessionServerAppManager::setSessionServerState(const std::string &appId,
 {
     RIALTO_SERVER_MANAGER_LOG_INFO("RialtoServerManager requests to change state of %s to %s", appId.c_str(),
                                    toString(newState));
-    const bool isLaunched{isSessionServerLaunched(appId)};
-    if (newState != firebolt::rialto::common::SessionServerState::NOT_RUNNING && !isLaunched)
-    {
-        return addSessionServer(appId, newState);
-    }
-    else if (isLaunched)
+    if (isSessionServerLaunched(appId))
     {
         return changeSessionServerState(appId, newState);
     }
-    else
-    {
-        RIALTO_SERVER_MANAGER_LOG_ERROR("Change state of %s to %s failed. App is not launched", appId.c_str(),
-                                        toString(newState));
-        return false;
-    }
+    RIALTO_SERVER_MANAGER_LOG_ERROR("Change state of %s to %s failed. App is not launched", appId.c_str(),
+                                    toString(newState));
+    return false;
 }
 
 void SessionServerAppManager::onSessionServerStateChanged(const std::string &appId,

--- a/serverManager/common/source/SessionServerAppManager.h
+++ b/serverManager/common/source/SessionServerAppManager.h
@@ -46,6 +46,8 @@ public:
     SessionServerAppManager &operator=(const SessionServerAppManager &) = delete;
     SessionServerAppManager &operator=(SessionServerAppManager &&) = delete;
 
+    bool initiateApplication(const std::string &appId, const firebolt::rialto::common::SessionServerState &state,
+                             const firebolt::rialto::common::AppConfig &appConfig) override;
     bool setSessionServerState(const std::string &appId,
                                const firebolt::rialto::common::SessionServerState &newState) override;
     void onSessionServerStateChanged(const std::string &appId,

--- a/serverManager/common/source/SessionServerAppManager.h
+++ b/serverManager/common/source/SessionServerAppManager.h
@@ -56,8 +56,10 @@ public:
     bool setLogLevels(const service::LoggingLevels &logLevels) const override;
 
 private:
-    bool addSessionServer(const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState);
-    bool launchSessionServer(const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState);
+    bool addSessionServer(const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState,
+                          const firebolt::rialto::common::AppConfig &appConfig);
+    bool launchSessionServer(const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState,
+                             const firebolt::rialto::common::AppConfig &appConfig);
     void removeSessionServer(const std::string &appId, bool killApp = false);
     bool configureSessionServer(const std::string &appId);
     bool changeSessionServerState(const std::string &appId, const firebolt::rialto::common::SessionServerState &newState);

--- a/serverManager/public/include/IServerManagerService.h
+++ b/serverManager/public/include/IServerManagerService.h
@@ -48,13 +48,29 @@ public:
     IServerManagerService &operator=(IServerManagerService &&) = delete;
 
     /**
+     * @brief Moves an application from NOT_RUNNING to ACTIVE or INACTIVE_STATE
+     *
+     * This method causes a new RialtoSessionServer instance is spawned for the application in the requested state.
+     * This API will return error if the application is already in the ACTIVE or INACTIVE state (the
+     * changeSessionServerState() API should be used in this scenario).
+     *
+     * @param[in]     appId     : The ID of the application
+     * @param[in]     state     : Desired state, cannot be NOT_RUNNING
+     * @param[in]     appConfig : Configuration parameters for app
+     *
+     * @retval true on success.
+     */
+    virtual bool initiateApplication(const std::string &appId, const firebolt::rialto::common::SessionServerState &state,
+                                     const firebolt::rialto::common::AppConfig &appConfig) = 0;
+
+    /**
      * @brief Changes session server state
      *
-     * This method requests an session server to change its state. When session server state is changed from NotRunning
-     * to Inactive/Active state, new RialtoSessionServer instance is spawned. Otherwise SetState request is sent
-     * to RialtoSessionServer.
+     * This method requests an session server to change its state. This API will return an error if the application is
+     * currently in the NOT_RUNNING state (in this scenario the initApplication() API should be used otherwise SetState
+     * request is sent to RialtoSessionServer for the app.
      *
-     * @param[in]     appId     : The ID of an application
+     * @param[in]     appId     : The ID of the application
      * @param[in]     state     : Desired state
      *
      * @retval true on success.

--- a/serverManager/serverManagerSim/HttpRequest.cpp
+++ b/serverManager/serverManagerSim/HttpRequest.cpp
@@ -49,7 +49,9 @@ std::vector<std::string> splitUri(std::string uri)
 namespace rialto::servermanager
 {
 HttpRequest::HttpRequest(mg_connection *conn, const mg_request_info *request_info)
-    : m_connection{conn}, m_method{request_info->request_method}
+    : m_connection{conn}, m_method{request_info->request_method}, m_postData{request_info->post_data
+                                                                                 ? request_info->post_data
+                                                                                 : ""}
 {
     auto uri = splitUri(request_info->uri);
     if (uri.size() > 0)
@@ -70,6 +72,11 @@ std::string HttpRequest::getMethod() const
 std::string HttpRequest::getCommand() const
 {
     return m_command;
+}
+
+std::string HttpRequest::getPostData() const
+{
+    return m_postData;
 }
 
 std::vector<std::string> HttpRequest::getParams() const

--- a/serverManager/serverManagerSim/HttpRequest.h
+++ b/serverManager/serverManagerSim/HttpRequest.h
@@ -34,6 +34,7 @@ public:
 
     std::string getMethod() const;
     std::string getCommand() const;
+    std::string getPostData() const;
     std::vector<std::string> getParams() const;
 
     void reply(const std::string &message) const;
@@ -42,6 +43,7 @@ private:
     mg_connection *m_connection;
     std::string m_method;
     std::string m_command;
+    std::string m_postData;
     std::vector<std::string> m_params;
 };
 } // namespace rialto::servermanager

--- a/serverManager/serverManagerSim/RialtoServerManagerSim.cpp
+++ b/serverManager/serverManagerSim/RialtoServerManagerSim.cpp
@@ -34,6 +34,11 @@ int main(int argc, char *argv[])
     fprintf(stderr, "== For example:                                                          ==\n");
     fprintf(stderr, "== curl -X POST -d \"\" <BOX_IP>:9008/SetState/YouTube/NotRunning          ==\n");
     fprintf(stderr, "==                                                                       ==\n");
+    fprintf(stderr, "== Custom socket name can be set in POST data. Available values are:     ==\n");
+    fprintf(stderr, "==  - Empty string (socket name will be automatically generated)         ==\n");
+    fprintf(stderr, "==  - Full socket path, e.g. POST -d \"/var/customsocket\"                 ==\n");
+    fprintf(stderr, "==  - Socket name, e.g. POST -d \"sock\" will create /tmp/sock socket      ==\n");
+    fprintf(stderr, "==                                                                       ==\n");
     fprintf(stderr, "== To get current state, send GET HttpRequest: /GetState/AppName         ==\n");
     fprintf(stderr, "== For example:                                                          ==\n");
     fprintf(stderr, "== curl -X GET <BOX_IP>:9008/GetState/YouTube                            ==\n");

--- a/serverManager/serverManagerSim/TestService.cpp
+++ b/serverManager/serverManagerSim/TestService.cpp
@@ -65,7 +65,8 @@ void TestService::shutdown()
     m_serverCv.notify_one();
 }
 
-bool TestService::setState(const std::string &appName, const firebolt::rialto::common::SessionServerState &state)
+bool TestService::setState(const std::string &appName, const firebolt::rialto::common::SessionServerState &state,
+                           const firebolt::rialto::common::AppConfig &appConfig)
 {
     if (state == firebolt::rialto::common::SessionServerState::ACTIVE)
     {
@@ -77,6 +78,10 @@ bool TestService::setState(const std::string &appName, const firebolt::rialto::c
             fprintf(stderr, "Failed to switch active: %s to inactive", activeApp.c_str());
             return false;
         }
+    }
+    if (getState(appName) == firebolt::rialto::common::SessionServerState::NOT_RUNNING)
+    {
+        return m_serverManagerService->initiateApplication(appName, state, appConfig);
     }
     return m_serverManagerService->changeSessionServerState(appName, state);
 }

--- a/serverManager/serverManagerSim/TestService.h
+++ b/serverManager/serverManagerSim/TestService.h
@@ -41,7 +41,8 @@ public:
     void run();
     void shutdown();
 
-    bool setState(const std::string &appName, const firebolt::rialto::common::SessionServerState &state);
+    bool setState(const std::string &appName, const firebolt::rialto::common::SessionServerState &state,
+                  const firebolt::rialto::common::AppConfig &appConfig);
     firebolt::rialto::common::SessionServerState getState(const std::string &appName);
     std::string getAppInfo(const std::string &appName);
     bool setLogLevels(const service::LoggingLevels &logLevels);

--- a/serverManager/serverManagerSim/commands/SetState.cpp
+++ b/serverManager/serverManagerSim/commands/SetState.cpp
@@ -60,8 +60,9 @@ void SetState::run() const
     }
     std::string appName{m_kRequest.getParams()[0]};
     firebolt::rialto::common::SessionServerState state{convert(m_kRequest.getParams()[1])};
+    firebolt::rialto::common::AppConfig appConfig{m_kRequest.getPostData()};
     std::string reply{"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"};
-    if (m_service.setState(appName, state))
+    if (m_service.setState(appName, state, appConfig))
     {
         reply += "SetState command succeeded!\r\n";
     }

--- a/serverManager/service/include/ServerManagerService.h
+++ b/serverManager/service/include/ServerManagerService.h
@@ -37,6 +37,8 @@ public:
     ServerManagerService &operator=(const ServerManagerService &) = delete;
     ServerManagerService &operator=(ServerManagerService &&) = delete;
 
+    bool initiateApplication(const std::string &appId, const firebolt::rialto::common::SessionServerState &state,
+                             const firebolt::rialto::common::AppConfig &appConfig) override;
     bool changeSessionServerState(const std::string &appId,
                                   const firebolt::rialto::common::SessionServerState &state) override;
     std::string getAppConnectionInfo(const std::string &appId) const override;

--- a/serverManager/service/source/ServerManagerService.cpp
+++ b/serverManager/service/source/ServerManagerService.cpp
@@ -33,6 +33,13 @@ ServerManagerService::~ServerManagerService()
     RIALTO_SERVER_MANAGER_LOG_INFO("RialtoServerManager is closing...");
 }
 
+bool ServerManagerService::initiateApplication(const std::string &appId,
+                                               const firebolt::rialto::common::SessionServerState &state,
+                                               const firebolt::rialto::common::AppConfig &appConfig)
+{
+    return m_kContext->getSessionServerAppManager().initiateApplication(appId, state, appConfig);
+}
+
 bool ServerManagerService::changeSessionServerState(const std::string &appId,
                                                     const firebolt::rialto::common::SessionServerState &state)
 {

--- a/tests/serverManager/CMakeLists.txt
+++ b/tests/serverManager/CMakeLists.txt
@@ -32,6 +32,7 @@ add_gtests (
         unittests/service/ServerManagerServiceTestsFixture.cpp
         )
 
+add_subdirectory(matchers)
 add_subdirectory(stubs)
 
 target_include_directories(
@@ -42,6 +43,7 @@ target_include_directories(
         $<TARGET_PROPERTY:RialtoServerManagerCommon,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoServerManagerIpc,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoServerManager,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:RialtoServerManagerMatchers,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoServerManagerStub,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoLogging,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoCommon,INTERFACE_INCLUDE_DIRECTORIES>
@@ -59,6 +61,7 @@ target_link_libraries(
         RialtoServerManagerUnitTests
 
         # # Link application source
+        RialtoServerManagerMatchers
         RialtoServerManagerStub
         RialtoServerManagerCommon
         RialtoServerManagerIpc

--- a/tests/serverManager/matchers/CMakeLists.txt
+++ b/tests/serverManager/matchers/CMakeLists.txt
@@ -1,0 +1,45 @@
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Sky UK
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Find includes in corresponding build directories
+set( CMAKE_INCLUDE_CURRENT_DIR ON )
+
+add_library (
+        RialtoServerManagerMatchers
+
+        STATIC
+        Matchers.cpp
+)
+
+target_include_directories (
+        RialtoServerManagerMatchers
+
+        PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+
+        PRIVATE
+        $<TARGET_PROPERTY:RialtoCommon,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_link_libraries (
+        RialtoServerManagerMatchers
+
+        PRIVATE
+        RialtoCommon
+)

--- a/tests/serverManager/matchers/Matchers.cpp
+++ b/tests/serverManager/matchers/Matchers.cpp
@@ -1,0 +1,28 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Matchers.h"
+
+namespace firebolt::rialto::common
+{
+bool operator==(const AppConfig &lhs, const AppConfig &rhs)
+{
+    return lhs.clientIpcSocketName == rhs.clientIpcSocketName;
+}
+} // namespace firebolt::rialto::common

--- a/tests/serverManager/matchers/Matchers.h
+++ b/tests/serverManager/matchers/Matchers.h
@@ -1,0 +1,25 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SessionServerCommon.h"
+
+namespace firebolt::rialto::common
+{
+bool operator==(const AppConfig &lhs, const AppConfig &rhs);
+} // namespace firebolt::rialto::common

--- a/tests/serverManager/mocks/SessionServerAppFactoryMock.h
+++ b/tests/serverManager/mocks/SessionServerAppFactoryMock.h
@@ -35,7 +35,7 @@ public:
 
     MOCK_METHOD(std::unique_ptr<ISessionServerApp>, create,
                 (const std::string &appId, const firebolt::rialto::common::SessionServerState &initialState,
-                 SessionServerAppManager &sessionServerAppManager),
+                 const firebolt::rialto::common::AppConfig &appConfig, SessionServerAppManager &sessionServerAppManager),
                 (const, override));
 };
 } // namespace rialto::servermanager::common

--- a/tests/serverManager/mocks/SessionServerAppManagerMock.h
+++ b/tests/serverManager/mocks/SessionServerAppManagerMock.h
@@ -32,6 +32,10 @@ public:
     SessionServerAppManagerMock() = default;
     virtual ~SessionServerAppManagerMock() = default;
 
+    MOCK_METHOD(bool, initiateApplication,
+                (const std::string &appId, const firebolt::rialto::common::SessionServerState &state,
+                 const firebolt::rialto::common::AppConfig &appConfig),
+                (override));
     MOCK_METHOD(bool, setSessionServerState,
                 (const std::string &, const firebolt::rialto::common::SessionServerState &), (override));
     MOCK_METHOD(void, onSessionServerStateChanged,

--- a/tests/serverManager/unittests/common/SessionServerAppManagerTestsFixture.cpp
+++ b/tests/serverManager/unittests/common/SessionServerAppManagerTestsFixture.cpp
@@ -53,6 +53,7 @@ constexpr rialto::servermanager::service::LoggingLevels
                            rialto::servermanager::service::LoggingLevel::WARNING,
                            rialto::servermanager::service::LoggingLevel::MILESTONE,
                            rialto::servermanager::service::LoggingLevel::INFO};
+const firebolt::rialto::common::AppConfig APP_CONFIG{SESSION_SERVER_SOCKET_NAME};
 } // namespace
 
 MATCHER_P2(MaxResourceMatcher, maxPlaybacks, maxWebAudioPlayers, "")
@@ -184,6 +185,12 @@ void SessionServerAppManagerTests::sessionServerWillKillRunningApplicationAtTear
 void SessionServerAppManagerTests::sessionServerWillReturnAppSocketName(const std::string &socketName)
 {
     EXPECT_CALL(m_sessionServerAppMock, getSessionManagementSocketName()).WillOnce(Return(socketName));
+}
+
+bool SessionServerAppManagerTests::triggerInitiateApplication(const firebolt::rialto::common::SessionServerState &state)
+{
+    EXPECT_TRUE(m_sut);
+    return m_sut->initiateApplication(APP_NAME, state, APP_CONFIG);
 }
 
 bool SessionServerAppManagerTests::triggerSetSessionServerState(const firebolt::rialto::common::SessionServerState &newState)

--- a/tests/serverManager/unittests/common/SessionServerAppManagerTestsFixture.cpp
+++ b/tests/serverManager/unittests/common/SessionServerAppManagerTestsFixture.cpp
@@ -19,6 +19,7 @@
 
 #include "SessionServerAppManagerTestsFixture.h"
 #include "LoggingLevels.h"
+#include "Matchers.h"
 #include "SessionServerAppManager.h"
 #include <string>
 #include <utility>
@@ -85,7 +86,7 @@ SessionServerAppManagerTests::SessionServerAppManagerTests()
 void SessionServerAppManagerTests::sessionServerLaunchWillFail(const firebolt::rialto::common::SessionServerState &state)
 {
     ASSERT_TRUE(m_sessionServerAppFactoryMock);
-    EXPECT_CALL(*m_sessionServerAppFactoryMock, create(APP_NAME, state, _))
+    EXPECT_CALL(*m_sessionServerAppFactoryMock, create(APP_NAME, state, APP_CONFIG, _))
         .WillOnce(Return(ByMove(std::move(m_sessionServerApp))));
     EXPECT_CALL(m_sessionServerAppMock, launch()).WillOnce(Return(false));
 }
@@ -93,7 +94,7 @@ void SessionServerAppManagerTests::sessionServerLaunchWillFail(const firebolt::r
 void SessionServerAppManagerTests::sessionServerConnectWillFail(const firebolt::rialto::common::SessionServerState &state)
 {
     ASSERT_TRUE(m_sessionServerAppFactoryMock);
-    EXPECT_CALL(*m_sessionServerAppFactoryMock, create(APP_NAME, state, _))
+    EXPECT_CALL(*m_sessionServerAppFactoryMock, create(APP_NAME, state, APP_CONFIG, _))
         .WillOnce(Return(ByMove(std::move(m_sessionServerApp))));
     EXPECT_CALL(m_sessionServerAppMock, launch()).WillOnce(Return(true));
     EXPECT_CALL(m_sessionServerAppMock, getAppManagementSocketName()).WillOnce(Return(APP_MGMT_SOCKET));
@@ -109,7 +110,7 @@ void SessionServerAppManagerTests::sessionServerChangeStateWillFail(const firebo
 void SessionServerAppManagerTests::sessionServerWillLaunch(const firebolt::rialto::common::SessionServerState &state)
 {
     ASSERT_TRUE(m_sessionServerAppFactoryMock);
-    EXPECT_CALL(*m_sessionServerAppFactoryMock, create(APP_NAME, state, _))
+    EXPECT_CALL(*m_sessionServerAppFactoryMock, create(APP_NAME, state, APP_CONFIG, _))
         .WillOnce(Return(ByMove(std::move(m_sessionServerApp))));
     EXPECT_CALL(m_sessionServerAppMock, launch()).WillOnce(Return(true));
     EXPECT_CALL(m_sessionServerAppMock, getAppManagementSocketName()).WillOnce(Return(APP_MGMT_SOCKET));

--- a/tests/serverManager/unittests/common/SessionServerAppManagerTestsFixture.h
+++ b/tests/serverManager/unittests/common/SessionServerAppManagerTestsFixture.h
@@ -55,6 +55,7 @@ public:
     void sessionServerWillKillRunningApplicationAtTeardown();
     void clientWillBeRemovedAfterStateChangedIndication(const firebolt::rialto::common::SessionServerState &state);
 
+    bool triggerInitiateApplication(const firebolt::rialto::common::SessionServerState &state);
     bool triggerSetSessionServerState(const firebolt::rialto::common::SessionServerState &newState);
     void triggerOnSessionServerStateChanged(const firebolt::rialto::common::SessionServerState &newState);
     std::string triggerGetAppConnectionInfo();

--- a/tests/serverManager/unittests/service/ServerManagerServiceTests.cpp
+++ b/tests/serverManager/unittests/service/ServerManagerServiceTests.cpp
@@ -25,7 +25,20 @@ namespace
 const std::string APP_NAME{"YouTube"};
 const firebolt::rialto::common::SessionServerState APP_STATE{firebolt::rialto::common::SessionServerState::INACTIVE};
 const std::string APP_SOCKET{getenv("RIALTO_SOCKET_PATH")};
+const firebolt::rialto::common::AppConfig APP_CONFIG{APP_SOCKET};
 } // namespace
+
+TEST_F(ServerManagerServiceTests, initiateApplicationShouldReturnTrueIfOperationSucceeded)
+{
+    initiateApplicationWillBeCalled(APP_NAME, APP_STATE, APP_CONFIG, true);
+    ASSERT_TRUE(triggerInitiateApplication(APP_NAME, APP_STATE, APP_CONFIG));
+}
+
+TEST_F(ServerManagerServiceTests, initiateApplicationShouldReturnFalseIfOperationFailed)
+{
+    initiateApplicationWillBeCalled(APP_NAME, APP_STATE, APP_CONFIG, false);
+    ASSERT_FALSE(triggerInitiateApplication(APP_NAME, APP_STATE, APP_CONFIG));
+}
 
 TEST_F(ServerManagerServiceTests, setStateShouldReturnTrueIfOperationSucceeded)
 {

--- a/tests/serverManager/unittests/service/ServerManagerServiceTestsFixture.cpp
+++ b/tests/serverManager/unittests/service/ServerManagerServiceTestsFixture.cpp
@@ -28,11 +28,27 @@ using testing::AtLeast;
 using testing::Return;
 using testing::ReturnRef;
 
+namespace firebolt::rialto::common
+{
+bool operator==(const AppConfig &lhs, const AppConfig &rhs)
+{
+    return lhs.clientIpcSocketName == rhs.clientIpcSocketName;
+}
+} // namespace firebolt::rialto::common
+
 ServerManagerServiceTests::ServerManagerServiceTests()
 {
     auto serviceContext{std::make_unique<StrictMock<rialto::servermanager::service::ServiceContextMock>>()};
     EXPECT_CALL(*serviceContext, getSessionServerAppManager).Times(AtLeast(0)).WillRepeatedly(ReturnRef(m_appManager));
     m_sut = std::make_unique<rialto::servermanager::service::ServerManagerService>(std::move(serviceContext));
+}
+
+void ServerManagerServiceTests::initiateApplicationWillBeCalled(const std::string &appId,
+                                                                const firebolt::rialto::common::SessionServerState &state,
+                                                                const firebolt::rialto::common::AppConfig &appConfig,
+                                                                bool returnValue)
+{
+    EXPECT_CALL(m_appManager, initiateApplication(appId, state, appConfig)).WillOnce(Return(returnValue));
 }
 
 void ServerManagerServiceTests::setSessionServerStateWillBeCalled(
@@ -49,6 +65,14 @@ void ServerManagerServiceTests::getAppConnectionInfoWillBeCalled(const std::stri
 void ServerManagerServiceTests::setLogLevelsWillBeCalled(bool returnValue)
 {
     EXPECT_CALL(m_appManager, setLogLevels(_)).WillOnce(Return(returnValue));
+}
+
+bool ServerManagerServiceTests::triggerInitiateApplication(const std::string &appId,
+                                                           const firebolt::rialto::common::SessionServerState &state,
+                                                           const firebolt::rialto::common::AppConfig &appConfig)
+{
+    EXPECT_TRUE(m_sut);
+    return m_sut->initiateApplication(appId, state, appConfig);
 }
 
 bool ServerManagerServiceTests::triggerChangeSessionServerState(const std::string &appId,

--- a/tests/serverManager/unittests/service/ServerManagerServiceTestsFixture.cpp
+++ b/tests/serverManager/unittests/service/ServerManagerServiceTestsFixture.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "ServerManagerServiceTestsFixture.h"
+#include "Matchers.h"
 #include "ServerManagerService.h"
 #include "ServiceContextMock.h"
 #include <string>
@@ -27,14 +28,6 @@ using testing::_;
 using testing::AtLeast;
 using testing::Return;
 using testing::ReturnRef;
-
-namespace firebolt::rialto::common
-{
-bool operator==(const AppConfig &lhs, const AppConfig &rhs)
-{
-    return lhs.clientIpcSocketName == rhs.clientIpcSocketName;
-}
-} // namespace firebolt::rialto::common
 
 ServerManagerServiceTests::ServerManagerServiceTests()
 {

--- a/tests/serverManager/unittests/service/ServerManagerServiceTestsFixture.h
+++ b/tests/serverManager/unittests/service/ServerManagerServiceTestsFixture.h
@@ -34,11 +34,16 @@ public:
     ServerManagerServiceTests();
     virtual ~ServerManagerServiceTests() = default;
 
+    void initiateApplicationWillBeCalled(const std::string &appId,
+                                         const firebolt::rialto::common::SessionServerState &state,
+                                         const firebolt::rialto::common::AppConfig &appConfig, bool returnValue);
     void setSessionServerStateWillBeCalled(const std::string &appId,
                                            const firebolt::rialto::common::SessionServerState &state, bool returnValue);
     void getAppConnectionInfoWillBeCalled(const std::string &appId, const std::string &returnValue);
     void setLogLevelsWillBeCalled(bool returnValue);
 
+    bool triggerInitiateApplication(const std::string &appId, const firebolt::rialto::common::SessionServerState &state,
+                                    const firebolt::rialto::common::AppConfig &appConfig);
     bool triggerChangeSessionServerState(const std::string &appId,
                                          const firebolt::rialto::common::SessionServerState &state);
     std::string triggerGetAppConnectionInfo(const std::string &appId);


### PR DESCRIPTION
Summary: Custom socket name support in servermanager
Type: Feature
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Stuart Pett
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: RIALTO-101