### PR TITLE
Fix NPLB tests

### DIFF
--- a/media/client/ipc/source/MediaKeysIpc.cpp
+++ b/media/client/ipc/source/MediaKeysIpc.cpp
@@ -160,6 +160,7 @@ MediaKeysIpc::MediaKeysIpc(const std::string &keySystem, const std::shared_ptr<I
 
     if (!createMediaKeys(keySystem))
     {
+        detachChannel();
         throw std::runtime_error("Could not create the media keys instance");
     }
 }

--- a/media/client/ipc/source/MediaPipelineIpc.cpp
+++ b/media/client/ipc/source/MediaPipelineIpc.cpp
@@ -81,6 +81,7 @@ MediaPipelineIpc::MediaPipelineIpc(IMediaPipelineIpcClient *client, const VideoR
     // create media player session
     if (!createSession(videoRequirements))
     {
+        detachChannel();
         throw std::runtime_error("Could not create the media player session");
     }
 }

--- a/media/client/ipc/source/WebAudioPlayerIpc.cpp
+++ b/media/client/ipc/source/WebAudioPlayerIpc.cpp
@@ -77,6 +77,7 @@ WebAudioPlayerIpc::WebAudioPlayerIpc(IWebAudioPlayerIpcClient *client, const std
 
     if (!createWebAudioPlayer(audioMimeType, priority, config))
     {
+        detachChannel();
         throw std::runtime_error("Could not create the web audio player");
     }
 }

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -224,9 +224,9 @@ protected:
     bool m_wasAllSourcesAttachedCalled;
 
     /**
-     * @brief Flag used to check if Eos has been set on this playback
+     * @brief Map of flag used to check if Eos has been set on the media type for this playback
      */
-    bool m_isEos;
+    std::map<MediaSourceType, bool> m_isMediaTypeEosMap;
 
     /**
      * @brief Load internally, only to be called on the main thread.

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -224,7 +224,7 @@ protected:
     bool m_wasAllSourcesAttachedCalled;
 
     /**
-     * @brief Map of flag used to check if Eos has been set on the media type for this playback
+     * @brief Map of flags used to check if Eos has been set on the media type for this playback
      */
     std::map<MediaSourceType, bool> m_isMediaTypeEosMap;
 

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -224,6 +224,11 @@ protected:
     bool m_wasAllSourcesAttachedCalled;
 
     /**
+     * @brief Flag used to check if Eos has been set on this playback
+     */
+    bool m_isEos;
+
+    /**
      * @brief Load internally, only to be called on the main thread.
      *
      * @param[in] type     : The media type.

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -449,7 +449,7 @@ bool MediaPipelineServerInternal::setPositionInternal(int64_t position)
     m_gstPlayer->setPosition(position);
 
     // Reset Eos on seek
-    for (auto& isMediaTypeEos: m_isMediaTypeEosMap)
+    for (auto &isMediaTypeEos : m_isMediaTypeEosMap)
     {
         isMediaTypeEos.second = false;
     }

--- a/tests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
@@ -128,6 +128,7 @@ TEST_F(RialtoClientCreateMediaKeysIpcTest, CreateMediaKeysFailure)
     expectInitIpc();
     expectSubscribeEvents();
     expectIpcApiCallFailure();
+    expectUnsubscribeEvents();
 
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createMediaKeys"), _, _, _, _));

--- a/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
@@ -150,6 +150,7 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateSessionFailure)
     expectInitIpc();
     expectSubscribeEvents();
     expectIpcApiCallFailure();
+    expectUnsubscribeEvents();
 
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createSession"), _, _, _, _));

--- a/tests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
@@ -146,6 +146,7 @@ TEST_F(RialtoClientCreateWebAudioPlayerIpcTest, CreateSessionFailure)
     expectInitIpc();
     expectSubscribeEvents();
     expectIpcApiCallFailure();
+    expectUnsubscribeEvents();
 
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createWebAudioPlayer"), _, _, _, _));

--- a/tests/media/server/main/mediaPipeline/CallbackTest.cpp
+++ b/tests/media/server/main/mediaPipeline/CallbackTest.cpp
@@ -17,15 +17,7 @@
  * limitations under the License.
  */
 
-#include "IGstGenericPlayerClient.h"
 #include "MediaPipelineTestBase.h"
