### PR TITLE
Move res usage

### DIFF
--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -188,11 +188,6 @@ struct GenericPlayerContext
     int64_t lastAudioSampleTimestamps{0};
 
     /**
-     * @brief Whether this playback is the secondary video in a dual video scenario.
-     */
-    int64_t isSecondaryVideo{false};
-
-    /**
      * @brief The decryption service.
      */
     IDecryptionService *decryptionService{nullptr};

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -118,7 +118,6 @@ private:
     void scheduleAudioUnderflow() override;
     void scheduleVideoUnderflow() override;
     bool setWesterossinkRectangle() override;
-    bool setWesterossinkSecondaryVideo() override;
     void notifyNeedMediaData(bool audioNotificationNeeded, bool videoNotificationNeeded) override;
     GstBuffer *createBuffer(const IMediaPipeline::MediaSegment &mediaSegment) const override;
     void attachAudioData() override;
@@ -179,6 +178,13 @@ private:
      * @param[in] self      : Reference to the calling object.
      */
     static void deepElementAdded(GstBin *pipeline, GstBin *bin, GstElement *element, GstGenericPlayer *self);
+
+    /**
+     * @brief Creates a Westeros sink and sets the res-usage flag for a secondary video.
+     *
+     * @retval true on success.
+     */
+    bool setWesterossinkSecondaryVideo();
 
 private:
     /**

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -186,6 +186,16 @@ private:
      */
     bool setWesterossinkSecondaryVideo();
 
+    /**
+     * @brief Terminates the player pipeline.
+     */
+    void termPipeline();
+
+    /**
+     * @brief Shutdown and destroys the worker thread.
+     */
+    void resetWorkerThread();
+
 private:
     /**
      * @brief The player context.

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -72,13 +72,6 @@ public:
     virtual bool setWesterossinkRectangle() = 0;
 
     /**
-     * @brief Sets Westeros sink res-usage flag for a secondary video.
-     *
-     * @retval true on success.
-     */
-    virtual bool setWesterossinkSecondaryVideo() = 0;
-
-    /**
      * @brief Sends NeedMediaData notification. Called by the worker thread.
      */
     virtual void notifyNeedMediaData(bool audioNotificationNeeded, bool videoNotificationNeeded) = 0;

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -244,7 +244,6 @@ void GstGenericPlayer::resetWorkerThread()
     m_workerThread->enqueueTask(m_taskFactory->createShutdown(*this));
     m_workerThread->join();
     m_workerThread.reset();
-
 }
 
 void GstGenericPlayer::termPipeline()
@@ -772,13 +771,13 @@ bool GstGenericPlayer::setWesterossinkRectangle()
 bool GstGenericPlayer::setWesterossinkSecondaryVideo()
 {
     bool result = false;
-    GstElementFactory* factory = m_gstWrapper->gstElementFactoryFind("westerossink");
+    GstElementFactory *factory = m_gstWrapper->gstElementFactoryFind("westerossink");
     if (factory)
     {
-        GstElement* videoSink = m_gstWrapper->gstElementFactoryCreate(factory, nullptr);
+        GstElement *videoSink = m_gstWrapper->gstElementFactoryCreate(factory, nullptr);
         if (videoSink)
         {
-            if(m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(videoSink), "res-usage"))
+            if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(videoSink), "res-usage"))
             {
                 m_glibWrapper->gObjectSet(videoSink, "res-usage", 0x0u, nullptr);
                 m_glibWrapper->gObjectSet(m_context.pipeline, "video-sink", videoSink, nullptr);

--- a/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
@@ -82,10 +82,6 @@ void SetupElement::execute() const
     RIALTO_SERVER_LOG_DEBUG("Executing SetupElement");
     if (m_glibWrapper->gStrHasPrefix(GST_ELEMENT_NAME(m_element), "westerossink"))
     {
-        if (m_context.isSecondaryVideo)
-        {
-            m_player.setWesterossinkSecondaryVideo();
-        }
         if (!m_context.pendingGeometry.empty())
         {
             m_player.setWesterossinkRectangle();

--- a/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -95,7 +95,8 @@ protected:
     {
         EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink")))
             .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
-        EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(reinterpret_cast<GstElementFactory *>(&m_westerousFactory), _))
+        EXPECT_CALL(*m_gstWrapperMock,
+                    gstElementFactoryCreate(reinterpret_cast<GstElementFactory *>(&m_westerousFactory), _))
             .WillOnce(Return(&m_westerousSink));
         EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, CharStrMatcher("res-usage")))
             .WillOnce(Return(&m_rectangleSpec));
@@ -153,8 +154,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateDestroySecondaryVideoNoWest
     m_videoReq.maxWidth = kMinPrimaryVideoWidth;
     m_videoReq.maxHeight = kMinPrimaryVideoHeight - 1;
 
-    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink")))
-        .WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink"))).WillOnce(Return(nullptr));
 
     createGstGenericPlayerSuccess();
 
@@ -179,11 +179,10 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateWesterossinkFailureForSecon
         .WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
 
-    EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock,
-                                                                  m_type, m_videoReq, m_gstWrapperMock,
-                                                                  m_glibWrapperMock, m_gstSrcFactoryMock,
-                                                                  m_timerFactoryMock, std::move(m_taskFactory),
-                                                                  std::move(workerThreadFactory),
+    EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, m_type,
+                                                                  m_videoReq, m_gstWrapperMock, m_glibWrapperMock,
+                                                                  m_gstSrcFactoryMock, m_timerFactoryMock,
+                                                                  std::move(m_taskFactory), std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
                  std::runtime_error);
