### PR TITLE
Enable native audio for brcm

### DIFF
--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -197,6 +197,11 @@ private:
      */
     void resetWorkerThread();
 
+    /**
+     * @brief Whether native audio should be enabled on the current platform.
+     */
+    bool shouldEnableNativeAudio();
+
 private:
     /**
      * @brief The player context.

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -897,7 +897,7 @@ bool GstGenericPlayer::shouldEnableNativeAudio()
 
     if (m_glibWrapper->gOnceInitEnter(&init))
     {
-        GstElementFactory* factory = m_gstWrapper->gstElementFactoryFind("brcmaudiosink");
+        GstElementFactory *factory = m_gstWrapper->gstElementFactoryFind("brcmaudiosink");
         if (factory)
         {
             m_gstWrapper->gstObjectUnref(GST_OBJECT(factory));

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -891,22 +891,13 @@ void GstGenericPlayer::updatePlaybackGroup(GstElement *typefind, const GstCaps *
 
 bool GstGenericPlayer::shouldEnableNativeAudio()
 {
-    // Only needs to be checked once as its platform specific
-    static bool enableNativeAudio = false;
-    static gsize init = 0;
-
-    if (m_glibWrapper->gOnceInitEnter(&init))
+    GstElementFactory *factory = m_gstWrapper->gstElementFactoryFind("brcmaudiosink");
+    if (factory)
     {
-        GstElementFactory *factory = m_gstWrapper->gstElementFactoryFind("brcmaudiosink");
-        if (factory)
-        {
-            m_gstWrapper->gstObjectUnref(GST_OBJECT(factory));
-            enableNativeAudio = true;
-        }
-        m_glibWrapper->gOnceInitLeave(&init, 1);
+        m_gstWrapper->gstObjectUnref(GST_OBJECT(factory));
+        return true;
     }
-
-    return enableNativeAudio;
+    return false;
 }
 
 }; // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -897,17 +897,16 @@ bool GstGenericPlayer::shouldEnableNativeAudio()
 
     if (m_glibWrapper->gOnceInitEnter(&init))
     {
-        GstElementFactory* factory = gst_element_factory_find("brcmaudiosink");
+        GstElementFactory* factory = m_gstWrapper->gstElementFactoryFind("brcmaudiosink");
         if (factory)
         {
-            gst_object_unref(GST_OBJECT(factory));
+            m_gstWrapper->gstObjectUnref(GST_OBJECT(factory));
             enableNativeAudio = true;
         }
         m_glibWrapper->gOnceInitLeave(&init, 1);
     }
 
     return enableNativeAudio;
-
 }
 
 }; // namespace firebolt::rialto::server

--- a/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -317,7 +317,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, PlaysinkNotFound)
 /**
  * Test that a GstGenericPlayer sets native audio flag from brcmaudiosink.
  */
-TEST_F(RialtoServerCreateGstGenericPlayerTest, SetNativeAudioForBcmAudioSink)
+TEST_F(RialtoServerCreateGstGenericPlayerTest, SetNativeAudioForBrcmAudioSink)
 {
     initFactories();
 

--- a/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -313,3 +313,35 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, PlaysinkNotFound)
     executeTaskWhenEnqueued();
     gstPlayerWillBeDestroyed();
 }
+
+/**
+ * Test that a GstGenericPlayer sets native audio flag from brcmaudiosink.
+ */
+TEST_F(RialtoServerCreateGstGenericPlayerTest, SetNativeAudioForBcmAudioSink)
+{
+    initFactories();
+
+    expectMakePlaybin();
+    expectSetFlagsWithNativeAudio();
+    expectSetSignalCallbacks();
+    expectSetUri();
+    expectCheckPlaySink();
+    expectSetMessageCallback();
+
+    EXPECT_CALL(*m_gstSrcMock, initSrc());
+    EXPECT_CALL(m_workerThreadFactoryMock, createWorkerThread()).WillOnce(Return(ByMove(std::move(workerThread))));
+    EXPECT_CALL(*m_gstProtectionMetadataFactoryMock, createProtectionMetadataWrapper(_))
+        .WillOnce(Return(ByMove(std::move(m_gstProtectionMetadataWrapper))));
+
+    EXPECT_NO_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock,
+                                                                     m_type, m_videoReq, m_gstWrapperMock,
+                                                                     m_glibWrapperMock, m_gstSrcFactoryMock,
+                                                                     m_timerFactoryMock, std::move(m_taskFactory),
+                                                                     std::move(workerThreadFactory),
+                                                                     std::move(gstDispatcherThreadFactory),
+                                                                     m_gstProtectionMetadataFactoryMock););
+    EXPECT_NE(m_gstPlayer, nullptr);
+
+    executeTaskWhenEnqueued();
+    gstPlayerWillBeDestroyed();
+}

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -130,8 +130,7 @@ void GstGenericPlayerTestCommon::expectSetFlags()
         .WillOnce(Return(&m_videoFlag));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
-    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_))
-        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_)).WillOnce(Return(FALSE));
 
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, CharStrMatcher("flags")));
 }
@@ -152,8 +151,7 @@ void GstGenericPlayerTestCommon::expectSetFlagsWithNativeAudio()
         .WillOnce(Return(&m_videoFlag));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