-
-using ::testing::A;
-using ::testing::ByMove;
-using ::testing::DoAll;
-using ::testing::Ref;
-using ::testing::ReturnRef;
-using ::testing::SaveArg;
 
 MATCHER_P(QosInfoMatcher, expectedQosInfo, "")
 {
@@ -35,46 +27,21 @@ MATCHER_P(QosInfoMatcher, expectedQosInfo, "")
 class RialtoServerMediaPipelineCallbackTest : public MediaPipelineTestBase
 {
 protected:
-    IGstGenericPlayerClient *m_gstPlayerCallback;
-
     RialtoServerMediaPipelineCallbackTest()
     {
         createMediaPipeline();
 
-        GetGstPlayerClient();
+        loadGstPlayer();
     }
 
     ~RialtoServerMediaPipelineCallbackTest() { destroyMediaPipeline(); }
 
-    void GetGstPlayerClient()
+    void setPlaybackStatePlaying()
     {
-        mainThreadWillEnqueueTaskAndWait();
-        EXPECT_CALL(*m_gstPlayerFactoryMock, createGstGenericPlayer(_, _, _, _, _))
-            .WillOnce(DoAll(SaveArg<0>(&m_gstPlayerCallback), Return(ByMove(std::move(m_gstPlayer)))));
-
-        // notifyNetworkState posts a task onto the main thread but doesnt wait
         mainThreadWillEnqueueTask();
-        EXPECT_CALL(*m_mediaPipelineClientMock, notifyNetworkState(NetworkState::BUFFERING));
+        EXPECT_CALL(*m_mediaPipelineClientMock, notifyPlaybackState(PlaybackState::PLAYING));
 
-        EXPECT_EQ(m_mediaPipeline->load(MediaType::MSE, "mime", "mse://1"), true);
-
-        ASSERT_NE(m_gstPlayerCallback, nullptr);
-    }
-
-    void setEos()
-    {
-        const uint32_t kNeedDataRequestId{0};
-        auto status = firebolt::rialto::MediaSourceStatus::EOS;
-        IMediaPipeline::MediaSegmentVector dataVec;
-        mainThreadWillEnqueueTaskAndWait();
-        ASSERT_TRUE(m_activeRequestsMock);
-        EXPECT_CALL(*m_activeRequestsMock, getType(kNeedDataRequestId))
-            .WillOnce(Return(firebolt::rialto::MediaSourceType::VIDEO));
-        EXPECT_CALL(*m_activeRequestsMock, getSegments(kNeedDataRequestId)).WillOnce(ReturnRef(dataVec));
-        EXPECT_CALL(*m_activeRequestsMock, erase(kNeedDataRequestId));
-        EXPECT_CALL(*m_gstPlayerMock, attachSamples(A<const IMediaPipeline::MediaSegmentVector &>()));
-        EXPECT_CALL(*m_gstPlayerMock, setEos(firebolt::rialto::MediaSourceType::VIDEO));
-        EXPECT_TRUE(m_mediaPipeline->haveData(status, kNeedDataRequestId));
+        m_gstPlayerCallback->notifyPlaybackState(PlaybackState::PLAYING);
     }
 };
 
@@ -119,32 +86,11 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNetworkState)
  */
 TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInPrerollingState)
 {
-    std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
-    mainThreadWillEnqueueTaskAndWait();
-
-    EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));
-
-    EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), true);
-
     auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
-    int sourceId{mediaSource->getId()};
+    int sourceId = attachSource(mediaSourceType, "video/h264");
     int numFrames{1};
-    mainThreadWillEnqueueTaskAndWait();
-    ASSERT_TRUE(m_sharedMemoryBufferMock);
-    ASSERT_TRUE(m_activeRequestsMock);
-    EXPECT_CALL(*m_sharedMemoryBufferMock,
-                clearData(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, mediaSourceType))
-        .WillOnce(Return(true));
-    EXPECT_CALL(*m_sharedMemoryBufferMock,
-                getMaxDataLen(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, mediaSourceType))
-        .WillOnce(Return(7 * 1024 * 1024));
-    EXPECT_CALL(*m_sharedMemoryBufferMock,
-                getDataOffset(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, mediaSourceType))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*m_activeRequestsMock, insert(mediaSourceType, _)).WillOnce(Return(0));
-    EXPECT_CALL(*m_mediaPipelineClientMock,
-                notifyNeedMediaData(sourceId, numFrames, 0, _)); // params tested in NeedMediaDataTests
+
+    expectNotifyNeedData(mediaSourceType, sourceId, numFrames);
 
     m_gstPlayerCallback->notifyNeedMediaData(mediaSourceType);
 }
