### PR TITLE
Handle ocdm errors

### DIFF
--- a/media/server/main/include/MediaKeySession.h
+++ b/media/server/main/include/MediaKeySession.h
@@ -25,6 +25,7 @@
 #include "IOcdmSessionClient.h"
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -169,11 +170,40 @@ private:
     std::vector<uint8_t> m_selectedKeyId;
 
     /**
+     * @brief Whether a Ocdm call is currently ongoing.
+     */
+    bool m_ongoingOcdmOperation;
+
+    /**
+     * @brief Whether Ocdm has returned an error via the onError callback.
+     */
+    bool m_ocdmError;
+
+    /**
+     * @brief Mutex protecting the ocdm error checking.
+     */
+    std::mutex m_ocdmErrorMutex;
+
+    /**
      * @brief Posts a getChallenge task onto the main thread.
      *
      * The challenge data is retrieved from ocdm and notified on a onLicenseRequest.
      */
     void getChallenge();
+
+    /**
+     * @brief Initalises the ocdm error data which checks for onError callbacks.
+     */
+    void initOcdmErrorChecking();
+
+    /**
+     * @brief Checks if onError has been received.
+     *
+     * @param[in] operationStr : Operation name for logging purposes.
+     *
+     * @retval True if an error was received.
+     */
+    bool checkForOcdmErrors(const char* operationStr);
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/main/include/MediaKeySession.h
+++ b/media/server/main/include/MediaKeySession.h
@@ -203,7 +203,7 @@ private:
      *
      * @retval True if an error was received.
      */
-    bool checkForOcdmErrors(const char* operationStr);
+    bool checkForOcdmErrors(const char *operationStr);
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -123,8 +123,7 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
             }
         }
 
-        if ((checkForOcdmErrors("generateRequest")) &&
-            (MediaKeyErrorStatus::OK == status))
+        if ((checkForOcdmErrors("generateRequest")) && (MediaKeyErrorStatus::OK == status))
         {
             status = MediaKeyErrorStatus::FAIL;
         }
@@ -166,8 +165,7 @@ MediaKeyErrorStatus MediaKeySession::loadSession()
         RIALTO_SERVER_LOG_ERROR("Failed to load the key session");
     }
 
