### PR TITLE
Reapply reset ipc channel on disconnect

### DIFF
--- a/build_ut.py
+++ b/build_ut.py
@@ -89,7 +89,7 @@ def main ():
                              + "Output written to xml if -xml option specified '*suite_name*_" + valgrindOutput + ".xml' \n" \
                              + "Note: Valgrind can only write output to one source (log or xml). \n" \
                              + "Note: Requires version valgrind 3.17.0+ installed. \n")
-    argParser.add_argument("-cov", "--coverage", action='store_true', help="Generates UT coverage report")  
+    argParser.add_argument("-cov", "--coverage", action='store_true', help="Generates UT coverage report")
     args = vars(argParser.parse_args())
 
     # Set env variable
@@ -165,7 +165,7 @@ def buildTargets (suites, outputDir, resultsFile, debug, coverage):
     if coverage:
         cmakeCmd.append("-DCOVERAGE_ENABLED=1")
     runcmd(cmakeCmd, cwd=os.getcwd())
-    
+
     # Make targets
     jarg = "-j" + str(multiprocessing.cpu_count())
     makeCmd = ["make", jarg]

--- a/media/client/ipc/include/ControlIpc.h
+++ b/media/client/ipc/include/ControlIpc.h
@@ -72,8 +72,8 @@ public:
     bool registerClient() override;
 
 private:
-    bool createRpcStubs() override;
-    bool subscribeToEvents() override;
+    bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
+    bool subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
     /**
      * @brief Handler for a application state update from the server.

--- a/media/client/ipc/include/IIpcClient.h
+++ b/media/client/ipc/include/IIpcClient.h
@@ -80,11 +80,11 @@ public:
     IIpcClient &operator=(IIpcClient &&) = delete;
 
     /**
-     * @brief Gets the Ipc channel created by the IpcClient.
+     * @brief Gets a weak ptr to the Ipc channel created by the IpcClient.
      *
-     * @retval the ipc channel or null if ipc not connected.
+     * @retval the ipc channel weak ptr.
      */
-    virtual std::shared_ptr<ipc::IChannel> getChannel() const = 0;
+    virtual std::weak_ptr<ipc::IChannel> getChannel() const = 0;
 
     /**
      * @brief Create the blocking closure to be passed to the RPC stubs.

--- a/media/client/ipc/include/IpcClient.h
+++ b/media/client/ipc/include/IpcClient.h
@@ -21,6 +21,7 @@
 #define FIREBOLT_RIALTO_CLIENT_IPC_CLIENT_H_
 
 #include "IIpcClient.h"
+#include <atomic>
 #include <memory>
 #include <mutex>
 
@@ -51,7 +52,7 @@ public:
      */
     ~IpcClient() override;
 
-    std::shared_ptr<ipc::IChannel> getChannel() const override;
+    std::weak_ptr<ipc::IChannel> getChannel() const override;
 
     std::shared_ptr<ipc::IBlockingClosure> createBlockingClosure() override;
 
@@ -82,6 +83,11 @@ protected:
      * @brief Factory for creating a blocking closure.
      */
     std::shared_ptr<ipc::IBlockingClosureFactory> m_blockingClosureFactory;
+
+    /**
+     * @brief Whether disconnection of ipc has been requested by the client and is ongoing.
+     */
+    std::atomic<bool> m_disconnecting;
 
     /**
      * @brief The processing loop for the ipc thread.

--- a/media/client/ipc/include/IpcModule.h
+++ b/media/client/ipc/include/IpcModule.h
@@ -58,7 +58,7 @@ protected:
     /**
      * @brief The ipc communication channel.
      */
-    std::shared_ptr<ipc::IChannel> m_ipcChannel;
+    std::weak_ptr<ipc::IChannel> m_ipcChannel;
 
     /**
      * @brief Subscribed event tags.
@@ -68,23 +68,29 @@ protected:
     /**
      * @brief Create the Rpc stubs for the derived object.
      *
+     * @param[in] ipcChannel      : The ipc channel
+     *
      * @retval true if the rpc stubs are created successfully, false otherwise.
      */
-    virtual bool createRpcStubs() = 0;
+    virtual bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) = 0;
 
     /**
      * @brief Subscribes to the Ipc events for the derived object.
      *
+     * @param[in] ipcChannel      : The ipc channel
+     *
      * @retval true if the events are subscribed successfully, false otherwise.
      */