@@ -154,36 +100,13 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInPrerollingSta
  */
 TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInPlayingState)
 {
-    std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
-    mainThreadWillEnqueueTaskAndWait();
-
-    EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));
-
-    EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), true);
-
-    EXPECT_CALL(*m_mediaPipelineClientMock, notifyPlaybackState(PlaybackState::PLAYING));
-    mainThreadWillEnqueueTask();
-    m_gstPlayerCallback->notifyPlaybackState(PlaybackState::PLAYING);
-
     auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
-    int sourceId{mediaSource->getId()};
+    int sourceId = attachSource(mediaSourceType, "video/h264");
     int numFrames{24};
-    mainThreadWillEnqueueTaskAndWait();
-    ASSERT_TRUE(m_sharedMemoryBufferMock);
-    ASSERT_TRUE(m_activeRequestsMock);
-    EXPECT_CALL(*m_sharedMemoryBufferMock,
-                clearData(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, mediaSourceType))
-        .WillOnce(Return(true));
-    EXPECT_CALL(*m_sharedMemoryBufferMock,
-                getMaxDataLen(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, mediaSourceType))
-        .WillOnce(Return(7 * 1024 * 1024));
-    EXPECT_CALL(*m_sharedMemoryBufferMock,
-                getDataOffset(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, mediaSourceType))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*m_activeRequestsMock, insert(mediaSourceType, _)).WillOnce(Return(0));
-    EXPECT_CALL(*m_mediaPipelineClientMock,
-                notifyNeedMediaData(sourceId, numFrames, 0, _)); // params tested in NeedMediaDataTests
+
+    setPlaybackStatePlaying();
+
+    expectNotifyNeedData(mediaSourceType, sourceId, numFrames);
 
     m_gstPlayerCallback->notifyNeedMediaData(mediaSourceType);
 }
@@ -205,33 +128,53 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataFailureDueToSou
 }
 
 /**
- * Test a notification of the need media data is ignored if EOS.
+ * Test a notification of the need media data for audio is ignored if EOS.
  */
-TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInEos)
+TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataAudioInEos)
 {
-    std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
-    mainThreadWillEnqueueTaskAndWait();
+    auto mediaSourceType = firebolt::rialto::MediaSourceType::AUDIO;
+    attachSource(mediaSourceType, "audio/x-opus");
 
-    EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));
+    setPlaybackStatePlaying();
+    setEos(mediaSourceType);
 
-    EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), true);
-
-    EXPECT_CALL(*m_mediaPipelineClientMock, notifyPlaybackState(PlaybackState::PLAYING));
-    mainThreadWillEnqueueTask();
-    m_gstPlayerCallback->notifyPlaybackState(PlaybackState::PLAYING);
-
-    auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
-    mainThreadWillEnqueueTaskAndWait();
-    ASSERT_TRUE(m_sharedMemoryBufferMock);
-    ASSERT_TRUE(m_activeRequestsMock);
-    EXPECT_CALL(*m_sharedMemoryBufferMock,
-                clearData(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, mediaSourceType))
-        .WillOnce(Return(true));
-
-    setEos();
+    expectNotifyNeedDataEos(mediaSourceType);
 
     m_gstPlayerCallback->notifyNeedMediaData(mediaSourceType);