@@ -206,16 +205,14 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, SetResUsageFailureForSecondaryVid
         .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(reinterpret_cast<GstElementFactory *>(&m_westerousFactory), _))
         .WillOnce(Return(&m_westerousSink));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, CharStrMatcher("res-usage")))
-        .WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, CharStrMatcher("res-usage"))).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_westerousSink)));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
 
-    EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock,
-                                                                  m_type, m_videoReq, m_gstWrapperMock,
-                                                                  m_glibWrapperMock, m_gstSrcFactoryMock,
-                                                                  m_timerFactoryMock, std::move(m_taskFactory),
-                                                                  std::move(workerThreadFactory),
+    EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, m_type,
+                                                                  m_videoReq, m_gstWrapperMock, m_glibWrapperMock,
+                                                                  m_gstSrcFactoryMock, m_timerFactoryMock,
+                                                                  std::move(m_taskFactory), std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
                  std::runtime_error);

--- a/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -39,6 +39,24 @@ protected:
     MediaType m_type{MediaType::MSE};
     VideoRequirements m_videoReq = {kMinPrimaryVideoWidth, kMinPrimaryVideoHeight};
     GenericPlayerContext m_storedPlayerContext;
+    GstObject m_westerousFactory{}; // GstElementFactory is an opaque data structure
+    GstElement m_westerousSink{};
+    GParamSpec m_rectangleSpec{};
+
+    void expectCreatePipeline()
+    {
+        initFactories();
+        expectMakePlaybin();
+        expectSetFlags();
+        expectSetSignalCallbacks();
+        expectSetUri();
+        expectCheckPlaySink();
+
+        EXPECT_CALL(*m_gstSrcMock, initSrc());
+        EXPECT_CALL(m_workerThreadFactoryMock, createWorkerThread()).WillOnce(Return(ByMove(std::move(workerThread))));
+        EXPECT_CALL(*m_gstProtectionMetadataFactoryMock, createProtectionMetadataWrapper(_))
+            .WillOnce(Return(ByMove(std::move(m_gstProtectionMetadataWrapper))));
+    }
 
     void createGstGenericPlayerSuccess()
     {
@@ -72,6 +90,19 @@ protected:
 
         triggerSetupElement(&element);
     }