-    virtual bool subscribeToEvents() = 0;
+    virtual bool subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel) = 0;
 
     /**
      * @brief Unsubscribes to all Ipc events.
      *
+     * @param[in] ipcChannel      : The ipc channel
+     *
      * @retval true if the events are unsubscribed successfully, false otherwise.
      */
-    bool unsubscribeFromAllEvents();
+    bool unsubscribeFromAllEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel);
 
     /**
      * @brief Attach the connected ipc client channel to the MediaKeysIpc object.

--- a/media/client/ipc/include/MediaKeysCapabilitiesIpc.h
+++ b/media/client/ipc/include/MediaKeysCapabilitiesIpc.h
@@ -84,9 +84,9 @@ private:
      */
     std::unique_ptr<::firebolt::rialto::MediaKeysCapabilitiesModule_Stub> m_mediaKeysCapabilitiesStub;
 
-    bool createRpcStubs() override;
+    bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
-    bool subscribeToEvents() override { return true; }
+    bool subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel) override { return true; }
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/include/MediaKeysIpc.h
+++ b/media/client/ipc/include/MediaKeysIpc.h
@@ -122,9 +122,9 @@ private:
      */
     std::weak_ptr<IMediaKeysClient> m_mediaKeysIpcClient;
 
-    bool createRpcStubs() override;
+    bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
-    bool subscribeToEvents() override;
+    bool subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
     /**
      * @brief Handler for a license request from the server.

--- a/media/client/ipc/include/MediaPipelineCapabilitiesIpc.h
+++ b/media/client/ipc/include/MediaPipelineCapabilitiesIpc.h
@@ -87,9 +87,9 @@ private:
      */
     std::unique_ptr<::firebolt::rialto::MediaPipelineCapabilitiesModule_Stub> m_mediaPipelineCapabilitiesStub;
 
-    bool createRpcStubs() override;
+    bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
-    bool subscribeToEvents() override { return true; }
+    bool subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel) override { return true; }
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/include/MediaPipelineIpc.h
+++ b/media/client/ipc/include/MediaPipelineIpc.h
@@ -119,9 +119,9 @@ private:
      */
     std::unique_ptr<common::IEventThread> m_eventThread;
 
