### PR TITLE
Remove id from media source constructor

### DIFF
--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -147,19 +147,18 @@ public:
         /**
          * @brief Default constructor.
          *
-         * @param[out] id           : The source ID will be set by a successful call to attachSource()
          * @param[in]  configType   : The source config type.
          * @param[in]  mimeType     : The mime type string.
          * @param[in]  alignment    : The alignment of media segment.
          * @param[in]  streamFormat : The stream format
          * @param[in]  codecData    : The additional data for decoder
          */
-        explicit MediaSource(int32_t id = 0, SourceConfigType configType = SourceConfigType::UNKNOWN,
+        explicit MediaSource(SourceConfigType configType = SourceConfigType::UNKNOWN,
                              const std::string &mimeType = std::string(),
                              SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                              StreamFormat streamFormat = StreamFormat::UNDEFINED,
                              const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
-            : m_id(id), m_configType(configType), m_mimeType(mimeType), m_alignment(alignment),
+            : m_id(0), m_configType(configType), m_mimeType(mimeType), m_alignment(alignment),
               m_streamFormat(streamFormat), m_codecData(codecData)
         {
         }
@@ -205,18 +204,17 @@ public:
         /**
          * @brief Constructor for audio specific configuration.
          *
-         * @param[out] id           : The source ID will be set by a successful call to attachSource()
          * @param[in]  mimeType     : The mime type string.
          * @param[in]  audioConfig  : The audio specific configuration.
          * @param[in]  alignment    : The alignment of media segment.
          * @param[in]  streamFormat : The stream format
          * @param[in]  codecData    : The additional data for decoder
          */
-        MediaSourceAudio(int32_t id, const std::string &mimeType, const AudioConfig &audioConfig = AudioConfig(),
+        MediaSourceAudio(const std::string &mimeType, const AudioConfig &audioConfig = AudioConfig(),
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                          StreamFormat streamFormat = StreamFormat::UNDEFINED,
                          const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
-            : MediaSource(id, SourceConfigType::AUDIO, mimeType, alignment, streamFormat, codecData),
+            : MediaSource(SourceConfigType::AUDIO, mimeType, alignment, streamFormat, codecData),
               m_audioConfig(audioConfig)
         {
         }
@@ -251,17 +249,16 @@ public:
         /**
          * @brief Constructor for video specific configuration.
          *
-         * @param[out] id           : The source ID will be set by a successful call to attachSource()
          * @param[in]  mimeType     : The mime type string.
          * @param[in]  alignment    : The alignment of media segment.
          * @param[in]  streamFormat : The stream format
          * @param[in]  codecData    : The additional data for decoder
          */
-        MediaSourceVideo(int32_t id, const std::string &mimeType,
+        MediaSourceVideo(const std::string &mimeType,
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                          StreamFormat streamFormat = StreamFormat::UNDEFINED,
                          const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
-            : MediaSource(id, SourceConfigType::VIDEO, mimeType, alignment, streamFormat, codecData)
+            : MediaSource(SourceConfigType::VIDEO, mimeType, alignment, streamFormat, codecData)
         {
         }
         ~MediaSourceVideo() {}
@@ -273,18 +270,17 @@ public:
         /**
          * @brief Constructor for video specific configuration.
          *
-         * @param[out] id               : The source ID will be set by a successful call to attachSource()
          * @param[in]  mimeType         : The mime type string.
          * @param[in]  sourceConfigType : The source config type
          * @param[in]  alignment        : The alignment of media segment.
          * @param[in]  streamFormat     : The stream format
          * @param[in]  codecData        : The additional data for decoder
          */
-        MediaSourceVideo(int32_t id, SourceConfigType sourceConfigType, const std::string &mimeType,
+        MediaSourceVideo(SourceConfigType sourceConfigType, const std::string &mimeType,
                          SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                          StreamFormat streamFormat = StreamFormat::UNDEFINED,
                          const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
-            : MediaSource(id, sourceConfigType, mimeType, alignment, streamFormat, codecData)
+            : MediaSource(sourceConfigType, mimeType, alignment, streamFormat, codecData)
         {
         }
     };
@@ -299,18 +295,17 @@ public:
         /**
          * @brief Constructor for dolby vision specific configuration.
          *
-         * @param[out] id                : The source ID will be set by a successful call to attachSource()
          * @param[in] mimeType           : The mime type string.
          * @param[in] dolbyVisionProfile : The dolby vision profile
          * @param[in] alignment          : The alignment of media segment.
          * @param[in] streamFormat       : The stream format
          * @param[in] codecData          : The additional data for decoder
          */
-        MediaSourceVideoDolbyVision(int32_t id, const std::string &mimeType, int32_t dolbyVisionProfile,
+        MediaSourceVideoDolbyVision(const std::string &mimeType, int32_t dolbyVisionProfile,
                                     SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                                     StreamFormat streamFormat = StreamFormat::UNDEFINED,
                                     const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
-            : MediaSourceVideo(id, SourceConfigType::VIDEO_DOLBY_VISION, mimeType, alignment, streamFormat, codecData),
+            : MediaSourceVideo(SourceConfigType::VIDEO_DOLBY_VISION, mimeType, alignment, streamFormat, codecData),
               m_dolbyVisionProfile(dolbyVisionProfile)
         {
         }

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -254,8 +254,7 @@ public:
          * @param[in]  streamFormat : The stream format
          * @param[in]  codecData    : The additional data for decoder
          */
-        MediaSourceVideo(const std::string &mimeType,
-                         SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
+        MediaSourceVideo(const std::string &mimeType, SegmentAlignment alignment = SegmentAlignment::UNDEFINED,
                          StreamFormat streamFormat = StreamFormat::UNDEFINED,
                          const std::shared_ptr<std::vector<std::uint8_t>> &codecData = nullptr)
             : MediaSource(SourceConfigType::VIDEO, mimeType, alignment, streamFormat, codecData)

--- a/media/server/ipc/source/MediaPipelineModuleService.cpp
+++ b/media/server/ipc/source/MediaPipelineModuleService.cpp
@@ -345,21 +345,21 @@ void MediaPipelineModuleService::attachSource(::google::protobuf::RpcController 
         AudioConfig audioConfig{numberofchannels, sampleRate, codecSpecificConfig};
 
         mediaSource =
-            std::make_unique<IMediaPipeline::MediaSourceAudio>(0, request->mime_type(), audioConfig,
+            std::make_unique<IMediaPipeline::MediaSourceAudio>(request->mime_type(), audioConfig,
                                                                convertSegmentAlignment(request->segment_alignment()),
                                                                convertStreamFormat(request->stream_format()), codecData);
     }
     else if (configType == firebolt::rialto::SourceConfigType::VIDEO)
     {
         mediaSource =
-            std::make_unique<IMediaPipeline::MediaSourceVideo>(0, request->mime_type().c_str(),
+            std::make_unique<IMediaPipeline::MediaSourceVideo>(request->mime_type().c_str(),
                                                                convertSegmentAlignment(request->segment_alignment()),
                                                                convertStreamFormat(request->stream_format()), codecData);
     }
     else if (configType == firebolt::rialto::SourceConfigType::VIDEO_DOLBY_VISION)
     {
         mediaSource =
-            std::make_unique<IMediaPipeline::MediaSourceVideoDolbyVision>(0, request->mime_type().c_str(),
+            std::make_unique<IMediaPipeline::MediaSourceVideoDolbyVision>(request->mime_type().c_str(),
                                                                           request->dolby_vision_profile(),
                                                                           convertSegmentAlignment(
                                                                               request->segment_alignment()),

--- a/tests/media/client/ipc/mediaPipelineIpc/SourceTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/SourceTest.cpp
@@ -172,8 +172,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachAudioSourceWithAdditionalda
     AudioConfig audioConfig{6, 48000, codecSpecificConfig};
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType, audioConfig, alignment, streamFormat,
-                                                           codecData);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType, audioConfig, alignment, streamFormat, codecData);
 
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), true);
 }
@@ -208,8 +207,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachAudioSourceWithEmptyCodecDa
     AudioConfig audioConfig{6, 48000, codecSpecificConfig};
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType, audioConfig, alignment, streamFormat,
-                                                           codecData);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType, audioConfig, alignment, streamFormat, codecData);
 
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), true);
 }

--- a/tests/media/client/ipc/mediaPipelineIpc/SourceTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/SourceTest.cpp
@@ -138,7 +138,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachSourceSuccess)
         .WillOnce(WithArgs<3>(Invoke(this, &RialtoClientMediaPipelineIpcSourceTest::setAttachSourceResponse)));
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), true);
 }
@@ -172,7 +172,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachAudioSourceWithAdditionalda
     AudioConfig audioConfig{6, 48000, codecSpecificConfig};
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType, audioConfig, alignment, streamFormat,
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType, audioConfig, alignment, streamFormat,
                                                            codecData);
 
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), true);
@@ -208,7 +208,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachAudioSourceWithEmptyCodecDa
     AudioConfig audioConfig{6, 48000, codecSpecificConfig};
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType, audioConfig, alignment, streamFormat,
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType, audioConfig, alignment, streamFormat,
                                                            codecData);
 
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), true);
@@ -233,7 +233,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachDolbyVisionSourceWithSucces
         .WillOnce(WithArgs<3>(Invoke(this, &RialtoClientMediaPipelineIpcSourceTest::setAttachSourceResponse)));
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideoDolbyVision>(m_id, m_kMimeType, dolbyVisionProfile, alignment,
+        std::make_unique<IMediaPipeline::MediaSourceVideoDolbyVision>(m_kMimeType, dolbyVisionProfile, alignment,
                                                                       streamFormat, codecData);
 
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), true);
@@ -248,7 +248,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachSourceFailure)
 
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("attachSource"), _, _, _, _));
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), false);
 }
