### PR TITLE
Add video mp4 mimetype to rialto

### DIFF
--- a/media/server/gstplayer/include/GstCapabilities.h
+++ b/media/server/gstplayer/include/GstCapabilities.h
@@ -109,13 +109,6 @@ private:
     bool isCapsInVector(const std::vector<GstCaps *> &capsVector, GstCaps *caps) const;
 
     /**
-     * @brief Maps vector of supported caps to set of mime types
-     *
-     * @retval Mime types
-     */
-    std::unordered_set<std::string> convertFromCapsVectorToMimeSet(std::vector<GstCaps *> &supportedCaps);
-
-    /**
      * @brief Set of mime types which are supported by gstreamer
      */
     std::unordered_set<std::string> m_supportedMimeTypes;

--- a/media/server/gstplayer/include/GstMimeMapping.h
+++ b/media/server/gstplayer/include/GstMimeMapping.h
@@ -48,7 +48,7 @@ inline GstCaps *createSimpleCapsFromMimeType(std::shared_ptr<IGstWrapper> m_gstW
 {
     static const std::unordered_map<std::string, std::string> mimeToMediaType =
         {{"video/h264", "video/x-h264"},   {"video/h265", "video/x-h265"},  {"video/x-av1", "video/x-av1"},
-         {"video/x-vp9", "video/x-vp9"},   {"audio/mp4", "audio/mpeg"},     {"audio/aac", "audio/mpeg"},
+         {"video/x-vp9", "video/x-vp9"},  {"video/mp4", "video/mpeg"},  {"audio/mp4", "audio/mpeg"},     {"audio/aac", "audio/mpeg"},
          {"audio/x-eac3", "audio/x-eac3"}, {"audio/x-opus", "audio/x-opus"}};
 
     auto mimeToMediaTypeIt = mimeToMediaType.find(m_attachedSource.getMimeType());
@@ -81,6 +81,7 @@ inline std::unordered_set<std::string> convertFromCapsVectorToMimeSet(const std:
          {m_gstWrapper->gstCapsFromString("video/x-h264"), {"video/h264"}},
          {m_gstWrapper->gstCapsFromString("video/x-h265"), {"video/h265"}},
          {m_gstWrapper->gstCapsFromString("video/x-vp9"), {"video/x-vp9"}},
+         {m_gstWrapper->gstCapsFromString("video/mpeg, mpegversion=(int)4"), {"video/mp4"}},
          {m_gstWrapper->gstCapsFromString("video/x-h264(memory:DMABuf)"), {"video/h264"}},
          {m_gstWrapper->gstCapsFromString("video/x-h265(memory:DMABuf)"), {"video/h265"}},
          {m_gstWrapper->gstCapsFromString("video/x-av1(memory:DMABuf)"), {"video/x-av1"}},

--- a/media/server/gstplayer/include/GstMimeMapping.h
+++ b/media/server/gstplayer/include/GstMimeMapping.h
@@ -76,7 +76,6 @@ inline std::unordered_set<std::string> convertFromCapsVectorToMimeSet(const std:
         {{m_gstWrapper->gstCapsFromString("audio/mpeg, mpegversion=(int)4"), {"audio/mp4", "audio/aac", "audio/x-eac3"}},
          {m_gstWrapper->gstCapsFromString("audio/x-eac3"), {"audio/x-eac3"}},
          {m_gstWrapper->gstCapsFromString("audio/x-opus"), {"audio/x-opus"}},
-         {m_gstWrapper->gstCapsFromString("audio/x-opus, channel-mapping-family=(int)0"), {"audio/x-opus"}},
          {m_gstWrapper->gstCapsFromString("video/x-av1"), {"video/x-av1"}},
          {m_gstWrapper->gstCapsFromString("video/x-h264"), {"video/h264"}},
          {m_gstWrapper->gstCapsFromString("video/x-h265"), {"video/h265"}},
@@ -93,7 +92,7 @@ inline std::unordered_set<std::string> convertFromCapsVectorToMimeSet(const std:
     {
         for (const auto &capsToMime : capsToMimeVec)
         {
-            if (m_gstWrapper->gstCapsIsSubset(capsToMime.first, caps))
+            if (m_gstWrapper->gstCapsCanIntersect(capsToMime.first, caps))
             {
                 supportedMimes.insert(capsToMime.second.begin(), capsToMime.second.end());
             }

--- a/media/server/gstplayer/include/GstMimeMapping.h
+++ b/media/server/gstplayer/include/GstMimeMapping.h
@@ -47,9 +47,9 @@ inline GstCaps *createSimpleCapsFromMimeType(std::shared_ptr<IGstWrapper> m_gstW
                                              const IMediaPipeline::MediaSource &m_attachedSource)
 {
     static const std::unordered_map<std::string, std::string> mimeToMediaType =
-        {{"video/h264", "video/x-h264"},   {"video/h265", "video/x-h265"},  {"video/x-av1", "video/x-av1"},
-         {"video/x-vp9", "video/x-vp9"},  {"video/mp4", "video/mpeg"},  {"audio/mp4", "audio/mpeg"},     {"audio/aac", "audio/mpeg"},
-         {"audio/x-eac3", "audio/x-eac3"}, {"audio/x-opus", "audio/x-opus"}};
+        {{"video/h264", "video/x-h264"}, {"video/h265", "video/x-h265"},   {"video/x-av1", "video/x-av1"},
+         {"video/x-vp9", "video/x-vp9"}, {"video/mp4", "video/mpeg"},      {"audio/mp4", "audio/mpeg"},
+         {"audio/aac", "audio/mpeg"},    {"audio/x-eac3", "audio/x-eac3"}, {"audio/x-opus", "audio/x-opus"}};
 
     auto mimeToMediaTypeIt = mimeToMediaType.find(m_attachedSource.getMimeType());
     if (mimeToMediaTypeIt != mimeToMediaType.end())

--- a/tests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
@@ -316,7 +316,8 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecoderWithOneSinkPad_Parse
     EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
     EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
         .WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/mpeg, mpegversion=(int)4"], &decoderPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock,
+                gstCapsCanIntersect(&m_capsMap["video/mpeg, mpegversion=(int)4"], &decoderPadTemplateCapsSink))
         .WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);

--- a/tests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
@@ -56,11 +56,11 @@ public:
         : m_capsMap{{"audio/mpeg, mpegversion=(int)4", {}},
                     {"audio/x-eac3", {}},
                     {"audio/x-opus", {}},
-                    {"audio/x-opus, channel-mapping-family=(int)0", {}},
                     {"video/x-av1", {}},
                     {"video/x-h264", {}},
                     {"video/x-h265", {}},
                     {"video/x-vp9", {}},
+                    {"video/mpeg, mpegversion=(int)4", {}},
                     {"video/x-h264(memory:DMABuf)", {}},
                     {"video/x-h265(memory:DMABuf)", {}},
                     {"video/x-av1(memory:DMABuf)", {}},
@@ -176,10 +176,10 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OnlyOneDecoderWithTwoSinkPadsA
         .WillOnce(Return(nullptr));
 
     expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["audio/mpeg, mpegversion=(int)4"], &padTemplateCaps1))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["audio/mpeg, mpegversion=(int)4"], &padTemplateCaps1))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["audio/x-opus"], &padTemplateCaps2)).WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["audio/x-opus"], &padTemplateCaps2)).WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
 