-    bool createRpcStubs() override;
+    bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
-    bool subscribeToEvents() override;
+    bool subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
     /**
      * @brief Handler for a playback state update from the server.

--- a/media/client/ipc/include/WebAudioPlayerIpc.h
+++ b/media/client/ipc/include/WebAudioPlayerIpc.h
@@ -87,9 +87,9 @@ private:
 
     void destroyWebAudioPlayer();
 
-    bool createRpcStubs() override;
+    bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
-    bool subscribeToEvents() override;
+    bool subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
 
     void onPlaybackStateUpdated(const std::shared_ptr<firebolt::rialto::WebAudioPlayerStateEvent> &event);
     /**

--- a/media/client/ipc/source/ControlIpc.cpp
+++ b/media/client/ipc/source/ControlIpc.cpp
@@ -151,9 +151,9 @@ bool ControlIpc::registerClient()
     return true;
 }
 
-bool ControlIpc::createRpcStubs()
+bool ControlIpc::createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    m_controlStub = std::make_unique<::firebolt::rialto::ControlModule_Stub>(m_ipcChannel.get());
+    m_controlStub = std::make_unique<::firebolt::rialto::ControlModule_Stub>(ipcChannel.get());
     if (!m_controlStub)
     {
         return false;
@@ -161,21 +161,21 @@ bool ControlIpc::createRpcStubs()
     return true;
 }
 
-bool ControlIpc::subscribeToEvents()
+bool ControlIpc::subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    if (!m_ipcChannel)
+    if (!ipcChannel)
     {
         return false;
     }
 
-    int eventTag = m_ipcChannel->subscribe<firebolt::rialto::ApplicationStateChangeEvent>(
+    int eventTag = ipcChannel->subscribe<firebolt::rialto::ApplicationStateChangeEvent>(
         [this](const std::shared_ptr<firebolt::rialto::ApplicationStateChangeEvent> &event)
         { m_eventThread->add(&ControlIpc::onApplicationStateUpdated, this, event); });
     if (eventTag < 0)
         return false;
     m_eventTags.push_back(eventTag);
 
-    eventTag = m_ipcChannel->subscribe<firebolt::rialto::PingEvent>(
+    eventTag = ipcChannel->subscribe<firebolt::rialto::PingEvent>(
         [this](const std::shared_ptr<firebolt::rialto::PingEvent> &event)
         { m_eventThread->add(&ControlIpc::onPing, this, event); });
     if (eventTag < 0)

--- a/media/client/ipc/source/IpcClient.cpp
+++ b/media/client/ipc/source/IpcClient.cpp
@@ -39,7 +39,7 @@ IpcClient::IpcClient(const std::shared_ptr<ipc::IChannelFactory> &ipcChannelFact
                      const std::shared_ptr<ipc::IControllerFactory> &ipcControllerFactory,
                      const std::shared_ptr<ipc::IBlockingClosureFactory> &blockingClosureFactory)
     : m_ipcControllerFactory(ipcControllerFactory), m_ipcChannelFactory(ipcChannelFactory),
-      m_blockingClosureFactory(blockingClosureFactory)
+      m_blockingClosureFactory(blockingClosureFactory), m_disconnecting(false)
 {
     // For now, always connect the client on construction
     if (!connect())
@@ -115,22 +115,31 @@ bool IpcClient::connect()
 
 bool IpcClient::disconnect()
 {
-    if (!m_ipcChannel)
+    // Increase reference in case client disconnects from another thread
+    std::shared_ptr<ipc::IChannel> ipcChannel = m_ipcChannel;
+    if (!ipcChannel)
     {
+        // The ipc channel may have disconnected unexpectedly, join the ipc thread if possible
+        if (m_ipcThread.joinable())
+            m_ipcThread.join();
+
         RIALTO_CLIENT_LOG_INFO("Client already disconnect");
         return true;
     }
 
     RIALTO_CLIENT_LOG_INFO("closing IPC channel");
+    m_disconnecting = true;
+
     // disconnect from the server, this should terminate the thread so join that too
-    if (m_ipcChannel)
-        m_ipcChannel->disconnect();
+    ipcChannel->disconnect();
 
     if (m_ipcThread.joinable())
         m_ipcThread.join();
 
     // destroy the IPC channel
     m_ipcChannel.reset();
+
+    m_disconnecting = false;
 
     return true;
 }
@@ -146,17 +155,28 @@ void IpcClient::processIpcThread()
         m_ipcChannel->wait(-1);
     }
 
+    if (!m_disconnecting)
+    {
+        RIALTO_CLIENT_LOG_ERROR("The ipc channel unexpectedly disconnected, destroying the channel");
+
+        // Safe to destroy the ipc objects in the ipc thread as the client has already disconnected.
+        // This ensures the channel is destructed and that all ongoing ipc calls are unblocked.
+        m_ipcChannel.reset();
+    }
+
     RIALTO_CLIENT_LOG_INFO("exiting ipc thread");
 }
 
-std::shared_ptr<::firebolt::rialto::ipc::IChannel> IpcClient::getChannel() const
+std::weak_ptr<::firebolt::rialto::ipc::IChannel> IpcClient::getChannel() const
 {
     return m_ipcChannel;
 }
 
 std::shared_ptr<ipc::IBlockingClosure> IpcClient::createBlockingClosure()
 {
-    if (!m_ipcChannel)
+    // Increase reference in case client disconnects from another thread
+    std::shared_ptr<ipc::IChannel> ipcChannel = m_ipcChannel;
+    if (!ipcChannel)
     {
         RIALTO_CLIENT_LOG_ERROR("ipc channel not connected");
         return nullptr;
@@ -165,7 +185,7 @@ std::shared_ptr<ipc::IBlockingClosure> IpcClient::createBlockingClosure()
     // check which thread we're being called from, this determines if we pump
     // event loop from within the wait() method or not
     if (m_ipcThread.get_id() == std::this_thread::get_id())
-        return m_blockingClosureFactory->createBlockingClosurePoll(m_ipcChannel);
+        return m_blockingClosureFactory->createBlockingClosurePoll(ipcChannel);
     else
         return m_blockingClosureFactory->createBlockingClosureSemaphore();
 }

--- a/media/client/ipc/source/IpcClient.cpp
+++ b/media/client/ipc/source/IpcClient.cpp
@@ -60,11 +60,10 @@ bool IpcClient::connect()
 {
     if (m_ipcChannel)
     {
-        RIALTO_CLIENT_LOG_ERROR("Client already connected");
+        RIALTO_CLIENT_LOG_INFO("Client already connected");
         return true;
     }
 
-    RIALTO_CLIENT_LOG_ERROR("Client connect");
     // Verify that the version of the library that we linked against is
     // compatible with the version of the headers we compiled against.
     GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -128,7 +127,7 @@ bool IpcClient::disconnect()
         return true;
     }
 
-    RIALTO_CLIENT_LOG_ERROR("closing IPC channel");
+    RIALTO_CLIENT_LOG_INFO("closing IPC channel");
     m_disconnecting = true;
 
     // disconnect from the server, this should terminate the thread so join that too
@@ -149,7 +148,7 @@ void IpcClient::processIpcThread()
 {
     pthread_setname_np(pthread_self(), "rialto-ipc");
 
-    RIALTO_CLIENT_LOG_ERROR("started ipc thread");
+    RIALTO_CLIENT_LOG_INFO("started ipc thread");
 
     while (m_ipcChannel->process())
     {
@@ -165,7 +164,7 @@ void IpcClient::processIpcThread()
         m_ipcChannel.reset();
     }
 
-    RIALTO_CLIENT_LOG_ERROR("exiting ipc thread");
+    RIALTO_CLIENT_LOG_INFO("exiting ipc thread");
 }
 
 std::weak_ptr<::firebolt::rialto::ipc::IChannel> IpcClient::getChannel() const

--- a/media/client/ipc/source/IpcClient.cpp
+++ b/media/client/ipc/source/IpcClient.cpp
@@ -60,10 +60,11 @@ bool IpcClient::connect()
 {
     if (m_ipcChannel)
     {
-        RIALTO_CLIENT_LOG_INFO("Client already connected");
+        RIALTO_CLIENT_LOG_ERROR("Client already connected");
         return true;
     }
 
+    RIALTO_CLIENT_LOG_ERROR("Client connect");
     // Verify that the version of the library that we linked against is
     // compatible with the version of the headers we compiled against.
     GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -127,7 +128,7 @@ bool IpcClient::disconnect()
         return true;
     }
 
-    RIALTO_CLIENT_LOG_INFO("closing IPC channel");
+    RIALTO_CLIENT_LOG_ERROR("closing IPC channel");
     m_disconnecting = true;
 
     // disconnect from the server, this should terminate the thread so join that too
@@ -148,7 +149,7 @@ void IpcClient::processIpcThread()
 {
     pthread_setname_np(pthread_self(), "rialto-ipc");
 
-    RIALTO_CLIENT_LOG_INFO("started ipc thread");
+    RIALTO_CLIENT_LOG_ERROR("started ipc thread");
 
     while (m_ipcChannel->process())
     {
@@ -164,7 +165,7 @@ void IpcClient::processIpcThread()
         m_ipcChannel.reset();
     }
 
-    RIALTO_CLIENT_LOG_INFO("exiting ipc thread");
+    RIALTO_CLIENT_LOG_ERROR("exiting ipc thread");
 }
 
 std::weak_ptr<::firebolt::rialto::ipc::IChannel> IpcClient::getChannel() const

--- a/media/client/ipc/source/MediaKeysCapabilitiesIpc.cpp
+++ b/media/client/ipc/source/MediaKeysCapabilitiesIpc.cpp
@@ -83,10 +83,10 @@ MediaKeysCapabilitiesIpc::~MediaKeysCapabilitiesIpc()
     detachChannel();
 }
 
-bool MediaKeysCapabilitiesIpc::createRpcStubs()
+bool MediaKeysCapabilitiesIpc::createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
     m_mediaKeysCapabilitiesStub =
-        std::make_unique<::firebolt::rialto::MediaKeysCapabilitiesModule_Stub>(m_ipcChannel.get());
+        std::make_unique<::firebolt::rialto::MediaKeysCapabilitiesModule_Stub>(ipcChannel.get());
     if (!m_mediaKeysCapabilitiesStub)
     {
         return false;

--- a/media/client/ipc/source/MediaKeysIpc.cpp
+++ b/media/client/ipc/source/MediaKeysIpc.cpp
@@ -176,9 +176,9 @@ MediaKeysIpc::~MediaKeysIpc()
     m_eventThread.reset();
 }
 
-bool MediaKeysIpc::createRpcStubs()
+bool MediaKeysIpc::createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    m_mediaKeysStub = std::make_unique<::firebolt::rialto::MediaKeysModule_Stub>(m_ipcChannel.get());
+    m_mediaKeysStub = std::make_unique<::firebolt::rialto::MediaKeysModule_Stub>(ipcChannel.get());
     if (!m_mediaKeysStub)
     {
         return false;
@@ -186,28 +186,28 @@ bool MediaKeysIpc::createRpcStubs()
     return true;
 }
 
-bool MediaKeysIpc::subscribeToEvents()
+bool MediaKeysIpc::subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    if (!m_ipcChannel)
+    if (!ipcChannel)
     {
         return false;
     }
 
-    int eventTag = m_ipcChannel->subscribe<firebolt::rialto::LicenseRequestEvent>(
+    int eventTag = ipcChannel->subscribe<firebolt::rialto::LicenseRequestEvent>(
         [this](const std::shared_ptr<firebolt::rialto::LicenseRequestEvent> &event)
         { m_eventThread->add(&MediaKeysIpc::onLicenseRequest, this, event); });
     if (eventTag < 0)
         return false;
     m_eventTags.push_back(eventTag);
 
-    eventTag = m_ipcChannel->subscribe<firebolt::rialto::LicenseRenewalEvent>(
+    eventTag = ipcChannel->subscribe<firebolt::rialto::LicenseRenewalEvent>(
         [this](const std::shared_ptr<firebolt::rialto::LicenseRenewalEvent> &event)
         { m_eventThread->add(&MediaKeysIpc::onLicenseRenewal, this, event); });
     if (eventTag < 0)
         return false;
     m_eventTags.push_back(eventTag);
 
-    eventTag = m_ipcChannel->subscribe<firebolt::rialto::KeyStatusesChangedEvent>(
+    eventTag = ipcChannel->subscribe<firebolt::rialto::KeyStatusesChangedEvent>(
         [this](const std::shared_ptr<firebolt::rialto::KeyStatusesChangedEvent> &event)
         { m_eventThread->add(&MediaKeysIpc::onKeyStatusesChanged, this, event); });
     if (eventTag < 0)

--- a/media/client/ipc/source/MediaPipelineCapabilitiesIpc.cpp
+++ b/media/client/ipc/source/MediaPipelineCapabilitiesIpc.cpp
@@ -73,10 +73,10 @@ MediaPipelineCapabilitiesIpc::~MediaPipelineCapabilitiesIpc()
     detachChannel();
 }
 
-bool MediaPipelineCapabilitiesIpc::createRpcStubs()
+bool MediaPipelineCapabilitiesIpc::createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
     m_mediaPipelineCapabilitiesStub =
-        std::make_unique<::firebolt::rialto::MediaPipelineCapabilitiesModule_Stub>(m_ipcChannel.get());
+        std::make_unique<::firebolt::rialto::MediaPipelineCapabilitiesModule_Stub>(ipcChannel.get());
     if (!m_mediaPipelineCapabilitiesStub)
     {
         return false;

--- a/media/client/ipc/source/MediaPipelineIpc.cpp
+++ b/media/client/ipc/source/MediaPipelineIpc.cpp
@@ -97,9 +97,9 @@ MediaPipelineIpc::~MediaPipelineIpc()
     m_eventThread.reset();
 }
 
-bool MediaPipelineIpc::createRpcStubs()
+bool MediaPipelineIpc::createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    m_mediaPipelineStub = std::make_unique<::firebolt::rialto::MediaPipelineModule_Stub>(m_ipcChannel.get());
+    m_mediaPipelineStub = std::make_unique<::firebolt::rialto::MediaPipelineModule_Stub>(ipcChannel.get());
     if (!m_mediaPipelineStub)
     {
         return false;
@@ -107,42 +107,42 @@ bool MediaPipelineIpc::createRpcStubs()
     return true;
 }
 
-bool MediaPipelineIpc::subscribeToEvents()
+bool MediaPipelineIpc::subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    if (!m_ipcChannel)
+    if (!ipcChannel)
     {
         return false;
     }
 
-    int eventTag = m_ipcChannel->subscribe<firebolt::rialto::PlaybackStateChangeEvent>(
+    int eventTag = ipcChannel->subscribe<firebolt::rialto::PlaybackStateChangeEvent>(
         [this](const std::shared_ptr<firebolt::rialto::PlaybackStateChangeEvent> &event)
         { m_eventThread->add(&MediaPipelineIpc::onPlaybackStateUpdated, this, event); });
     if (eventTag < 0)
         return false;
     m_eventTags.push_back(eventTag);
 
-    eventTag = m_ipcChannel->subscribe<firebolt::rialto::PositionChangeEvent>(
+    eventTag = ipcChannel->subscribe<firebolt::rialto::PositionChangeEvent>(
         [this](const std::shared_ptr<firebolt::rialto::PositionChangeEvent> &event)
         { m_eventThread->add(&MediaPipelineIpc::onPositionUpdated, this, event); });
     if (eventTag < 0)
         return false;
     m_eventTags.push_back(eventTag);
 
-    eventTag = m_ipcChannel->subscribe<firebolt::rialto::NetworkStateChangeEvent>(
+    eventTag = ipcChannel->subscribe<firebolt::rialto::NetworkStateChangeEvent>(
         [this](const std::shared_ptr<firebolt::rialto::NetworkStateChangeEvent> &event)
         { m_eventThread->add(&MediaPipelineIpc::onNetworkStateUpdated, this, event); });
     if (eventTag < 0)
         return false;
     m_eventTags.push_back(eventTag);
 
-    eventTag = m_ipcChannel->subscribe<firebolt::rialto::NeedMediaDataEvent>(
+    eventTag = ipcChannel->subscribe<firebolt::rialto::NeedMediaDataEvent>(
         [this](const std::shared_ptr<firebolt::rialto::NeedMediaDataEvent> &event)
         { m_eventThread->add(&MediaPipelineIpc::onNeedMediaData, this, event); });
     if (eventTag < 0)
         return false;
     m_eventTags.push_back(eventTag);
 
-    eventTag = m_ipcChannel->subscribe<firebolt::rialto::QosEvent>(
+    eventTag = ipcChannel->subscribe<firebolt::rialto::QosEvent>(
         [this](const std::shared_ptr<firebolt::rialto::QosEvent> &event)
         { m_eventThread->add(&MediaPipelineIpc::onQos, this, event); });
     if (eventTag < 0)

--- a/media/client/ipc/source/WebAudioPlayerIpc.cpp
+++ b/media/client/ipc/source/WebAudioPlayerIpc.cpp
@@ -92,9 +92,9 @@ WebAudioPlayerIpc::~WebAudioPlayerIpc()
     m_eventThread.reset();
 }
 
-bool WebAudioPlayerIpc::createRpcStubs()
+bool WebAudioPlayerIpc::createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    m_webAudioPlayerStub = std::make_unique<::firebolt::rialto::WebAudioPlayerModule_Stub>(m_ipcChannel.get());
+    m_webAudioPlayerStub = std::make_unique<::firebolt::rialto::WebAudioPlayerModule_Stub>(ipcChannel.get());
     if (!m_webAudioPlayerStub)
     {
         return false;
@@ -102,14 +102,14 @@ bool WebAudioPlayerIpc::createRpcStubs()
     return true;
 }
 
-bool WebAudioPlayerIpc::subscribeToEvents()
+bool WebAudioPlayerIpc::subscribeToEvents(const std::shared_ptr<ipc::IChannel> &ipcChannel)
 {
-    if (!m_ipcChannel)
+    if (!ipcChannel)
     {
         return false;
     }
 
-    int eventTag = m_ipcChannel->subscribe<firebolt::rialto::WebAudioPlayerStateEvent>(
+    int eventTag = ipcChannel->subscribe<firebolt::rialto::WebAudioPlayerStateEvent>(
         [this](const std::shared_ptr<firebolt::rialto::WebAudioPlayerStateEvent> &event)
         { m_eventThread->add(&WebAudioPlayerIpc::onPlaybackStateUpdated, this, event); });
     if (eventTag < 0)

--- a/media/public/include/IControlClient.h
+++ b/media/public/include/IControlClient.h
@@ -26,7 +26,7 @@
  * The definition of the IControlClient interface.
  *
  * This file comprises the definition of the IControlClient abstract
- * class. This is the API by which a IRialtoControl implementation will
+ * class. This is the API by which a IControl implementation will
  * pass notifications to its client.
  */
 