+
+    void expectSetSecondaryVideo()
+    {
+        EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink")))
+            .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
+        EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(reinterpret_cast<GstElementFactory *>(&m_westerousFactory), _))
+            .WillOnce(Return(&m_westerousSink));
+        EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, CharStrMatcher("res-usage")))
+            .WillOnce(Return(&m_rectangleSpec));
+        EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(_, CharStrMatcher("res-usage")));
+        EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(_, CharStrMatcher("video-sink")));
+        EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
+    }
 };
 
 /**
@@ -81,8 +112,6 @@ protected:
 TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateDestroyPrimaryVideoSuccess)
 {
     createGstGenericPlayerSuccess();
-    setupElementSuccess(); // Stores the player context
-    EXPECT_EQ(false, m_storedPlayerContext.isSecondaryVideo);
 
     destroyGstGenericPlayerSuccess();
 }
@@ -95,9 +124,8 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateDestroySecondaryVideoMinWid
     // Width < minimum
     m_videoReq.maxWidth = kMinPrimaryVideoWidth - 1;
     m_videoReq.maxHeight = kMinPrimaryVideoHeight;
+    expectSetSecondaryVideo();
     createGstGenericPlayerSuccess();
-    setupElementSuccess(); // Stores the player context
-    EXPECT_EQ(true, m_storedPlayerContext.isSecondaryVideo);
 
     destroyGstGenericPlayerSuccess();
 }
@@ -110,11 +138,88 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateDestroySecondaryVideoMinHei
     // Height < minimum
     m_videoReq.maxWidth = kMinPrimaryVideoWidth;
     m_videoReq.maxHeight = kMinPrimaryVideoHeight - 1;
+    expectSetSecondaryVideo();
     createGstGenericPlayerSuccess();
-    setupElementSuccess(); // Stores the player context
-    EXPECT_EQ(true, m_storedPlayerContext.isSecondaryVideo);
 
     destroyGstGenericPlayerSuccess();
+}
+
+/**
+ * Test that a GstGenericPlayer can be created successfully for a secondary video if no westerous sink.
+ */
+TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateDestroySecondaryVideoNoWesterousSuccess)
+{
+    // Height < minimum
+    m_videoReq.maxWidth = kMinPrimaryVideoWidth;
+    m_videoReq.maxHeight = kMinPrimaryVideoHeight - 1;
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink")))
+        .WillOnce(Return(nullptr));
+
+    createGstGenericPlayerSuccess();
+
+    destroyGstGenericPlayerSuccess();
+}
+
+/**
+ * Test that a GstGenericPlayer object throws an exception if failure to create a westeroussink.
+ */
+TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateWesterossinkFailureForSecondaryVideo)
+{
+    // Height < minimum
+    m_videoReq.maxWidth = kMinPrimaryVideoWidth;
+    m_videoReq.maxHeight = kMinPrimaryVideoHeight - 1;
+    expectCreatePipeline();
+    gstPlayerWillBeDestroyed();
+    executeTaskWhenEnqueued();
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink")))
+        .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(reinterpret_cast<GstElementFactory *>(&m_westerousFactory), _))
+        .WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
+
+    EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock,
+                                                                  m_type, m_videoReq, m_gstWrapperMock,
+                                                                  m_glibWrapperMock, m_gstSrcFactoryMock,
+                                                                  m_timerFactoryMock, std::move(m_taskFactory),
+                                                                  std::move(workerThreadFactory),
+                                                                  std::move(gstDispatcherThreadFactory),
+                                                                  m_gstProtectionMetadataFactoryMock),
+                 std::runtime_error);
+    EXPECT_EQ(m_gstPlayer, nullptr);
+}
+
+/**
+ * Test that a GstGenericPlayer object throws an exception if failure to set the res-usage flag on a westerossink.
+ */
+TEST_F(RialtoServerCreateGstGenericPlayerTest, SetResUsageFailureForSecondaryVideo)
+{
+    // Height < minimum
+    m_videoReq.maxWidth = kMinPrimaryVideoWidth;
+    m_videoReq.maxHeight = kMinPrimaryVideoHeight - 1;
+    expectCreatePipeline();
+    gstPlayerWillBeDestroyed();
+    executeTaskWhenEnqueued();
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink")))
+        .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(reinterpret_cast<GstElementFactory *>(&m_westerousFactory), _))
+        .WillOnce(Return(&m_westerousSink));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, CharStrMatcher("res-usage")))
+        .WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_westerousSink)));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_westerousFactory)));
+
+    EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock,
+                                                                  m_type, m_videoReq, m_gstWrapperMock,
+                                                                  m_glibWrapperMock, m_gstSrcFactoryMock,
+                                                                  m_timerFactoryMock, std::move(m_taskFactory),
+                                                                  std::move(workerThreadFactory),
+                                                                  std::move(gstDispatcherThreadFactory),
+                                                                  m_gstProtectionMetadataFactoryMock),
+                 std::runtime_error);
+    EXPECT_EQ(m_gstPlayer, nullptr);
 }
 
 /**
@@ -171,7 +276,13 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, GstSrcFactoryFails)
  */
 TEST_F(RialtoServerCreateGstGenericPlayerTest, UnknownMediaType)
 {
-    EXPECT_CALL(*m_gstSrcFactoryMock, getGstSrc()).WillOnce(Return(nullptr));
+    initFactories();
+    expectShutdown();
+    executeTaskWhenEnqueued();
+    EXPECT_CALL(*m_gstSrcMock, initSrc());
+    EXPECT_CALL(m_workerThreadFactoryMock, createWorkerThread()).WillOnce(Return(ByMove(std::move(workerThread))));
+    EXPECT_CALL(*m_gstProtectionMetadataFactoryMock, createProtectionMetadataWrapper(_))
+        .WillOnce(Return(ByMove(std::move(m_gstProtectionMetadataWrapper))));
 
     EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock,
                                                                   MediaType::UNKNOWN, m_videoReq, m_gstWrapperMock,

--- a/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -79,18 +79,6 @@ protected:
         m_gstPlayer.reset();
     }
 