@@ -262,7 +262,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachSourceChannelDisconnected)
     expectUnsubscribeEvents();
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), false);
 
     // Reattach channel on destroySession
@@ -282,7 +282,7 @@ TEST_F(RialtoClientMediaPipelineIpcSourceTest, AttachSourceReconnectChannel)
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("attachSource"), _, _, _, _));
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
     EXPECT_EQ(m_mediaPipelineIpc->attachSource(mediaSource, m_id), true);
 }
 

--- a/tests/media/client/main/mediaPipeline/DataTest.cpp
+++ b/tests/media/client/main/mediaPipeline/DataTest.cpp
@@ -84,7 +84,7 @@ protected:
     void attachSource(std::int32_t sourceId)
     {
         std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-            std::make_unique<IMediaPipeline::MediaSourceAudio>(sourceId, "audio/mp4");
+            std::make_unique<IMediaPipeline::MediaSourceAudio>("audio/mp4");
         EXPECT_CALL(*m_mediaPipelineIpcMock, attachSource(Ref(mediaSource), _))
             .WillOnce(DoAll(SetArgReferee<1>(sourceId), Return(true)));
         EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), true);

--- a/tests/media/client/main/mediaPipeline/SetPositionTest.cpp
+++ b/tests/media/client/main/mediaPipeline/SetPositionTest.cpp
@@ -45,7 +45,7 @@ protected:
     void attachSource()
     {
         std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-            std::make_unique<IMediaPipeline::MediaSourceAudio>(m_sourceId, "audio/mp4");
+            std::make_unique<IMediaPipeline::MediaSourceAudio>("audio/mp4");
         EXPECT_CALL(*m_mediaPipelineIpcMock, attachSource(Ref(mediaSource), _))
             .WillOnce(DoAll(SetArgReferee<1>(m_sourceId), Return(true)));
         EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), true);