-    if ((checkForOcdmErrors("loadSession")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("loadSession")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -197,8 +195,7 @@ MediaKeyErrorStatus MediaKeySession::updateSession(const std::vector<uint8_t> &r
         }
     }
 
-    if ((checkForOcdmErrors("updateSession")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("updateSession")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -216,8 +213,7 @@ MediaKeyErrorStatus MediaKeySession::decrypt(GstBuffer *encrypted, GstCaps *caps
         RIALTO_SERVER_LOG_ERROR("Failed to decrypt buffer");
     }
 
-    if ((checkForOcdmErrors("decrypt")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("decrypt")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -238,8 +234,7 @@ MediaKeyErrorStatus MediaKeySession::decrypt(GstBuffer *encrypted, GstBuffer *su
         RIALTO_SERVER_LOG_ERROR("Failed to decrypt");
     }
 
-    if ((checkForOcdmErrors("decrypt")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("decrypt")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -287,8 +282,7 @@ MediaKeyErrorStatus MediaKeySession::closeKeySession()
         }
     }
 
-    if ((checkForOcdmErrors("closeKeySession")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("closeKeySession")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -306,8 +300,7 @@ MediaKeyErrorStatus MediaKeySession::removeKeySession()
         RIALTO_SERVER_LOG_ERROR("Failed to remove the key session");
     }
 
-    if ((checkForOcdmErrors("removeKeySession")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("removeKeySession")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -325,8 +318,7 @@ MediaKeyErrorStatus MediaKeySession::getCdmKeySessionId(std::string &cdmKeySessi
         RIALTO_SERVER_LOG_ERROR("Failed to get cdm key session id");
     }
 
-    if ((checkForOcdmErrors("getCdmKeySessionId")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("getCdmKeySessionId")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -351,8 +343,7 @@ MediaKeyErrorStatus MediaKeySession::setDrmHeader(const std::vector<uint8_t> &re
         RIALTO_SERVER_LOG_ERROR("Failed to set drm header");
     }
 
-    if ((checkForOcdmErrors("setDrmHeader")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("setDrmHeader")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -370,8 +361,7 @@ MediaKeyErrorStatus MediaKeySession::getLastDrmError(uint32_t &errorCode)
         RIALTO_SERVER_LOG_ERROR("Failed to get last drm error");
     }
 
-    if ((checkForOcdmErrors("getLastDrmError")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("getLastDrmError")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -395,8 +385,7 @@ MediaKeyErrorStatus MediaKeySession::selectKeyId(const std::vector<uint8_t> &key
         m_selectedKeyId = keyId;
     }
 
-    if ((checkForOcdmErrors("selectKeyId")) &&
-        (MediaKeyErrorStatus::OK == status))
+    if ((checkForOcdmErrors("selectKeyId")) && (MediaKeyErrorStatus::OK == status))
     {
         status = MediaKeyErrorStatus::FAIL;
     }
@@ -483,7 +472,7 @@ void MediaKeySession::initOcdmErrorChecking()
     m_ocdmError = false;
 }
 
-bool MediaKeySession::checkForOcdmErrors(const char* operationStr)
+bool MediaKeySession::checkForOcdmErrors(const char *operationStr)
 {
     bool error = false;
 

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -64,7 +64,8 @@ MediaKeySession::MediaKeySession(const std::string &keySystem, int32_t keySessio
                                  KeySessionType sessionType, std::weak_ptr<IMediaKeysClient> client, bool isLDL,
                                  const std::shared_ptr<IMainThreadFactory> &mainThreadFactory)
     : m_kKeySystem(keySystem), m_kKeySessionId(keySessionId), m_kSessionType(sessionType), m_mediaKeysClient(client),
-      m_kIsLDL(isLDL), m_isSessionConstructed(false), m_licenseRequested(false)
+      m_kIsLDL(isLDL), m_isSessionConstructed(false), m_licenseRequested(false), m_ongoingOcdmOperation(false),
+      m_ocdmError(false)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
 

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -103,6 +103,8 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
     // Only construct session if it hasnt previously been constructed
     if (!m_isSessionConstructed)
     {
+        initOcdmErrorChecking();
+
         MediaKeyErrorStatus status =
             m_ocdmSession->constructSession(m_kSessionType, initDataType, &initData[0], initData.size());
         if (MediaKeyErrorStatus::OK != status)
@@ -120,6 +122,13 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
                 getChallenge();
             }
         }
+
+        if ((checkForOcdmErrors("generateRequest")) &&
+            (MediaKeyErrorStatus::OK == status))
+        {
+            status = MediaKeyErrorStatus::FAIL;
+        }
+
         return status;
     }
 
@@ -149,16 +158,27 @@ void MediaKeySession::getChallenge()
 
 MediaKeyErrorStatus MediaKeySession::loadSession()
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status = m_ocdmSession->load();
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to load the key session");
     }
+
+    if ((checkForOcdmErrors("loadSession")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
+    }
+
     return status;
 }
 
 MediaKeyErrorStatus MediaKeySession::updateSession(const std::vector<uint8_t> &responseData)
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status;
     if (kNetflixKeySystem == m_kKeySystem)
     {
@@ -167,7 +187,6 @@ MediaKeyErrorStatus MediaKeySession::updateSession(const std::vector<uint8_t> &r
         {
             RIALTO_SERVER_LOG_ERROR("Failed to store the license data for the key session");
         }
-        return status;
     }
     else
     {
@@ -176,17 +195,33 @@ MediaKeyErrorStatus MediaKeySession::updateSession(const std::vector<uint8_t> &r
         {
             RIALTO_SERVER_LOG_ERROR("Failed to update the key session");
         }
-        return status;
     }
+
+    if ((checkForOcdmErrors("updateSession")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
+    }
+
+    return status;
 }
 
 MediaKeyErrorStatus MediaKeySession::decrypt(GstBuffer *encrypted, GstCaps *caps)
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status = m_ocdmSession->decryptBuffer(encrypted, caps);
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to decrypt buffer");
     }
+
+    if ((checkForOcdmErrors("decrypt")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
+    }
+
     return status;
 }
 
@@ -194,31 +229,41 @@ MediaKeyErrorStatus MediaKeySession::decrypt(GstBuffer *encrypted, GstCaps *caps
 MediaKeyErrorStatus MediaKeySession::decrypt(GstBuffer *encrypted, GstBuffer *subSample, const uint32_t subSampleCount,
                                              GstBuffer *IV, GstBuffer *keyId, uint32_t initWithLast15, GstCaps *caps)
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status =
         m_ocdmSession->decrypt(encrypted, subSample, subSampleCount, IV, keyId, initWithLast15, caps);
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to decrypt");
     }
+
+    if ((checkForOcdmErrors("decrypt")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
+    }
+
     return status;
 }
 
 MediaKeyErrorStatus MediaKeySession::closeKeySession()
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status;
     if (kNetflixKeySystem == m_kKeySystem)
     {
-        status = m_ocdmSession->cancelChallengeData();
-        if (MediaKeyErrorStatus::OK != status)
+        if (MediaKeyErrorStatus::OK != m_ocdmSession->cancelChallengeData())
         {
             RIALTO_SERVER_LOG_WARN("Failed to cancel the challenge data for the key session");
         }
 
-        status = m_ocdmSession->cleanDecryptContext();
-        if (MediaKeyErrorStatus::OK != status)
+        if (MediaKeyErrorStatus::OK != m_ocdmSession->cleanDecryptContext())
         {
             RIALTO_SERVER_LOG_WARN("Failed to clean the decrypt context for the key session");
         }
+        status = MediaKeyErrorStatus::OK;
     }
     else
     {
@@ -226,18 +271,26 @@ MediaKeyErrorStatus MediaKeySession::closeKeySession()
         if (MediaKeyErrorStatus::OK != status)
         {
             RIALTO_SERVER_LOG_ERROR("Failed to Close the key session");
-            return status;
         }
     }
 
-    status = m_ocdmSession->destructSession();
-    if (MediaKeyErrorStatus::OK != status)
+    if (MediaKeyErrorStatus::OK == status)
     {
-        RIALTO_SERVER_LOG_ERROR("Failed to destruct the key session");
+        status = m_ocdmSession->destructSession();
+        if (MediaKeyErrorStatus::OK != status)
+        {
+            RIALTO_SERVER_LOG_ERROR("Failed to destruct the key session");
+        }
+        else
+        {
+            m_isSessionConstructed = false;
+        }
     }
-    else
+
+    if ((checkForOcdmErrors("closeKeySession")) &&
+        (MediaKeyErrorStatus::OK == status))
     {
-        m_isSessionConstructed = false;
+        status = MediaKeyErrorStatus::FAIL;
     }
 
     return status;
@@ -245,11 +298,18 @@ MediaKeyErrorStatus MediaKeySession::closeKeySession()
 
 MediaKeyErrorStatus MediaKeySession::removeKeySession()
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status = m_ocdmSession->remove();
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to remove the key session");
-        return status;
+    }
+
+    if ((checkForOcdmErrors("removeKeySession")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
     }
 
     return status;
@@ -257,11 +317,18 @@ MediaKeyErrorStatus MediaKeySession::removeKeySession()
 
 MediaKeyErrorStatus MediaKeySession::getCdmKeySessionId(std::string &cdmKeySessionId)
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status = m_ocdmSession->getCdmKeySessionId(cdmKeySessionId);
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to get cdm key session id");
-        return status;
+    }
+
+    if ((checkForOcdmErrors("getCdmKeySessionId")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
     }
 
     return status;
@@ -276,21 +343,39 @@ bool MediaKeySession::containsKey(const std::vector<uint8_t> &keyId)
 
 MediaKeyErrorStatus MediaKeySession::setDrmHeader(const std::vector<uint8_t> &requestData)
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status = m_ocdmSession->setDrmHeader(requestData.data(), requestData.size());
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to set drm header");
     }
+
+    if ((checkForOcdmErrors("setDrmHeader")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
+    }
+
     return status;
 }
 
 MediaKeyErrorStatus MediaKeySession::getLastDrmError(uint32_t &errorCode)
 {
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status = m_ocdmSession->getLastDrmError(errorCode);
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to get last drm error");
     }
+
+    if ((checkForOcdmErrors("getLastDrmError")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
+    }
+
     return status;
 }
 
@@ -300,12 +385,22 @@ MediaKeyErrorStatus MediaKeySession::selectKeyId(const std::vector<uint8_t> &key
     {
         return MediaKeyErrorStatus::OK;
     }
+
+    initOcdmErrorChecking();
+
     MediaKeyErrorStatus status = m_ocdmSession->selectKeyId(keyId.size(), keyId.data());
     if (MediaKeyErrorStatus::OK == status)
     {
         RIALTO_SERVER_LOG_INFO("New keyId selected successfully");
         m_selectedKeyId = keyId;
     }
+
+    if ((checkForOcdmErrors("selectKeyId")) &&
+        (MediaKeyErrorStatus::OK == status))
+    {
+        status = MediaKeyErrorStatus::FAIL;
+    }
+
     return status;
 }
 
@@ -369,5 +464,38 @@ void MediaKeySession::onAllKeysUpdated()
 void MediaKeySession::onError(const char message[])
 {
     RIALTO_SERVER_LOG_ERROR("Ocdm returned error: %s", message);
+
+    std::lock_guard<std::mutex> lock(m_ocdmErrorMutex);
+    if (!m_ongoingOcdmOperation)
+    {
+        RIALTO_SERVER_LOG_WARN("Received an asycronous OCDM error, ignoring");
+    }
+    else
+    {
+        m_ocdmError = true;
+    }
 }
+
+void MediaKeySession::initOcdmErrorChecking()
+{
+    std::lock_guard<std::mutex> lock(m_ocdmErrorMutex);
+    m_ongoingOcdmOperation = true;
+    m_ocdmError = false;
+}
+
+bool MediaKeySession::checkForOcdmErrors(const char* operationStr)
+{
+    bool error = false;
+
+    std::lock_guard<std::mutex> lock(m_ocdmErrorMutex);
+    if (m_ocdmError)
+    {
+        RIALTO_SERVER_LOG_ERROR("MediaKeySession received an onError callback, operation '%s' failed", operationStr);
+        error = true;
+    }
+    m_ongoingOcdmOperation = false;
+
+    return error;
+}
+
 }; // namespace firebolt::rialto::server

--- a/tests/media/server/main/mediaKeySession/CloseKeySessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/CloseKeySessionTest.cpp
@@ -104,3 +104,21 @@ TEST_F(RialtoServerMediaKeySessionCloseKeySessionTest, OcdmDestructSessionFailur
 
     EXPECT_EQ(MediaKeyErrorStatus::INVALID_STATE, m_mediaKeySession->closeKeySession());
 }
+
+/**
+ * Test that CloseKeySession fails if ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionCloseKeySessionTest, OnErrorFailure)
+{
+    createKeySession(kWidevineKeySystem);
+
+    EXPECT_CALL(*m_ocdmSessionMock, close())
+        .WillOnce(Invoke([this]()
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
+    EXPECT_CALL(*m_ocdmSessionMock, destructSession()).WillOnce(Return(MediaKeyErrorStatus::OK));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->closeKeySession());
+}

--- a/tests/media/server/main/mediaKeySession/CloseKeySessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/CloseKeySessionTest.cpp
@@ -113,7 +113,8 @@ TEST_F(RialtoServerMediaKeySessionCloseKeySessionTest, OnErrorFailure)
     createKeySession(kWidevineKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, close())
-        .WillOnce(Invoke([this]()
+        .WillOnce(Invoke(
+            [this]()
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/DecryptBufferTest.cpp
+++ b/tests/media/server/main/mediaKeySession/DecryptBufferTest.cpp
@@ -62,7 +62,8 @@ TEST_F(RialtoServerMediaKeySessionDecryptBufferTest, OnErrorFailure)
     createKeySession(kWidevineKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, decryptBuffer(&m_encrypted, &m_caps))
-        .WillOnce(Invoke([this](GstBuffer * encrypted, GstCaps *caps)
+        .WillOnce(Invoke(
+            [this](GstBuffer *encrypted, GstCaps *caps)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/DecryptTest.cpp
+++ b/tests/media/server/main/mediaKeySession/DecryptTest.cpp
@@ -71,9 +71,10 @@ TEST_F(RialtoServerMediaKeySessionDecryptTest, OnErrorFailure)
     createKeySession(kWidevineKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock,
-                    decrypt(&m_encrypted, &m_subSample, m_kSubSampleCount, &m_IV, &m_keyId, m_initWithLast15, &m_caps))
-        .WillOnce(Invoke([this](GstBuffer * encrypted, GstBuffer *subSample, const uint32_t subSampleCount, GstBuffer *IV,
-                 GstBuffer *keyId, uint32_t initWithLast15, GstCaps *caps)
+                decrypt(&m_encrypted, &m_subSample, m_kSubSampleCount, &m_IV, &m_keyId, m_initWithLast15, &m_caps))
+        .WillOnce(Invoke(
+            [this](GstBuffer *encrypted, GstBuffer *subSample, const uint32_t subSampleCount, GstBuffer *IV,
+                   GstBuffer *keyId, uint32_t initWithLast15, GstCaps *caps)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
+++ b/tests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
@@ -127,7 +127,8 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, OnErrorFailure)
     createKeySession(kWidevineKeySystem);
     EXPECT_CALL(*m_ocdmSessionMock,
                 constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
-        .WillOnce(Invoke([this](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize)
+        .WillOnce(Invoke(
+            [this](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/GetCdmKeySessionIdTest.cpp
+++ b/tests/media/server/main/mediaKeySession/GetCdmKeySessionIdTest.cpp
@@ -46,3 +46,19 @@ TEST_F(RialtoServerMediaKeySessionGetCdmKeySessionIdTest, OcdmSessionFailure)
     EXPECT_CALL(*m_ocdmSessionMock, getCdmKeySessionId(cdmKeySessionId)).WillOnce(Return(MediaKeyErrorStatus::FAIL));
     EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->getCdmKeySessionId(cdmKeySessionId));
 }
+
+/**
+ * Test that GetCdmKeySessionId fails if ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionGetCdmKeySessionIdTest, OnErrorFailure)
+{
+    std::string cdmKeySessionId;
+    EXPECT_CALL(*m_ocdmSessionMock, getCdmKeySessionId(cdmKeySessionId))
+        .WillOnce(Invoke([this](std::string & cdmKeySessionId)
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->getCdmKeySessionId(cdmKeySessionId));
+}

--- a/tests/media/server/main/mediaKeySession/GetCdmKeySessionIdTest.cpp
+++ b/tests/media/server/main/mediaKeySession/GetCdmKeySessionIdTest.cpp
@@ -54,7 +54,8 @@ TEST_F(RialtoServerMediaKeySessionGetCdmKeySessionIdTest, OnErrorFailure)
 {
     std::string cdmKeySessionId;
     EXPECT_CALL(*m_ocdmSessionMock, getCdmKeySessionId(cdmKeySessionId))
-        .WillOnce(Invoke([this](std::string & cdmKeySessionId)
+        .WillOnce(Invoke(
+            [this](std::string &cdmKeySessionId)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/GetLastDrmErrorTest.cpp
+++ b/tests/media/server/main/mediaKeySession/GetLastDrmErrorTest.cpp
@@ -58,7 +58,8 @@ TEST_F(RialtoServerMediaKeySessionGetLastDrmErrorTest, OnErrorFailure)
     createKeySession(kNetflixKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, getLastDrmError(m_lastDrmError))
-        .WillOnce(Invoke([this](uint32_t & errorCode)
+        .WillOnce(Invoke(
+            [this](uint32_t &errorCode)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/GetLastDrmErrorTest.cpp
+++ b/tests/media/server/main/mediaKeySession/GetLastDrmErrorTest.cpp
@@ -39,13 +39,30 @@ TEST_F(RialtoServerMediaKeySessionGetLastDrmErrorTest, Success)
 }
 
 /**
- * Test that method returns failure when get last drm error fails
+ * Test that getLastDrmError fails if the ocdm session api fails.
  */
-TEST_F(RialtoServerMediaKeySessionGetLastDrmErrorTest, Fail)
+TEST_F(RialtoServerMediaKeySessionGetLastDrmErrorTest, OcdmSessionFail)
 {
     createKeySession(kNetflixKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, getLastDrmError(m_lastDrmError)).WillOnce(Return(MediaKeyErrorStatus::FAIL));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->getLastDrmError(m_lastDrmError));
+}
+
+/**
+ * Test that getLastDrmError fails if ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionGetLastDrmErrorTest, OnErrorFailure)
+{
+    createKeySession(kNetflixKeySystem);
+
+    EXPECT_CALL(*m_ocdmSessionMock, getLastDrmError(m_lastDrmError))
+        .WillOnce(Invoke([this](uint32_t & errorCode)
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
 
     EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->getLastDrmError(m_lastDrmError));
 }

--- a/tests/media/server/main/mediaKeySession/LoadSessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/LoadSessionTest.cpp
@@ -44,3 +44,18 @@ TEST_F(RialtoServerMediaKeySessionLoadSessionTest, OcdmSessionFailure)
     EXPECT_CALL(*m_ocdmSessionMock, load()).WillOnce(Return(MediaKeyErrorStatus::NOT_SUPPORTED));
     EXPECT_EQ(MediaKeyErrorStatus::NOT_SUPPORTED, m_mediaKeySession->loadSession());
 }
+
+/**
+ * Test that loadSession fails if ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionLoadSessionTest, OnErrorFailure)
+{
+    EXPECT_CALL(*m_ocdmSessionMock, load())
+        .WillOnce(Invoke([this]()
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->loadSession());
+}

--- a/tests/media/server/main/mediaKeySession/LoadSessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/LoadSessionTest.cpp
@@ -51,7 +51,8 @@ TEST_F(RialtoServerMediaKeySessionLoadSessionTest, OcdmSessionFailure)
 TEST_F(RialtoServerMediaKeySessionLoadSessionTest, OnErrorFailure)
 {
     EXPECT_CALL(*m_ocdmSessionMock, load())
-        .WillOnce(Invoke([this]()
+        .WillOnce(Invoke(
+            [this]()
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/RemoveKeySessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/RemoveKeySessionTest.cpp
@@ -44,3 +44,18 @@ TEST_F(RialtoServerMediaKeySessionRemoveKeySessionTest, OcdmSessionFailure)
     EXPECT_CALL(*m_ocdmSessionMock, remove()).WillOnce(Return(MediaKeyErrorStatus::NOT_SUPPORTED));
     EXPECT_EQ(MediaKeyErrorStatus::NOT_SUPPORTED, m_mediaKeySession->removeKeySession());
 }
+
+/**
+ * Test that removeKeySession fails if ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionRemoveKeySessionTest, OnErrorFailure)
+{
+    EXPECT_CALL(*m_ocdmSessionMock, remove())
+        .WillOnce(Invoke([this]()
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->removeKeySession());
+}

--- a/tests/media/server/main/mediaKeySession/RemoveKeySessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/RemoveKeySessionTest.cpp
@@ -51,7 +51,8 @@ TEST_F(RialtoServerMediaKeySessionRemoveKeySessionTest, OcdmSessionFailure)
 TEST_F(RialtoServerMediaKeySessionRemoveKeySessionTest, OnErrorFailure)
 {
     EXPECT_CALL(*m_ocdmSessionMock, remove())
-        .WillOnce(Invoke([this]()
+        .WillOnce(Invoke(
+            [this]()
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/SelectKeyIdTest.cpp
+++ b/tests/media/server/main/mediaKeySession/SelectKeyIdTest.cpp
@@ -84,3 +84,20 @@ TEST_F(RialtoServerMediaKeySessionSelectKeyIdTest, SaveKeyAfterSuccessfulOperati
 
     EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->selectKeyId(m_kKeyId));
 }
+
+/**
+ * Test that selectKeyId fails if ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionSelectKeyIdTest, OnErrorFailure)
+{
+    createKeySession(kNetflixKeySystem);
+
+    EXPECT_CALL(*m_ocdmSessionMock, selectKeyId(m_kKeyId.size(), m_kKeyId.data()))
+        .WillOnce(Invoke([this](uint8_t keyLength, const uint8_t keyId[])
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->selectKeyId(m_kKeyId));
+}

--- a/tests/media/server/main/mediaKeySession/SelectKeyIdTest.cpp
+++ b/tests/media/server/main/mediaKeySession/SelectKeyIdTest.cpp
@@ -93,7 +93,8 @@ TEST_F(RialtoServerMediaKeySessionSelectKeyIdTest, OnErrorFailure)
     createKeySession(kNetflixKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, selectKeyId(m_kKeyId.size(), m_kKeyId.data()))
-        .WillOnce(Invoke([this](uint8_t keyLength, const uint8_t keyId[])
+        .WillOnce(Invoke(
+            [this](uint8_t keyLength, const uint8_t keyId[])
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/SetDrmHeaderTest.cpp
+++ b/tests/media/server/main/mediaKeySession/SetDrmHeaderTest.cpp
@@ -40,14 +40,31 @@ TEST_F(RialtoServerMediaKeySessionSetDrmHeaderTest, Success)
 }
 
 /**
- * Test that method returns failure when set drm header fails
+ * Test that setDrmHeader fails if the ocdm session api set drm header fails.
  */
-TEST_F(RialtoServerMediaKeySessionSetDrmHeaderTest, Fail)
+TEST_F(RialtoServerMediaKeySessionSetDrmHeaderTest, OcdmSessionFailure)
 {
     createKeySession(kNetflixKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, setDrmHeader(&m_kDrmHeader[0], m_kDrmHeader.size()))
         .WillOnce(Return(MediaKeyErrorStatus::FAIL));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->setDrmHeader(m_kDrmHeader));
+}
+
+/**
+ * Test that setDrmHeader fails if the ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionSetDrmHeaderTest, OnErrorFailure)
+{
+    createKeySession(kWidevineKeySystem);
+
+    EXPECT_CALL(*m_ocdmSessionMock, setDrmHeader(&m_kDrmHeader[0], m_kDrmHeader.size()))
+        .WillOnce(Invoke([this](const uint8_t drmHeader[], uint32_t drmHeaderSize)
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
 
     EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->setDrmHeader(m_kDrmHeader));
 }

--- a/tests/media/server/main/mediaKeySession/SetDrmHeaderTest.cpp
+++ b/tests/media/server/main/mediaKeySession/SetDrmHeaderTest.cpp
@@ -60,7 +60,8 @@ TEST_F(RialtoServerMediaKeySessionSetDrmHeaderTest, OnErrorFailure)
     createKeySession(kWidevineKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, setDrmHeader(&m_kDrmHeader[0], m_kDrmHeader.size()))
-        .WillOnce(Invoke([this](const uint8_t drmHeader[], uint32_t drmHeaderSize)
+        .WillOnce(Invoke(
+            [this](const uint8_t drmHeader[], uint32_t drmHeaderSize)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/UpdateSessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/UpdateSessionTest.cpp
@@ -87,7 +87,8 @@ TEST_F(RialtoServerMediaKeySessionUpdateSessionTest, OcdmSessionUpdateOnErrorFai
     createKeySession(kWidevineKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock, update(&m_kResponseData[0], m_kResponseData.size()))
-        .WillOnce(Invoke([this](const uint8_t response[], uint32_t responseSize)
+        .WillOnce(Invoke(
+            [this](const uint8_t response[], uint32_t responseSize)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;

--- a/tests/media/server/main/mediaKeySession/UpdateSessionTest.cpp
+++ b/tests/media/server/main/mediaKeySession/UpdateSessionTest.cpp
@@ -78,3 +78,20 @@ TEST_F(RialtoServerMediaKeySessionUpdateSessionTest, OcdmSessionUpdateFailure)
 
     EXPECT_EQ(MediaKeyErrorStatus::INVALID_STATE, m_mediaKeySession->updateSession(m_kResponseData));
 }
+
+/**
+ * Test that UpdateSession fails if the ocdm onError is called during the operation.
+ */
+TEST_F(RialtoServerMediaKeySessionUpdateSessionTest, OcdmSessionUpdateOnErrorFailure)
+{
+    createKeySession(kWidevineKeySystem);
+
+    EXPECT_CALL(*m_ocdmSessionMock, update(&m_kResponseData[0], m_kResponseData.size()))
+        .WillOnce(Invoke([this](const uint8_t response[], uint32_t responseSize)
+            {
+                m_mediaKeySession->onError("Failure");
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->updateSession(m_kResponseData));
+}


### PR DESCRIPTION
Summary: MediaKeySession now stores ocdm errors received via onError and returns the relevant status from Apis.
Type: Feature
Test Plan: Unittests, NPLB
Jira: RIALTO-154