+}
+
+/**
+ * Test a notification of the need media data for video is ignored if EOS.
+ */
+TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataVideoInEos)
+{
+    auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
+    attachSource(mediaSourceType, "video/h264");
+
+    setPlaybackStatePlaying();
+    setEos(mediaSourceType);
+
+    expectNotifyNeedDataEos(mediaSourceType);
+
+    m_gstPlayerCallback->notifyNeedMediaData(mediaSourceType);
+}
+
+/**
+ * Test a notification of the need media data is sent if another source is Eos.
+ */
+TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataOtherSourcesInEos)
+{
+    int videoSourceId = attachSource(firebolt::rialto::MediaSourceType::VIDEO, "video/h264");
+    attachSource(firebolt::rialto::MediaSourceType::AUDIO, "audio/x-opus");
+
+    int numFrames{24};
+
+    setPlaybackStatePlaying();
+    setEos(firebolt::rialto::MediaSourceType::AUDIO);
+
+    expectNotifyNeedData(firebolt::rialto::MediaSourceType::VIDEO, videoSourceId, numFrames);
+
+    m_gstPlayerCallback->notifyNeedMediaData(firebolt::rialto::MediaSourceType::VIDEO);
 }
 
 /**
@@ -239,16 +182,8 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInEos)
  */
 TEST_F(RialtoServerMediaPipelineCallbackTest, notifyQos)
 {
-    std::unique_ptr<IMediaPipeline::MediaSource> mediaSource =
-        std::make_unique<IMediaPipeline::MediaSourceVideo>("video/h264");
-    mainThreadWillEnqueueTaskAndWait();
-
-    EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));
-
-    EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), true);
-
     auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
-    int sourceId{mediaSource->getId()};
+    int sourceId = attachSource(mediaSourceType, "audio/x-opus");
     QosInfo qosInfo{5u, 2u};
 
     mainThreadWillEnqueueTask();

--- a/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
+++ b/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
@@ -134,7 +134,7 @@ TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionFailureDu
 }
 
 /**
- * Test that SetPosition returns failure if the gstreamer player is not initialized
+ * Test that SetPosition succeeds
  */
 TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionSuccess)
 {
@@ -143,6 +143,30 @@ TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionSuccess)
 
     EXPECT_CALL(*m_gstPlayerMock, setPosition(m_kPosition));
     EXPECT_TRUE(m_mediaPipeline->setPosition(m_kPosition));
+}
+
+/**
+ * Test that SetPosition resets the Eos flag on
+ */
+TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionResetEos)
+{
+    loadGstPlayer();
+    int videoSourceId = attachSource(firebolt::rialto::MediaSourceType::VIDEO, "video/h264");
+    int audioSourceId = attachSource(firebolt::rialto::MediaSourceType::AUDIO, "audio/x-opus");
+    setEos(firebolt::rialto::MediaSourceType::VIDEO);
+    setEos(firebolt::rialto::MediaSourceType::AUDIO);
+
+    mainThreadWillEnqueueTaskAndWait();
+
+    EXPECT_CALL(*m_gstPlayerMock, setPosition(m_kPosition));
+    EXPECT_TRUE(m_mediaPipeline->setPosition(m_kPosition));
+
+    // Expect need data notified to client
+    expectNotifyNeedData(firebolt::rialto::MediaSourceType::VIDEO, videoSourceId, 1);
+    m_gstPlayerCallback->notifyNeedMediaData(firebolt::rialto::MediaSourceType::VIDEO);
+
+    expectNotifyNeedData(firebolt::rialto::MediaSourceType::AUDIO, audioSourceId, 1);
+    m_gstPlayerCallback->notifyNeedMediaData(firebolt::rialto::MediaSourceType::AUDIO);
 }
 
 /**

--- a/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
+++ b/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
@@ -146,7 +146,7 @@ TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionSuccess)
 }
 
 /**
- * Test that SetPosition resets the Eos flag on
+ * Test that SetPosition resets the Eos flag on success
  */
 TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionResetEos)
 {

--- a/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
+++ b/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
@@ -134,7 +134,7 @@ TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionFailureDu
 }
 
 /**
- * Test that SetPosition succeeds
+ * Test that SetPosition succeeds.
  */
 TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionSuccess)
 {

--- a/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
+++ b/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
@@ -94,7 +94,6 @@ void MediaPipelineTestBase::loadGstPlayer()
     ASSERT_NE(m_gstPlayerCallback, nullptr);
 }
 