--- a/tests/media/client/main/mediaPipeline/SourceTest.cpp
+++ b/tests/media/client/main/mediaPipeline/SourceTest.cpp
@@ -51,7 +51,7 @@ TEST_F(RialtoClientMediaPipelineSourceTest, AttachSourceSuccess)
 {
     int32_t m_newId = 123;
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     EXPECT_CALL(*m_mediaPipelineIpcMock, attachSource(Ref(mediaSource), _))
         .WillOnce(DoAll(SetArgReferee<1>(m_newId), Return(true)));
@@ -67,7 +67,7 @@ TEST_F(RialtoClientMediaPipelineSourceTest, AttachSourceFailure)
 {
     int32_t m_newId = 123;
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_id, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     EXPECT_CALL(*m_mediaPipelineIpcMock, attachSource(Ref(mediaSource), _))
         .WillOnce(DoAll(SetArgReferee<1>(m_newId), Return(false)));

--- a/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -56,7 +56,7 @@ protected:
 TEST_F(GstGenericPlayerTest, shouldAttachSource)
 {
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/mpeg");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/mpeg");
 
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
@@ -310,10 +310,11 @@ TEST_F(AttachSourceTest, shouldAttachVideoDolbyVisionSource)
     GstBuffer buf;
     std::shared_ptr<std::vector<std::uint8_t>> codecData{
         std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{'T', 'E', 'S', 'T'})};
-    std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source = std::make_unique<
-        firebolt::rialto::IMediaPipeline::MediaSourceVideoDolbyVision>("video/h265", dolbyVisionProfile,
-                                                                       firebolt::rialto::SegmentAlignment::AU,
-                                                                       firebolt::rialto::StreamFormat::AVC, codecData);
+    std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideoDolbyVision>("video/h265", dolbyVisionProfile,
+                                                                                        firebolt::rialto::SegmentAlignment::AU,
+                                                                                        firebolt::rialto::StreamFormat::AVC,
+                                                                                        codecData);
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
@@ -58,7 +58,7 @@ protected:
 TEST_F(AttachSourceTest, shouldAttachAudioSource)
 {
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "audio/aac");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -79,7 +79,7 @@ TEST_F(AttachSourceTest, shouldAttachAudioSourceWithChannelsAndRate)
 {
     firebolt::rialto::AudioConfig audioConfig{6, 48000, {}};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "audio/x-eac3", audioConfig);
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/x-eac3", audioConfig);
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -101,7 +101,7 @@ TEST_F(AttachSourceTest, shouldAttachOpusWithAudioSpecificConf)
 {
     firebolt::rialto::AudioConfig audioConfig{0, 0, {'T', 'E', 'S', 'T'}};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "audio/x-opus", audioConfig);
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/x-opus", audioConfig);
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -125,7 +125,7 @@ TEST_F(AttachSourceTest, shouldAttachVideoSource)
     std::shared_ptr<std::vector<std::uint8_t>> codecData{
         std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{'T', 'E', 'S', 'T'})};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264",
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/h264",
                                                                              firebolt::rialto::SegmentAlignment::AU,
                                                                              firebolt::rialto::StreamFormat::AVC,
                                                                              codecData);