-    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_))
-        .WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("brcmaudiosink")))
         .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&sinkFactory)));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&sinkFactory)));

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -130,7 +130,7 @@ void GstGenericPlayerTestCommon::expectSetFlags()
         .WillOnce(Return(&m_videoFlag));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
-    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_)).WillOnce(Return(FALSE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("brcmaudiosink"))).WillOnce(Return(nullptr));
 
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, CharStrMatcher("flags")));
 }
@@ -151,11 +151,9 @@ void GstGenericPlayerTestCommon::expectSetFlagsWithNativeAudio()
         .WillOnce(Return(&m_videoFlag));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
-    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("brcmaudiosink")))
         .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&sinkFactory)));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&sinkFactory)));
-    EXPECT_CALL(*m_glibWrapperMock, gOnceInitLeave(_, 1));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-audio")))
         .WillOnce(Return(&nativeAudioFlag));
 

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -130,6 +130,36 @@ void GstGenericPlayerTestCommon::expectSetFlags()
         .WillOnce(Return(&m_videoFlag));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
+    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_))
+        .WillOnce(Return(FALSE));
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, CharStrMatcher("flags")));
+}
+
+void GstGenericPlayerTestCommon::expectSetFlagsWithNativeAudio()
+{
+    GstObject sinkFactory{}; // GstElementFactory is an opaque data structure
+    GFlagsValue nativeAudioFlag{4, "native-audio", "native-audio"};
+
+    EXPECT_CALL(*m_glibWrapperMock, gTypeFromName(CharStrMatcher("GstPlayFlags")))
+        .Times(4)
+        .WillRepeatedly(Return(m_gstPlayFlagsType));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeClassRef(m_gstPlayFlagsType)).Times(4).WillRepeatedly(Return(&m_flagsClass));
+
+    EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("audio")))
+        .WillOnce(Return(&m_audioFlag));
+    EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("video")))
+        .WillOnce(Return(&m_videoFlag));
+    EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-video")))
+        .WillOnce(Return(&m_nativeVideoFlag));
+    EXPECT_CALL(*m_glibWrapperMock, gOnceInitEnter(_))
+        .WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("brcmaudiosink")))
+        .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&sinkFactory)));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&sinkFactory)));
+    EXPECT_CALL(*m_glibWrapperMock, gOnceInitLeave(_, 1));
+    EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-audio")))
+        .WillOnce(Return(&nativeAudioFlag));
 
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, CharStrMatcher("flags")));
 }

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -137,9 +137,6 @@ void GstGenericPlayerTestCommon::expectSetFlags()
 
 void GstGenericPlayerTestCommon::expectSetFlagsWithNativeAudio()
 {
-    GstObject sinkFactory{}; // GstElementFactory is an opaque data structure
-    GFlagsValue nativeAudioFlag{4, "native-audio", "native-audio"};
-
     EXPECT_CALL(*m_glibWrapperMock, gTypeFromName(CharStrMatcher("GstPlayFlags")))
         .Times(4)
         .WillRepeatedly(Return(m_gstPlayFlagsType));
@@ -152,10 +149,10 @@ void GstGenericPlayerTestCommon::expectSetFlagsWithNativeAudio()
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryFind(CharStrMatcher("brcmaudiosink")))
-        .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&sinkFactory)));
-    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&sinkFactory)));
+        .WillOnce(Return(reinterpret_cast<GstElementFactory *>(&m_sinkFactory)));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(reinterpret_cast<GstElementFactory *>(&m_sinkFactory)));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, CharStrMatcher("native-audio")))
-        .WillOnce(Return(&nativeAudioFlag));
+        .WillOnce(Return(&m_nativeAudioFlag));
 
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, CharStrMatcher("flags")));
 }

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -110,6 +110,7 @@ private:
     GFlagsValue m_audioFlag{1, "audio", "audio"};
     GFlagsValue m_videoFlag{2, "video", "video"};
     GFlagsValue m_nativeVideoFlag{3, "native-video", "native-video"};
+    GFlagsValue m_nativeAudioFlag{4, "native-audio", "native-audio"};
     gpointer m_setupSourceUserData;
     GCallback m_setupSourceFunc;
     gulong m_setupSourceSignalId{0};
@@ -119,6 +120,7 @@ private:
     gpointer m_deepElementAddedUserData;
     GCallback m_deepElementAddedFunc;
     gulong m_deepElementAddedSignalId{2};
+    GstObject m_sinkFactory{}; // GstElementFactory is an opaque data structure
 };
 
 #endif // GST_GENERIC_PLAYER_TEST_COMMON_H_

--- a/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -94,6 +94,7 @@ protected:
     void initFactories();
     void expectMakePlaybin();
     void expectSetFlags();
+    void expectSetFlagsWithNativeAudio();
     void expectSetSignalCallbacks();
     void expectSetUri();
     void expectCheckPlaySink();


### PR DESCRIPTION
Summary: Enable native-audio for the broadcom platform, this fixes audio only playback.
Type: BugFix
Test Plan: YouTube Cert Tests, Unittests
Jira: RIALTO-179