-    void setupElementSuccess()
-    {
-        GstElement element{};
-        std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
-        EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
-        EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&element));
-        EXPECT_CALL(m_taskFactoryMock, createSetupElement(_, _, &element))
-            .WillOnce(DoAll(SaveArg<0>(&m_storedPlayerContext), Return(ByMove(std::move(task)))));
-
-        triggerSetupElement(&element);
-    }
-
     void expectSetSecondaryVideo()
     {
         EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("westerossink")))

--- a/tests/media/server/gstplayer/genericPlayer/GstDispatcherThreadClientTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstDispatcherThreadClientTest.cpp
@@ -31,7 +31,7 @@ class GstDispatcherThreadClientTest : public GstGenericPlayerTestCommon
 {
 protected:
     std::unique_ptr<IGstDispatcherThreadClient> m_sut;
-    VideoRequirements m_videoReq = {};
+    VideoRequirements m_videoReq = {kMinPrimaryVideoWidth, kMinPrimaryVideoHeight};
 
     GstDispatcherThreadClientTest()
     {

--- a/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -194,44 +194,6 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangle)
     EXPECT_TRUE(m_sut->setWesterossinkRectangle());
 }
 
-TEST_F(GstGenericPlayerPrivateTest, shouldNotSetSecondaryVideoWhenVideoSinkIsNull)
-{
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, CharStrMatcher("video-sink"), _));
-    EXPECT_FALSE(m_sut->setWesterossinkSecondaryVideo());
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldNotSetSecondaryVideoWhenVideoSinkDoesNotHaveRectangleProperty)
-{
-    GstElement videoSink{};
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, CharStrMatcher("video-sink"), _))
-        .WillOnce(Invoke(
-            [&](gpointer object, const gchar *first_property_name, void *element)
-            {
-                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
-                *elementPtr = &videoSink;
-            }));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, CharStrMatcher("res-usage"))).WillOnce(Return(nullptr));
-    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&videoSink));
-    EXPECT_FALSE(m_sut->setWesterossinkSecondaryVideo());
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldSetSecondaryVideo)
-{
-    GstElement videoSink{};
-    GParamSpec rectangleSpec{};
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, CharStrMatcher("video-sink"), _))
-        .WillOnce(Invoke(
-            [&](gpointer object, const gchar *first_property_name, void *element)
-            {
-                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
-                *elementPtr = &videoSink;
-            }));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, CharStrMatcher("res-usage")))
-        .WillOnce(Return(&rectangleSpec));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(_, CharStrMatcher("res-usage")));
-    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&videoSink));
-    EXPECT_TRUE(m_sut->setWesterossinkSecondaryVideo());
-}
 
 TEST_F(GstGenericPlayerPrivateTest, shouldNotifyNeedAudioData)
 {

--- a/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -194,7 +194,6 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangle)
     EXPECT_TRUE(m_sut->setWesterossinkRectangle());
 }
 
-
 TEST_F(GstGenericPlayerPrivateTest, shouldNotifyNeedAudioData)
 {
     modifyContext([&](GenericPlayerContext &context) { context.audioNeedData = true; });

--- a/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -34,7 +34,7 @@ class GstGenericPlayerTest : public GstGenericPlayerTestCommon
 {
 protected:
     std::unique_ptr<IGstGenericPlayer> m_sut;
-    VideoRequirements m_videoReq = {};
+    VideoRequirements m_videoReq = {kMinPrimaryVideoWidth, kMinPrimaryVideoHeight};
 
     GstGenericPlayerTest()
     {

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -47,17 +47,27 @@ void GstGenericPlayerTestCommon::gstPlayerWillBeCreated()
 
 void GstGenericPlayerTestCommon::gstPlayerWillBeDestroyed()
 {
-    std::unique_ptr<IPlayerTask> stopTask{std::make_unique<StrictMock<PlayerTaskMock>>()};
-    std::unique_ptr<IPlayerTask> shutdownTask{std::make_unique<StrictMock<PlayerTaskMock>>()};
-    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*stopTask), execute());
-    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*shutdownTask), execute());
-    EXPECT_CALL(m_taskFactoryMock, createShutdown(_)).WillOnce(Return(ByMove(std::move(shutdownTask))));
-    EXPECT_CALL(m_workerThreadMock, join());
-    EXPECT_CALL(m_taskFactoryMock, createStop(_, _)).WillOnce(Return(ByMove(std::move(stopTask))));
+    expectShutdown();
+    expectStop();
     EXPECT_CALL(*m_gstWrapperMock, gstPipelineGetBus(GST_PIPELINE(&m_pipeline))).WillOnce(Return(&m_bus));
     EXPECT_CALL(*m_gstWrapperMock, gstBusSetSyncHandler(&m_bus, nullptr, nullptr, nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_bus));
     EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&m_pipeline));