@@ -156,7 +156,7 @@ TEST_F(AttachSourceTest, shouldAttachVideoSourceEmptyCodecData)
     GstBuffer buf;
     std::shared_ptr<std::vector<std::uint8_t>> codecData{std::make_shared<std::vector<std::uint8_t>>()};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264",
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/h264",
                                                                              firebolt::rialto::SegmentAlignment::AU,
                                                                              firebolt::rialto::StreamFormat::AVC,
                                                                              codecData);
@@ -185,7 +185,7 @@ TEST_F(AttachSourceTest, shouldUpdateEmptyCapsInAudioSource)
 {
     m_context.streamInfo.emplace(firebolt::rialto::MediaSourceType::AUDIO, &m_appSrc);
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -204,7 +204,7 @@ TEST_F(AttachSourceTest, shouldUpdateExistingCapsInAudioSource)
 {
     m_context.streamInfo.emplace(firebolt::rialto::MediaSourceType::AUDIO, &m_appSrc);
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "audio/aac");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -226,7 +226,7 @@ TEST_F(AttachSourceTest, shouldUpdateEmptyCapsInVideoSource)
 {
     m_context.streamInfo.emplace(firebolt::rialto::MediaSourceType::VIDEO, &m_appSrc);
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -245,7 +245,7 @@ TEST_F(AttachSourceTest, shouldUpdateExistingCapsInVideoSource)
 {
     m_context.streamInfo.emplace(firebolt::rialto::MediaSourceType::VIDEO, &m_appSrc);
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/h264");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -266,7 +266,7 @@ TEST_F(AttachSourceTest, shouldNotUpdateAudioSource)
 {
     m_context.streamInfo.emplace(firebolt::rialto::MediaSourceType::AUDIO, &m_appSrc);
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "audio/aac");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -287,7 +287,7 @@ TEST_F(AttachSourceTest, shouldNotUpdateVideoSource)
 {
     m_context.streamInfo.emplace(firebolt::rialto::MediaSourceType::VIDEO, &m_appSrc);
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/h264");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -311,7 +311,7 @@ TEST_F(AttachSourceTest, shouldAttachVideoDolbyVisionSource)
     std::shared_ptr<std::vector<std::uint8_t>> codecData{
         std::make_shared<std::vector<std::uint8_t>>(std::vector<std::uint8_t>{'T', 'E', 'S', 'T'})};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source = std::make_unique<
-        firebolt::rialto::IMediaPipeline::MediaSourceVideoDolbyVision>(-1, "video/h265", dolbyVisionProfile,
+        firebolt::rialto::IMediaPipeline::MediaSourceVideoDolbyVision>("video/h265", dolbyVisionProfile,
                                                                        firebolt::rialto::SegmentAlignment::AU,
                                                                        firebolt::rialto::StreamFormat::AVC, codecData);
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
@@ -344,7 +344,7 @@ TEST_F(AttachSourceTest, shouldSwitchAudioSource)
     m_context.audioSourceRemoved = true;
     gchar oldCapsStr[]{"audio/x-eac3"};
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "audio/aac");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};
@@ -380,7 +380,7 @@ TEST_F(AttachSourceTest, shouldNotSwitchAudioSourceWhenMimeTypeIsEmpty)
     m_context.streamInfo.emplace(firebolt::rialto::MediaSourceType::AUDIO, &m_appSrc);
     m_context.audioSourceRemoved = true;
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(-1, "");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("");
     firebolt::rialto::server::tasks::generic::AttachSource task{m_context,     m_gstWrapper,
                                                                 m_glibWrapper, m_rdkGstreamerUtilsWrapper,
                                                                 m_gstPlayer,   source};

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
@@ -81,7 +81,7 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateAttachSamples)
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateAttachSource)
 {
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/mpeg");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/mpeg");
     auto task = m_sut.createAttachSource(m_context, m_gstPlayer, source);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::AttachSource &>(*task));