-
 int MediaPipelineTestBase::attachSource(MediaSourceType sourceType, const std::string &mimeType)
 {
     std::unique_ptr<IMediaPipeline::MediaSource> mediaSource;
@@ -122,8 +121,7 @@ void MediaPipelineTestBase::setEos(MediaSourceType sourceType)
     IMediaPipeline::MediaSegmentVector dataVec;
     mainThreadWillEnqueueTaskAndWait();
     ASSERT_TRUE(m_activeRequestsMock);
-    EXPECT_CALL(*m_activeRequestsMock, getType(kNeedDataRequestId))
-        .WillOnce(Return(sourceType));
+    EXPECT_CALL(*m_activeRequestsMock, getType(kNeedDataRequestId)).WillOnce(Return(sourceType));
     EXPECT_CALL(*m_activeRequestsMock, getSegments(kNeedDataRequestId)).WillOnce(ReturnRef(dataVec));
     EXPECT_CALL(*m_activeRequestsMock, erase(kNeedDataRequestId));
     EXPECT_CALL(*m_gstPlayerMock, attachSamples(A<const IMediaPipeline::MediaSegmentVector &>()));

--- a/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
+++ b/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
@@ -34,8 +34,8 @@ MediaPipelineTestBase::MediaPipelineTestBase()
       m_activeRequestsMock{static_cast<StrictMock<ActiveRequestsMock> *>(m_activeRequests.get())},
       m_mainThreadFactoryMock{std::make_shared<StrictMock<MainThreadFactoryMock>>()},
       m_mainThreadMock{std::make_shared<StrictMock<MainThreadMock>>()},
-      m_timerFactoryMock{std::make_shared<StrictMock<TimerFactoryMock>>()}, m_timerMock{
-                                                                                std::make_unique<StrictMock<TimerMock>>()}
+      m_timerFactoryMock{std::make_shared<StrictMock<TimerFactoryMock>>()},
+      m_timerMock{std::make_unique<StrictMock<TimerMock>>()}, m_gstPlayerCallback{nullptr}
 {
 }
 

--- a/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
+++ b/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.cpp
@@ -87,8 +87,75 @@ void MediaPipelineTestBase::loadGstPlayer()
     mainThreadWillEnqueueTaskAndWait();
     mainThreadWillEnqueueTask();
     EXPECT_CALL(*m_gstPlayerFactoryMock, createGstGenericPlayer(_, _, _, _, _))
-        .WillOnce(Return(ByMove(std::move(m_gstPlayer))));
+        .WillOnce(DoAll(SaveArg<0>(&m_gstPlayerCallback), Return(ByMove(std::move(m_gstPlayer)))));
     EXPECT_CALL(*m_mediaPipelineClientMock, notifyNetworkState(NetworkState::BUFFERING));
 
     EXPECT_EQ(m_mediaPipeline->load(MediaType::MSE, "mime", "mse://1"), true);
+    ASSERT_NE(m_gstPlayerCallback, nullptr);
+}
+
+
+int MediaPipelineTestBase::attachSource(MediaSourceType sourceType, const std::string &mimeType)
+{
+    std::unique_ptr<IMediaPipeline::MediaSource> mediaSource;
+    if (MediaSourceType::AUDIO == sourceType)
+    {
+        mediaSource = std::make_unique<IMediaPipeline::MediaSourceAudio>(mimeType);
+    }
+    else
+    {
+        mediaSource = std::make_unique<IMediaPipeline::MediaSourceVideo>(mimeType);
+    }
+
+    mainThreadWillEnqueueTaskAndWait();
+    EXPECT_CALL(*m_gstPlayerMock, attachSource(Ref(mediaSource)));
+
+    EXPECT_EQ(m_mediaPipeline->attachSource(mediaSource), true);
+
+    return mediaSource->getId();
+}
+
+void MediaPipelineTestBase::setEos(MediaSourceType sourceType)
+{
+    const uint32_t kNeedDataRequestId{0};
+    auto status = firebolt::rialto::MediaSourceStatus::EOS;
+    IMediaPipeline::MediaSegmentVector dataVec;
+    mainThreadWillEnqueueTaskAndWait();
+    ASSERT_TRUE(m_activeRequestsMock);
+    EXPECT_CALL(*m_activeRequestsMock, getType(kNeedDataRequestId))
+        .WillOnce(Return(sourceType));
+    EXPECT_CALL(*m_activeRequestsMock, getSegments(kNeedDataRequestId)).WillOnce(ReturnRef(dataVec));
+    EXPECT_CALL(*m_activeRequestsMock, erase(kNeedDataRequestId));
+    EXPECT_CALL(*m_gstPlayerMock, attachSamples(A<const IMediaPipeline::MediaSegmentVector &>()));
+    EXPECT_CALL(*m_gstPlayerMock, setEos(sourceType));
+    EXPECT_TRUE(m_mediaPipeline->haveData(status, kNeedDataRequestId));
+}
+
+void MediaPipelineTestBase::expectNotifyNeedData(MediaSourceType sourceType, int sourceId, int numFrames)
+{
+    mainThreadWillEnqueueTaskAndWait();
+    ASSERT_TRUE(m_sharedMemoryBufferMock);
+    ASSERT_TRUE(m_activeRequestsMock);
+    EXPECT_CALL(*m_sharedMemoryBufferMock,
+                clearData(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, sourceType))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_sharedMemoryBufferMock,
+                getMaxDataLen(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, sourceType))
+        .WillOnce(Return(7 * 1024 * 1024));
+    EXPECT_CALL(*m_sharedMemoryBufferMock,
+                getDataOffset(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, sourceType))
+        .WillOnce(Return(0));
+    EXPECT_CALL(*m_activeRequestsMock, insert(sourceType, _)).WillOnce(Return(0));
+    EXPECT_CALL(*m_mediaPipelineClientMock,
+                notifyNeedMediaData(sourceId, numFrames, 0, _)); // params tested in NeedMediaDataTests
+}
+
+void MediaPipelineTestBase::expectNotifyNeedDataEos(MediaSourceType sourceType)
+{
+    mainThreadWillEnqueueTaskAndWait();
+    ASSERT_TRUE(m_sharedMemoryBufferMock);
+    ASSERT_TRUE(m_activeRequestsMock);
+    EXPECT_CALL(*m_sharedMemoryBufferMock,
+                clearData(ISharedMemoryBuffer::MediaPlaybackType::GENERIC, m_kSessionId, sourceType))
+        .WillOnce(Return(true));
 }

