### PR TITLE
Disable deprecated-declarations for gstreamer

### DIFF
--- a/media/server/gstplayer/CMakeLists.txt
+++ b/media/server/gstplayer/CMakeLists.txt
@@ -20,6 +20,10 @@
 # Find includes in corresponding build directories
 set( CMAKE_INCLUDE_CURRENT_DIR ON )
 
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 find_package( PkgConfig REQUIRED )
 pkg_check_modules( GStreamerApp REQUIRED IMPORTED_TARGET gstreamer-app-1.0 gstreamer-pbutils-1.0 gstreamer-audio-1.0)
 

--- a/media/server/gstplayer/CMakeLists.txt
+++ b/media/server/gstplayer/CMakeLists.txt
@@ -20,6 +20,8 @@
 # Find includes in corresponding build directories
 set( CMAKE_INCLUDE_CURRENT_DIR ON )
 
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
 add_compile_options(
   "-Wno-deprecated-declarations"
 )


### PR DESCRIPTION
Summary: Disable deprecated-declarations for gstplayer when compiling rialto to avoid compilation errors.
Type: BugFix
Test Plan: rialto build
Jira: RIALTO-197