--- a/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
+++ b/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
@@ -382,7 +382,7 @@ void MediaPipelineModuleServiceTests::mediaPipelineServiceWillFailToLoadSession(
 
 void MediaPipelineModuleServiceTests::mediaPipelineServiceWillAttachSource()
 {
-    m_source = std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(0, mimeType);
+    m_source = std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(mimeType);
     expectRequestSuccess();
     EXPECT_CALL(m_mediaPipelineServiceMock, attachSource(hardcodedSessionId, AttachedSourceMatcher(ByRef(m_source))))
         .WillOnce(Return(true));
@@ -394,7 +394,7 @@ void MediaPipelineModuleServiceTests::mediaPipelineServiceWillAttachAudioSourceW
     codecSpecificConfig.assign(codecSpecificConfigStr.begin(), codecSpecificConfigStr.end());
     firebolt::rialto::AudioConfig audioConfig{numberOfChannels, sampleRate, codecSpecificConfig};
     m_source =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(0, mimeType, audioConfig,
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(mimeType, audioConfig,
                                                                              firebolt::rialto::SegmentAlignment::UNDEFINED,
                                                                              firebolt::rialto::StreamFormat::RAW,
                                                                              codecData);
@@ -405,7 +405,7 @@ void MediaPipelineModuleServiceTests::mediaPipelineServiceWillAttachAudioSourceW
 
 void MediaPipelineModuleServiceTests::mediaPipelineServiceWillFailToAttachSource()
 {
-    m_source = std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(0, mimeType);
+    m_source = std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>(mimeType);
     expectRequestFailure();
     EXPECT_CALL(m_mediaPipelineServiceMock, attachSource(hardcodedSessionId, AttachedSourceMatcher(ByRef(m_source))))
         .WillOnce(Return(false));

--- a/tests/media/server/main/mediaPipeline/CallbackTest.cpp
+++ b/tests/media/server/main/mediaPipeline/CallbackTest.cpp
@@ -102,7 +102,7 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNetworkState)
 TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInPrerollingState)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
     mainThreadWillEnqueueTaskAndWait();
 
     EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));