--- a/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.h
+++ b/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.h
@@ -37,21 +37,22 @@
 #include "TimerMock.h"
 #include <gtest/gtest.h>
 #include <memory>
+#include <string>
 
 using namespace firebolt::rialto;
 using namespace firebolt::rialto::server;
 using namespace firebolt::rialto::server::mock;
 
 using ::testing::_;
-using ::testing::Invoke;
-using ::testing::Return;
-using ::testing::StrictMock;
-using ::testing::ReturnRef;
 using ::testing::A;
-using ::testing::Ref;
-using ::testing::DoAll;
 using ::testing::ByMove;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Ref;
+using ::testing::Return;
+using ::testing::ReturnRef;
 using ::testing::SaveArg;
+using ::testing::StrictMock;
 
 namespace
 {

--- a/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.h
+++ b/tests/media/server/main/mediaPipeline/base/MediaPipelineTestBase.h
@@ -46,6 +46,12 @@ using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrictMock;
+using ::testing::ReturnRef;
+using ::testing::A;
+using ::testing::Ref;
+using ::testing::DoAll;
+using ::testing::ByMove;
+using ::testing::SaveArg;
 
 namespace
 {
@@ -77,6 +83,7 @@ protected:
     std::shared_ptr<StrictMock<TimerFactoryMock>> m_timerFactoryMock;
     std::unique_ptr<StrictMock<TimerMock>> m_timerMock;
     StrictMock<DecryptionServiceMock> m_decryptionServiceMock;
+    IGstGenericPlayerClient *m_gstPlayerCallback;
 
     // Common variables
     const int m_kSessionId{1};
@@ -88,6 +95,10 @@ protected:
     void mainThreadWillEnqueueTask();
     void mainThreadWillEnqueueTaskAndWait();
     void loadGstPlayer();
+    int attachSource(MediaSourceType sourceType, const std::string &mimeType);
+    void setEos(MediaSourceType sourceType);
+    void expectNotifyNeedData(MediaSourceType sourceType, int sourceId, int numFrames);
+    void expectNotifyNeedDataEos(MediaSourceType sourceType);
 };
 
 #endif // MEDIA_PIPELINE_TEST_BASE_H_


### PR DESCRIPTION
Summary: Avoid sending unneeded need datas when an EOS has been received & detatch IPC when there is a failure to create objects over IPC.
Type: Bugfix
Test Plan: Unittests, NPLB, Youtube Cert Tests
Jira: RIALTO-118 & RIALTO-123