--- a/tests/media/client/ipc/controlIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/controlIpc/CreateTest.cpp
@@ -43,8 +43,8 @@ TEST_F(RialtoClientControlIpcCreateTest, CreateDestroy)
  */
 TEST_F(RialtoClientControlIpcCreateTest, CreateNoIpcChannel)
 {
+    expectInitIpcButAttachChannelFailure();
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
-    EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(nullptr));
 
     EXPECT_THROW(m_controlIpc =
                      std::make_shared<ControlIpc>(&m_controlClientMock, m_ipcClientMock, m_eventThreadFactoryMock),

--- a/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.cpp
+++ b/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.cpp
@@ -55,7 +55,7 @@ void IpcClientTestBase::createIpcClient()
 
 void IpcClientTestBase::expectIpcLoop()
 {
-    EXPECT_CALL(*m_channelMock, process()).InSequence(m_processSeq).WillOnce(Return(true));
+    EXPECT_CALL(*m_channelMock, process()).Times(2).WillOnce(Return(true)).WillOnce(Return(false));
     EXPECT_CALL(*m_channelMock, wait(_))
         .WillOnce(Invoke(
             [this](int timeoutMSecs)
@@ -88,7 +88,6 @@ void IpcClientTestBase::createRpcController()
 
 void IpcClientTestBase::disconnectIpcClient()
 {
-    EXPECT_CALL(*m_channelMock, process()).InSequence(m_processSeq).WillOnce(Return(false));
     EXPECT_CALL(*m_channelMock, disconnect())
         .WillOnce(Invoke(
             [this]()

--- a/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.cpp
+++ b/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.cpp
@@ -19,6 +19,7 @@
 
 #include "IpcClientTestBase.h"
 #include "IpcClient.h"
+#include <string>
 
 IpcClientTestBase::IpcClientTestBase()
     : m_channelFactoryMock{std::make_shared<StrictMock<ChannelFactoryMock>>()},
@@ -43,14 +44,27 @@ IpcClientTestBase::~IpcClientTestBase()
 
 void IpcClientTestBase::createIpcClient()
 {
-    EXPECT_CALL(*m_channelFactoryMock, createChannel(m_kRialtoPath)).WillOnce(Return(m_channelMock));
-    EXPECT_CALL(*m_channelMock, process()).Times(2).WillOnce(Return(true)).WillOnce(Return(false));
-    EXPECT_CALL(*m_channelMock, wait(-1)).WillOnce(Return(true));
+    expectCreateChannel();
+    expectIpcLoop();
 
     EXPECT_NO_THROW(m_sut = std::make_unique<IpcClient>(m_channelFactoryMock, m_controllerFactoryMock,
                                                         m_blockingClosureFactoryMock));
 
-    EXPECT_EQ(m_sut->getChannel(), m_channelMock);
+    EXPECT_EQ(m_sut->getChannel().lock(), m_channelMock);
+}
+
+void IpcClientTestBase::expectIpcLoop()
+{
+    EXPECT_CALL(*m_channelMock, process()).InSequence(m_processSeq).WillOnce(Return(true));
+    EXPECT_CALL(*m_channelMock, wait(_))
+        .WillOnce(Invoke(
+            [this](int timeoutMSecs)
+            {
+                std::unique_lock<std::mutex> locker(m_eventsLock);
+                if (!m_disconnected)
+                    m_eventsCond.wait(locker);
+                return true;
+            }));
 }
 
 void IpcClientTestBase::failToCreateIpcClient()
@@ -74,6 +88,26 @@ void IpcClientTestBase::createRpcController()
 
 void IpcClientTestBase::disconnectIpcClient()
 {
-    EXPECT_CALL(*m_channelMock, disconnect());
+    EXPECT_CALL(*m_channelMock, process()).InSequence(m_processSeq).WillOnce(Return(false));
+    EXPECT_CALL(*m_channelMock, disconnect())
+        .WillOnce(Invoke(
+            [this]()
+            {
+                std::lock_guard<std::mutex> locker(m_eventsLock);
+                m_disconnected = true;
+                m_eventsCond.notify_all();
+            }));
     m_sut.reset();
+}
+
+void IpcClientTestBase::expectCreateChannel()
+{
+    EXPECT_CALL(*m_channelFactoryMock, createChannel(m_kRialtoPath))
+        .WillOnce(Invoke(
+            [this](const std::string &socketPath)
+            {
+                std::lock_guard<std::mutex> locker(m_eventsLock);
+                m_disconnected = false;
+                return m_channelMock;
+            }));
 }

--- a/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.h
+++ b/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.h
@@ -27,15 +27,19 @@
 #include "IpcChannelMock.h"
 #include "IpcControllerFactoryMock.h"
 #include "RpcControllerMock.h"
+#include <condition_variable>
 #include <gtest/gtest.h>
 #include <memory>
+#include <mutex>
 
 using namespace firebolt::rialto;
 using namespace firebolt::rialto::ipc;
 using namespace firebolt::rialto::client;
 
 using ::testing::_;
+using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::Sequence;
 using ::testing::StrictMock;
 
 class IpcClientTestBase : public ::testing::Test
@@ -54,6 +58,13 @@ protected:
     // Common variables
     const char *m_kRialtoPath = getenv("RIALTO_SOCKET_PATH");
 
+    // Variables for the ipc event loop
+    std::mutex m_eventsLock;
+    std::condition_variable m_eventsCond;
+    bool m_disconnected = true;
+
+    Sequence m_processSeq;
+
     IpcClientTestBase();
     virtual ~IpcClientTestBase();
     void createIpcClient();
@@ -61,6 +72,8 @@ protected:
     void createBlockingClosure();
     void createRpcController();
     void disconnectIpcClient();
+    void expectCreateChannel();
+    void expectIpcLoop();
 };
 
 #endif // IPC_CLIENT_TEST_BASE_H_

--- a/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.h
+++ b/tests/media/client/ipc/ipcClient/base/IpcClientTestBase.h
@@ -63,8 +63,6 @@ protected:
     std::condition_variable m_eventsCond;
     bool m_disconnected = true;
 
-    Sequence m_processSeq;
-
     IpcClientTestBase();
     virtual ~IpcClientTestBase();
     void createIpcClient();

--- a/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.cpp
+++ b/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.cpp
@@ -36,7 +36,8 @@ void IpcModuleBase::expectInitIpc()
 
 void IpcModuleBase::expectInitIpcButAttachChannelFailure()
 {
-    EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(nullptr)).RetiresOnSaturation();
+    std::shared_ptr<StrictMock<ChannelMock>> channelMock;
+    EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(channelMock)).RetiresOnSaturation();
 }
 
 void IpcModuleBase::expectAttachChannel()

--- a/tests/media/client/ipc/mediaKeysCapabilitiesIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaKeysCapabilitiesIpc/CreateTest.cpp
@@ -49,7 +49,7 @@ TEST_F(RialtoClientCreateMediaKeysCapabilitiesIpcTest, Create)
  */
 TEST_F(RialtoClientCreateMediaKeysCapabilitiesIpcTest, CreateNoIpcChannel)
 {
-    EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(nullptr));
+    expectInitIpcButAttachChannelFailure();
 
     EXPECT_THROW(m_mediaKeysCapabilitiesIpc = std::make_unique<MediaKeysCapabilitiesIpc>(m_ipcClientMock),
                  std::runtime_error);

--- a/tests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
@@ -59,8 +59,8 @@ TEST_F(RialtoClientCreateMediaKeysIpcTest, Create)
  */
 TEST_F(RialtoClientCreateMediaKeysIpcTest, CreateNoIpcChannel)
 {
+    expectInitIpcButAttachChannelFailure();
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
-    EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(nullptr));
 
     EXPECT_THROW(m_mediaKeysIpc = std::make_unique<MediaKeysIpc>(m_keySystem, m_ipcClientMock, m_eventThreadFactoryMock),
                  std::runtime_error);

--- a/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
@@ -80,8 +80,8 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateDestroy)
  */
 TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateNoIpcChannel)
 {
+    expectInitIpcButAttachChannelFailure();
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
-    EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(nullptr));
 
     EXPECT_THROW(m_mediaPipelineIpc = std::make_unique<MediaPipelineIpc>(m_clientMock, m_videoReq, m_ipcClientMock,
                                                                          m_eventThreadFactoryMock),

--- a/tests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
@@ -83,8 +83,8 @@ TEST_F(RialtoClientCreateWebAudioPlayerIpcTest, CreateDestroy)
  */
 TEST_F(RialtoClientCreateWebAudioPlayerIpcTest, CreateNoIpcChannel)
 {
+    expectInitIpcButAttachChannelFailure();
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
-    EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(nullptr));
 
     EXPECT_THROW(m_webAudioPlayerIpc = std::make_unique<WebAudioPlayerIpc>(m_clientMock, m_audioMimeType, m_priority,
                                                                            &m_config, m_ipcClientMock,

--- a/tests/media/client/mocks/ipc/IpcClientMock.h
+++ b/tests/media/client/mocks/ipc/IpcClientMock.h
@@ -32,7 +32,7 @@ public:
     IpcClientMock() = default;
     virtual ~IpcClientMock() = default;
 
-    MOCK_METHOD(std::shared_ptr<ipc::IChannel>, getChannel, (), (override, const));
+    MOCK_METHOD(std::weak_ptr<ipc::IChannel>, getChannel, (), (override, const));
     MOCK_METHOD(std::shared_ptr<ipc::IBlockingClosure>, createBlockingClosure, (), (override));
     MOCK_METHOD(std::shared_ptr<google::protobuf::RpcController>, createRpcController, (), (override));
 };


### PR DESCRIPTION
Summary: Redeliver aa75cfd3634e3390ed4ad94104cd1e4924272ea1 and fix intermittent coredump in unittest.
Type: BugFix
Test Plan: YouTube Cert Tests, Unittests
Jira: RIALTO-174