@@ -216,8 +216,8 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OnlyOneDecoderWithTwoPadsWithT
         .WillOnce(Return(nullptr));
 
     expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["audio/mpeg, mpegversion=(int)4"], &padTemplateCaps1))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["audio/mpeg, mpegversion=(int)4"], &padTemplateCaps1))
         .WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
@@ -261,18 +261,17 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecoderWithOneSinkPad_Parse
     expectGetStaticPadTemplates(parserFactory, parserPadTemplates.get());
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc, &parserPadTemplateCapsSrc);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
-        .WillOnce(Return(true));
-
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSink, &parserPadTemplateCapsSink);
     EXPECT_CALL(*m_gstWrapperMock, gstCapsIsStrictlyEqual(&parserPadTemplateCapsSink, &decoderPadTemplateCapsSink))
         .WillOnce(Return(false));
 
     expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
         .WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
@@ -313,19 +312,18 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecoderWithOneSinkPad_Parse
     expectGetStaticPadTemplates(parserFactory, parserPadTemplates.get());
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc, &parserPadTemplateCapsSrc);
 
+    expectCapsToMimeMapping();
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
     EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
         .WillOnce(Return(false));
-
-    expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/mpeg, mpegversion=(int)4"], &decoderPadTemplateCapsSink))
         .WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
 