@@ -137,7 +137,7 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInPrerollingSta
 TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInPlayingState)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
     mainThreadWillEnqueueTaskAndWait();
 
     EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));
@@ -192,7 +192,7 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataFailureDueToSou
 TEST_F(RialtoServerMediaPipelineCallbackTest, notifyQos)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
     mainThreadWillEnqueueTaskAndWait();
 
     EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));

--- a/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
+++ b/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
@@ -210,7 +210,7 @@ TEST_F(RialtoServerMediaPipelineHaveDataTest, ServerInternalHaveDataSuccessWithR
     loadGstPlayer();
 
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
     mainThreadWillEnqueueTaskAndWait();
 
     EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));

--- a/tests/media/server/main/mediaPipeline/SourceTest.cpp
+++ b/tests/media/server/main/mediaPipeline/SourceTest.cpp
@@ -39,7 +39,7 @@ protected:
 TEST_F(RialtoServerMediaPipelineSourceTest, AttachSourceSuccess)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(-1, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     loadGstPlayer();
     mainThreadWillEnqueueTaskAndWait();
@@ -57,7 +57,7 @@ TEST_F(RialtoServerMediaPipelineSourceTest, AttachAudioSourceWitSpecificConfigur
 {
     AudioConfig audioConfig{6, 48000, {1, 2, 3}};
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(-1, m_kMimeType, audioConfig);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType, audioConfig);
 
     loadGstPlayer();
     mainThreadWillEnqueueTaskAndWait();
@@ -74,7 +74,7 @@ TEST_F(RialtoServerMediaPipelineSourceTest, AttachAudioSourceWitSpecificConfigur
 TEST_F(RialtoServerMediaPipelineSourceTest, NoGstPlayerFailure)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(-1, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     mainThreadWillEnqueueTaskAndWait();
     EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), false);
@@ -87,7 +87,7 @@ TEST_F(RialtoServerMediaPipelineSourceTest, NoGstPlayerFailure)
 TEST_F(RialtoServerMediaPipelineSourceTest, RemoveSourceSuccess)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(-1, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     loadGstPlayer();
     mainThreadWillEnqueueTaskAndWait();
@@ -127,7 +127,7 @@ TEST_F(RialtoServerMediaPipelineSourceTest, RemoveSourceNoSourcePresent)
 TEST_F(RialtoServerMediaPipelineSourceTest, AttachRemoveAttachSourceDifferentId)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(-1, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     loadGstPlayer();
 
@@ -153,7 +153,7 @@ TEST_F(RialtoServerMediaPipelineSourceTest, AttachRemoveAttachSourceDifferentId)
 TEST_F(RialtoServerMediaPipelineSourceTest, UpdateSourceIdNotChanged)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceAudio>(-1, m_kMimeType);
+        std::make_unique<IMediaPipeline::MediaSourceAudio>(m_kMimeType);
 
     loadGstPlayer();
 

--- a/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTestsFixture.cpp
+++ b/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTestsFixture.cpp
@@ -314,14 +314,14 @@ void MediaPipelineServiceTests::loadShouldFail()
 void MediaPipelineServiceTests::attachSourceShouldSucceed()
 {
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/h264");
     EXPECT_TRUE(m_sut->attachSource(sessionId, mediaSource));
 }
 
 void MediaPipelineServiceTests::attachSourceShouldFail()
 {
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>(-1, "video/h264");
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceVideo>("video/h264");
     EXPECT_FALSE(m_sut->attachSource(sessionId, mediaSource));
 }
 


### PR DESCRIPTION
Summary: Remove id from the MediaSource constructors, this can be set with the setId API.
Type: Cleanup
Test Plan: Unittests, rialto build
Jira: RIALTO-76