+}
+
+void GstGenericPlayerTestCommon::expectShutdown()
+{
+    std::unique_ptr<IPlayerTask> shutdownTask{std::make_unique<StrictMock<PlayerTaskMock>>()};
+    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*shutdownTask), execute());
+    EXPECT_CALL(m_taskFactoryMock, createShutdown(_)).WillOnce(Return(ByMove(std::move(shutdownTask))));
+    EXPECT_CALL(m_workerThreadMock, join());
+}
+
+void GstGenericPlayerTestCommon::expectStop()
+{
+    std::unique_ptr<IPlayerTask> stopTask{std::make_unique<StrictMock<PlayerTaskMock>>()};
+    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*stopTask), execute());
+    EXPECT_CALL(m_taskFactoryMock, createStop(_, _)).WillOnce(Return(ByMove(std::move(stopTask))));
 }
 
 void GstGenericPlayerTestCommon::executeTaskWhenEnqueued()

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -88,6 +88,8 @@ public:
 protected:
     void gstPlayerWillBeCreated();
     void gstPlayerWillBeDestroyed();
+    void expectShutdown();
+    void expectStop();
     void executeTaskWhenEnqueued();
     void initFactories();
     void expectMakePlaybin();

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
@@ -51,7 +51,6 @@ protected:
     {
         gst_init(nullptr, nullptr);
         m_elementFactory = gst_element_factory_find("fakesrc");
-        m_context.isSecondaryVideo = false;
     }
 
     ~SetupElementTest() { gst_object_unref(m_elementFactory); }
@@ -140,18 +139,6 @@ TEST_F(SetupElementTest, shouldSetupVideoElementWithPendingGeometry)
     EXPECT_FALSE(m_context.audioUnderflowEnabled);
 }
 
-TEST_F(SetupElementTest, shouldSetupVideoElementForSecondaryVideo)
-{
-    m_context.isSecondaryVideo = true;
-    firebolt::rialto::server::tasks::generic::SetupElement task{m_context, m_gstWrapper, m_glibWrapper, m_gstPlayer,
-                                                                &m_element};
-    EXPECT_CALL(*m_glibWrapper, gStrHasPrefix(_, CharStrMatcher("westerossink"))).WillOnce(Return(true));
-    EXPECT_CALL(m_gstPlayer, setWesterossinkSecondaryVideo());
-    expectSetupVideoElement();
-    task.execute();
-    EXPECT_FALSE(m_context.audioUnderflowEnabled);
-}
-
 TEST_F(SetupElementTest, shouldSetupVideoElementWithPendingGeometryOtherThanWesterosSink)
 {
     m_context.pendingGeometry = firebolt::rialto::server::Rectangle{1, 2, 3, 4};
@@ -165,7 +152,6 @@ TEST_F(SetupElementTest, shouldSetupVideoElementWithPendingGeometryOtherThanWest
 
 TEST_F(SetupElementTest, shouldSetupVideoElementForSecondaryVideoOtherThanWesterosSink)
 {
-    m_context.isSecondaryVideo = true;
     firebolt::rialto::server::tasks::generic::SetupElement task{m_context, m_gstWrapper, m_glibWrapper, m_gstPlayer,
                                                                 &m_element};
     EXPECT_CALL(*m_glibWrapper, gStrHasPrefix(_, CharStrMatcher("westerossink"))).WillOnce(Return(false));

--- a/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -36,7 +36,6 @@ public:
     MOCK_METHOD(void, scheduleAudioUnderflow, (), (override));
     MOCK_METHOD(void, scheduleVideoUnderflow, (), (override));
     MOCK_METHOD(bool, setWesterossinkRectangle, (), (override));
-    MOCK_METHOD(bool, setWesterossinkSecondaryVideo, (), (override));
     MOCK_METHOD(void, notifyNeedMediaData, (bool audioNotificationNeeded, bool videoNotificationNeeded), (override));
     MOCK_METHOD(GstBuffer *, createBuffer, (const IMediaPipeline::MediaSegment &mediaSegment), (const, override));
     MOCK_METHOD(void, attachAudioData, (), (override));


### PR DESCRIPTION
Summary: Set res-usage before the video sink is added to the pipeline, setting after is undefined behaviour for Westerossink.
Type: Fix
Test Plan: Unittests, Youtube Dual Video Test
Jira: RIALTO-69