-    EXPECT_THAT(m_sut->getSupportedMimeTypes(MediaSourceType::VIDEO), UnorderedElementsAre("video/h264"));
+    EXPECT_THAT(m_sut->getSupportedMimeTypes(MediaSourceType::VIDEO), UnorderedElementsAre("video/mp4"));
 
-    EXPECT_TRUE(m_sut->isMimeTypeSupported("video/h264"));
+    EXPECT_TRUE(m_sut->isMimeTypeSupported("video/mp4"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("video/h265"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("audio/x-opus"));
 }
@@ -362,18 +360,17 @@ TEST_F(GstCapabilitiesTest,
     expectGetStaticPadTemplates(parserFactory, parserPadTemplates.get());
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc, &parserPadTemplateCapsSrc);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
-        .WillOnce(Return(true));
-
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSink, &parserPadTemplateCapsSink);
     EXPECT_CALL(*m_gstWrapperMock, gstCapsIsStrictlyEqual(&parserPadTemplateCapsSink, &decoderPadTemplateCapsSink))
         .WillOnce(Return(false));
 
     expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
         .WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
         .WillOnce(Return(false));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
@@ -426,11 +423,6 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_TwoDecodersWithOneSinkPad_Pars
     expectGetStaticPadTemplates(parserFactory, parserPadTemplates.get(), 2);
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc, &parserPadTemplateCapsSrc, 2);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
-        .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink2, &parserPadTemplateCapsSrc))
-        .WillOnce(Return(false));
-
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSink, &parserPadTemplateCapsSink);
     EXPECT_CALL(*m_gstWrapperMock, gstCapsIsStrictlyEqual(&parserPadTemplateCapsSink, &decoderPadTemplateCapsSink))
         .WillOnce(Return(false));
@@ -438,10 +430,14 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_TwoDecodersWithOneSinkPad_Pars
         .WillOnce(Return(true));
 
     expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h265"], &decoderPadTemplateCapsSink2))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink2, &parserPadTemplateCapsSrc))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h265"], &decoderPadTemplateCapsSink2))
         .WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
@@ -490,20 +486,19 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecodersWithOneSinkPad_Pars
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc, &parserPadTemplateCapsSrc);
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc2, &parserPadTemplateCapsSrc2);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
-        .WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc2))
-        .WillOnce(Return(true));
-
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSink, &parserPadTemplateCapsSink);
     EXPECT_CALL(*m_gstWrapperMock, gstCapsIsStrictlyEqual(&parserPadTemplateCapsSink, &decoderPadTemplateCapsSink))
         .WillOnce(Return(false));
 
     expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc2))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
         .WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
@@ -558,11 +553,6 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecodersWithOneSinkPads_Two
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc, &parserPadTemplateCapsSrc);
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSrc2, &parserPadTemplateCapsSrc2);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
-        .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc2))
-        .WillOnce(Return(true));
-
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSink, &parserPadTemplateCapsSink);
     expectGetStaticCapsAndCapsUnref(parserPadTemplateSink2, &parserPadTemplateCapsSink2);
 
@@ -574,12 +564,16 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecodersWithOneSinkPads_Two
         .WillOnce(Return(false));
 
     expectCapsToMimeMapping();
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(_, _)).WillRepeatedly(Return(false));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(_, _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&decoderPadTemplateCapsSink, &parserPadTemplateCapsSrc2))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsSubset(&m_capsMap["video/x-av1"], &parserPadTemplateCapsSink2))
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h264"], &decoderPadTemplateCapsSink))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-h265"], &parserPadTemplateCapsSink))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["video/x-av1"], &parserPadTemplateCapsSink2))
         .WillOnce(Return(true));
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock);
@@ -589,6 +583,7 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecodersWithOneSinkPads_Two
 
     EXPECT_TRUE(m_sut->isMimeTypeSupported("video/h264"));
     EXPECT_TRUE(m_sut->isMimeTypeSupported("video/x-av1"));
+    EXPECT_FALSE(m_sut->isMimeTypeSupported("video/mp4"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("video/x-vp9"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("audio/x-opus"));
 }


### PR DESCRIPTION
Summary: Add support for mp4 codec in Rialto.
Type: Feature
Test Plan: Unittests
Jira: RIALTO-181