### PR TITLE
RialtoMSEAudioSink should implement 'mute' from interface 'GstStreamVolume'

### DIFF
--- a/media/client/ipc/include/MediaPipelineIpc.h
+++ b/media/client/ipc/include/MediaPipelineIpc.h
@@ -99,6 +99,10 @@ public:
 
     bool getVolume(double &volume) override;
 
+    bool setMute(bool mute) override;
+
+    bool getMute(bool &mute) override;
+
 private:
     /**
      * @brief The media player client ipc.

--- a/media/client/ipc/interface/IMediaPipelineIpc.h
+++ b/media/client/ipc/interface/IMediaPipelineIpc.h
@@ -205,6 +205,28 @@ public:
      * @retval true on success false otherwise
      */
     virtual bool getVolume(double &volume) = 0;
+
+    /**
+     * @brief Set mute status of pipeline.
+     *
+     * Muting does not change the underlying volume setting so when
+     * unmuted the user will hear audio at the same volume as previously
+     * set.
+     *
+     * @param[in] mute   Desired mute status, true=muted, false=not muted
+     *
+     * @retval true on success false otherwise
+     */
+    virtual bool setMute(bool mute) = 0;
+
+    /**
+     * @brief Get current mute status of the pipeline
+     *
+     * @param[out] mute   Current mute status
+     *
+     * @retval true on success false otherwise
+     */
+    virtual bool getMute(bool &mute) = 0;
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/source/MediaPipelineIpc.cpp
+++ b/media/client/ipc/source/MediaPipelineIpc.cpp
@@ -660,6 +660,69 @@ bool MediaPipelineIpc::getVolume(double &volume)
     return true;
 }
 
+bool MediaPipelineIpc::setMute(bool mute)
+{
+    if (!reattachChannelIfRequired())
+    {
+        RIALTO_CLIENT_LOG_ERROR("Reattachment of the ipc channel failed, ipc disconnected");
+        return false;
+    }
+
+    firebolt::rialto::SetMuteRequest request;
+
+    request.set_session_id(m_sessionId);
+    request.set_mute(mute);
+
+    firebolt::rialto::SetMuteResponse response;
+    auto ipcController = m_ipc->createRpcController();
+    auto blockingClosure = m_ipc->createBlockingClosure();
+    m_mediaPipelineStub->setMute(ipcController.get(), &request, &response, blockingClosure.get());
+
+    // waiting for call to complete
+    blockingClosure->wait();
+
+    // check the result
+    if (ipcController->Failed())
+    {
+        RIALTO_CLIENT_LOG_ERROR("failed to set mute due to '%s'", ipcController->ErrorText().c_str());
+        return false;
+    }
+
+    return true;
+}
+
+bool MediaPipelineIpc::getMute(bool &mute)
+{
+    if (!reattachChannelIfRequired())
+    {
+        RIALTO_CLIENT_LOG_ERROR("Reattachment of the ipc channel failed, ipc disconnected");
+        return false;
+    }
+
+    firebolt::rialto::GetMuteRequest request;
+
+    request.set_session_id(m_sessionId);
+
+    firebolt::rialto::GetMuteResponse response;
+    auto ipcController = m_ipc->createRpcController();
+    auto blockingClosure = m_ipc->createBlockingClosure();
+    m_mediaPipelineStub->getMute(ipcController.get(), &request, &response, blockingClosure.get());
+
+    // wait for the call to complete
+    blockingClosure->wait();
+
+    // check the result
+    if (ipcController->Failed())
+    {
+        RIALTO_CLIENT_LOG_ERROR("failed to get mute due to '%s'", ipcController->ErrorText().c_str());
+        return false;
+    }
+
+    mute = response.mute();
+
+    return true;
+}
+
 void MediaPipelineIpc::onPlaybackStateUpdated(const std::shared_ptr<firebolt::rialto::PlaybackStateChangeEvent> &event)
 {
     /* Ignore event if not for this session */

--- a/media/client/main/include/MediaPipeline.h
+++ b/media/client/main/include/MediaPipeline.h
@@ -137,6 +137,10 @@ public:
 
     bool getVolume(double &volume) override;
 
+    bool setMute(bool mute) override;
+
+    bool getMute(bool &mute) override;
+
 protected:
     /**
      * @brief The need data request data.

--- a/media/client/main/source/MediaPipeline.cpp
+++ b/media/client/main/source/MediaPipeline.cpp
@@ -420,6 +420,18 @@ bool MediaPipeline::getVolume(double &volume)
     return m_mediaPipelineIpc->getVolume(volume);
 }
 
+bool MediaPipeline::setMute(bool mute)
+{
+    RIALTO_CLIENT_LOG_DEBUG("entry:");
+    return m_mediaPipelineIpc->setMute(mute);
+}
+
+bool MediaPipeline::getMute(bool &mute)
+{
+    RIALTO_CLIENT_LOG_DEBUG("entry:");
+    return m_mediaPipelineIpc->getMute(mute);
+}
+
 void MediaPipeline::discardNeedDataRequest(uint32_t needDataRequestId)
 {
     // Find the needDataRequest for this needDataRequestId

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -1155,6 +1155,28 @@ public:
      * @retval true on success false otherwise
      */
     virtual bool getVolume(double &volume) = 0;
+
+    /**
+     * @brief Set mute status of pipeline.
+     *
+     * Muting does not change the underlying volume setting so when
+     * unmuted the user will hear audio at the same volume as previously
+     * set.
+     *
+     * @param[in] mute   Desired mute status, true=muted, false=not muted
+     *
+     * @retval true on success false otherwise
+     */
+    virtual bool setMute(bool mute) = 0;
+
+    /**
+     * @brief Get current mute status of the pipeline
+     *
+     * @param[out] mute   Current mute status
+     *
+     * @retval true on success false otherwise
+     */
+    virtual bool getMute(bool &mute) = 0;
 };
 
 }; // namespace firebolt::rialto

--- a/media/server/gstplayer/CMakeLists.txt
+++ b/media/server/gstplayer/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(
         source/tasks/generic/SetupSource.cpp
         source/tasks/generic/SetVideoGeometry.cpp
         source/tasks/generic/SetVolume.cpp
+        source/tasks/generic/SetMute.cpp
         source/tasks/generic/Shutdown.cpp
         source/tasks/generic/Stop.cpp
         source/tasks/generic/Underflow.cpp

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -111,6 +111,8 @@ public:
     bool getPosition(std::int64_t &position) override;
     void setVolume(double volume) override;
     bool getVolume(double &volume) override;
+    void setMute(bool mute) override;
+    bool getMute(bool &mute) override;
 
 private:
     void scheduleNeedMediaData(GstAppSrc *src) override;

--- a/media/server/gstplayer/include/GstWrapper.h
+++ b/media/server/gstplayer/include/GstWrapper.h
@@ -438,6 +438,16 @@ public:
         gst_stream_volume_set_volume(volume, format, val);
     }
 
+    gboolean gstStreamVolumeGetMute(GstStreamVolume *volume) const override
+    {
+        return gst_stream_volume_get_mute(volume);
+    }
+
+    void gstStreamVolumeSetMute(GstStreamVolume *volume, gboolean mute) const
+    {
+        return gst_stream_volume_set_mute(volume, mute);
+    }
+
     GstElement *gstPipelineNew(const gchar *name) const override { return gst_pipeline_new(name); }
 
     GstPluginFeature *gstRegistryLookupFeature(GstRegistry *registry, const char *name) const override

--- a/media/server/gstplayer/include/IGstWrapper.h
+++ b/media/server/gstplayer/include/IGstWrapper.h
@@ -1005,6 +1005,25 @@ public:
     virtual void gstStreamVolumeSetVolume(GstStreamVolume *volume, GstStreamVolumeFormat format, gdouble val) const = 0;
 
     /**
+     * @brief Get current mute status of the pipeline
+     *
+     * @param[in] volume : GstStreamVolume that should be used
+     *
+     * @retval Returns TRUE if the stream is muted
+     */
+    virtual gboolean gstStreamVolumeGetMute(GstStreamVolume *volume) const = 0;
+
+    /**
+     * @brief Sets mute status of pipeline
+     *
+     * @param[in] volume : GstStreamVolume that should be used
+     * @param[in] mute   : Mute state that should be set
+     *
+     * @retval Returns TRUE if the stream is muted
+     */
+    virtual void gstStreamVolumeSetMute(GstStreamVolume *volume, gboolean mute) const = 0;
+
+    /**
      * @brief Create a new pipeline with given name.
      *
      * @param[in] name  : Name of new pipeline.

--- a/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
@@ -270,6 +270,16 @@ public:
     virtual std::unique_ptr<IPlayerTask> createSetVolume(GenericPlayerContext &context, double volume) const = 0;
 
     /**
+     * @brief Creates a SetMute task.
+     *
+     * @param[in] context       : The GstGenericPlayer context
+     * @param[in] mute          : The mute state to be set
+     *
+     * @retval the new SetMute task instance.
+     */
+    virtual std::unique_ptr<IPlayerTask> createSetMute(GenericPlayerContext &context, bool mute) const = 0;
+
+    /**
      * @brief Creates a Shutdown task.
      *
      * @param[in] context       : The GstGenericPlayer context

--- a/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
@@ -74,6 +74,7 @@ public:
     std::unique_ptr<IPlayerTask> createSetVideoGeometry(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                         const Rectangle &rectangle) const override;
     std::unique_ptr<IPlayerTask> createSetVolume(GenericPlayerContext &context, double volume) const override;
+    std::unique_ptr<IPlayerTask> createSetMute(GenericPlayerContext &context, bool mute) const override;
     std::unique_ptr<IPlayerTask> createShutdown(IGstGenericPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createStop(GenericPlayerContext &context,
                                             IGstGenericPlayerPrivate &player) const override;

--- a/media/server/gstplayer/include/tasks/generic/SetMute.h
+++ b/media/server/gstplayer/include/tasks/generic/SetMute.h
@@ -1,0 +1,44 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_MUTE_H_
+#define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_MUTE_H_
+
+#include "GenericPlayerContext.h"
+#include "IGstWrapper.h"
+#include "IPlayerTask.h"
+#include <memory>
+
+namespace firebolt::rialto::server::tasks::generic
+{
+class SetMute : public IPlayerTask
+{
+public:
+    SetMute(GenericPlayerContext &context, std::shared_ptr<IGstWrapper> gstWrapper, bool mute);
+    ~SetMute() override;
+    void execute() const override;
+
+private:
+    GenericPlayerContext &m_context;
+    std::shared_ptr<IGstWrapper> m_gstWrapper;
+    bool m_mute;
+};
+} // namespace firebolt::rialto::server::tasks::generic
+
+#endif // FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_MUTE_H

--- a/media/server/gstplayer/interface/IGstGenericPlayer.h
+++ b/media/server/gstplayer/interface/IGstGenericPlayer.h
@@ -221,6 +221,26 @@ public:
      * @retval True on success
      */
     virtual bool getVolume(double &volume) = 0;
+
+    /**
+     * @brief Set mute status of pipeline
+     *
+     * Muting does not change the underlying volyme setting so when
+     * unmuted the user will hear audio at the same volume as previously
+     * set.
+     *
+     * @param[in] mute : Desired mute status, true=muted, false=not muted
+     */
+    virtual void setMute(bool mute) = 0;
+
+    /**
+     * @brief Get current mute status of the pipeline
+     *
+     * @param[out] mute : Current mute status
+     *
+     * @retval True in success, false otherwise
+     */
+    virtual bool getMute(bool &mute) = 0;
 };
 
 }; // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -880,6 +880,24 @@ bool GstGenericPlayer::getVolume(double &volume)
     return true;
 }
 
+void GstGenericPlayer::setMute(bool mute)
+{
+    if (m_workerThread)
+    {
+        m_workerThread->enqueueTask(m_taskFactory->createSetMute(m_context, mute));
+    }
+}
+
+bool GstGenericPlayer::getMute(bool &mute)
+{
+    if (!m_context.pipeline)
+    {
+        return false;
+    }
+    mute = m_gstWrapper->gstStreamVolumeGetMute(GST_STREAM_VOLUME(m_context.pipeline));
+    return true;
+}
+
 void GstGenericPlayer::handleBusMessage(GstMessage *message)
 {
     m_workerThread->enqueueTask(m_taskFactory->createHandleBusMessage(m_context, *this, message));

--- a/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
@@ -33,6 +33,7 @@
 #include "tasks/generic/RemoveSource.h"
 #include "tasks/generic/RenderFrame.h"
 #include "tasks/generic/ReportPosition.h"
+#include "tasks/generic/SetMute.h"
 #include "tasks/generic/SetPlaybackRate.h"
 #include "tasks/generic/SetPosition.h"
 #include "tasks/generic/SetVideoGeometry.h"
@@ -181,6 +182,11 @@ std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetVideoGeometry(Ge
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetVolume(GenericPlayerContext &context, double volume) const
 {
     return std::make_unique<tasks::generic::SetVolume>(context, m_gstWrapper, volume);
+}
+
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetMute(GenericPlayerContext &context, bool mute) const
+{
+    return std::make_unique<tasks::generic::SetMute>(context, m_gstWrapper, mute);
 }
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createShutdown(IGstGenericPlayerPrivate &player) const

--- a/media/server/gstplayer/source/tasks/generic/SetMute.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetMute.cpp
@@ -1,0 +1,47 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tasks/generic/SetMute.h"
+#include "RialtoServerLogging.h"
+#include <gst/gst.h>
+
+namespace firebolt::rialto::server::tasks::generic
+{
+SetMute::SetMute(GenericPlayerContext &context, std::shared_ptr<IGstWrapper> gstWrapper, bool mute)
+    : m_context{context}, m_gstWrapper{gstWrapper}, m_mute{mute}
+{
+    RIALTO_SERVER_LOG_DEBUG("Constructing SetMute");
+}
+
+SetMute::~SetMute()
+{
+    RIALTO_SERVER_LOG_DEBUG("SetMute finished");
+}
+
+void SetMute::execute() const
+{
+    RIALTO_SERVER_LOG_DEBUG("Executing SetMute");
+    if (!m_context.pipeline)
+    {
+        RIALTO_SERVER_LOG_ERROR("Setting mute failed. Pipeline is NULL");
+        return;
+    }
+    m_gstWrapper->gstStreamVolumeSetMute(GST_STREAM_VOLUME(m_context.pipeline), m_mute);
+}
+} // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/ipc/include/MediaPipelineModuleService.h
+++ b/media/server/ipc/include/MediaPipelineModuleService.h
@@ -90,6 +90,10 @@ public:
                    ::firebolt::rialto::SetVolumeResponse *response, ::google::protobuf::Closure *done) override;
     void getVolume(::google::protobuf::RpcController *controller, const ::firebolt::rialto::GetVolumeRequest *request,
                    ::firebolt::rialto::GetVolumeResponse *response, ::google::protobuf::Closure *done) override;
+    void setMute(::google::protobuf::RpcController *controller, const ::firebolt::rialto::SetMuteRequest *request,
+                 ::firebolt::rialto::SetMuteResponse *response, ::google::protobuf::Closure *done) override;
+    void getMute(::google::protobuf::RpcController *controller, const ::firebolt::rialto::GetMuteRequest *request,
+                 ::firebolt::rialto::GetMuteResponse *response, ::google::protobuf::Closure *done) override;
 
 private:
     service::IMediaPipelineService &m_mediaPipelineService;

--- a/media/server/ipc/source/MediaPipelineModuleService.cpp
+++ b/media/server/ipc/source/MediaPipelineModuleService.cpp
@@ -560,4 +560,39 @@ void MediaPipelineModuleService::getVolume(::google::protobuf::RpcController *co
 
     done->Run();
 }
+
+void MediaPipelineModuleService::setMute(::google::protobuf::RpcController *controller,
+                                         const ::firebolt::rialto::SetMuteRequest *request,
+                                         ::firebolt::rialto::SetMuteResponse *response, ::google::protobuf::Closure *done)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+
+    if (!m_mediaPipelineService.setMute(request->session_id(), request->mute()))
+    {
+        RIALTO_SERVER_LOG_ERROR("Set mute failed.");
+        controller->SetFailed("Operation failed");
+    }
+
+    done->Run();
+}
+
+void MediaPipelineModuleService::getMute(::google::protobuf::RpcController *controller,
+                                         const ::firebolt::rialto::GetMuteRequest *request,
+                                         ::firebolt::rialto::GetMuteResponse *response, ::google::protobuf::Closure *done)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+    bool mute{};
+
+    if (!m_mediaPipelineService.getMute(request->session_id(), mute))
+    {
+        RIALTO_SERVER_LOG_ERROR("Get mute failed.");
+        controller->SetFailed("Operation failed");
+    }
+    else
+    {
+        response->set_mute(mute);
+    }
+
+    done->Run();
+}
 } // namespace firebolt::rialto::server::ipc

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -124,6 +124,10 @@ public:
 
     bool getVolume(double &volume) override;
 
+    bool setMute(bool mute) override;
+
+    bool getMute(bool &mute) override;
+
     AddSegmentStatus addSegment(uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment) override;
 
     std::weak_ptr<IMediaPipelineClient> getClient() override;
@@ -394,6 +398,24 @@ protected:
      * @retval true on success false otherwise
      */
     bool getVolumeInternal(double &volume);
+
+    /**
+     * @brief Set mute internally, only to be called on the main thread.
+     *
+     * @param[in] mute Desired mute status, true=muted, false=not muted
+     *
+     * @retval true on success false otherwise
+     */
+    bool setMuteInternal(bool mute);
+
+    /**
+     * @brief Get mute internally, only to be called on the main thread.
+     *
+     * @param[out] mute Current mute status
+     *
+     * @retval true on success false otherwise
+     */
+    bool getMuteInternal(bool &mute);
 };
 
 }; // namespace firebolt::rialto::server

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -705,6 +705,53 @@ bool MediaPipelineServerInternal::getVolumeInternal(double &volume)
     return m_gstPlayer->getVolume(volume);
 }
 
+bool MediaPipelineServerInternal::setMute(bool mute)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+
+    bool result;
+    auto task = [&]() { result = setMuteInternal(mute); };
+
+    m_mainThread->enqueueTaskAndWait(m_mainThreadClientId, task);
+    return result;
+}
+
+bool MediaPipelineServerInternal::setMuteInternal(bool mute)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+
+    if (!m_gstPlayer)
+    {
+        RIALTO_SERVER_LOG_ERROR("Failed to set mute - Gstreamer player has not been loaded");
+        return false;
+    }
+    m_gstPlayer->setMute(mute);
+    return true;
+}
+
+bool MediaPipelineServerInternal::getMute(bool &mute)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+
+    bool result;
+    auto task = [&]() { result = getMuteInternal(mute); };
+
+    m_mainThread->enqueueTaskAndWait(m_mainThreadClientId, task);
+    return result;
+}
+
+bool MediaPipelineServerInternal::getMuteInternal(bool &mute)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+
+    if (!m_gstPlayer)
+    {
+        RIALTO_SERVER_LOG_ERROR("Failed to get mute - Gstreamer player has not been loaded");
+        return false;
+    }
+    return m_gstPlayer->getMute(mute);
+}
+
 AddSegmentStatus MediaPipelineServerInternal::addSegment(uint32_t needDataRequestId,
                                                          const std::unique_ptr<MediaSegment> &mediaSegment)
 {

--- a/media/server/service/include/IMediaPipelineService.h
+++ b/media/server/service/include/IMediaPipelineService.h
@@ -60,6 +60,8 @@ public:
     virtual bool renderFrame(int sessionId) = 0;
     virtual bool setVolume(int sessionId, double volume) = 0;
     virtual bool getVolume(int sessionId, double &volume) = 0;
+    virtual bool setMute(int sessionId, bool mute) = 0;
+    virtual bool getMute(int sessionId, bool &mute) = 0;
     virtual std::vector<std::string> getSupportedMimeTypes(MediaSourceType type) = 0;
     virtual bool isMimeTypeSupported(const std::string &mimeType) = 0;
 };

--- a/media/server/service/source/MediaPipelineService.cpp
+++ b/media/server/service/source/MediaPipelineService.cpp
@@ -324,6 +324,34 @@ bool MediaPipelineService::getVolume(int sessionId, double &volume)
     return mediaPipelineIter->second->getVolume(volume);
 }
 
+bool MediaPipelineService::setMute(int sessionId, bool mute)
+{
+    RIALTO_SERVER_LOG_DEBUG("Set mute requested, session id: %d", sessionId);
+
+    std::lock_guard<std::mutex> lock{m_mediaPipelineMutex};
+    auto mediaPipelineIter = m_mediaPipelines.find(sessionId);
+    if (mediaPipelineIter == m_mediaPipelines.end())
+    {
+        RIALTO_SERVER_LOG_ERROR("Session with id: %d does not exist", sessionId);
+        return false;
+    }
+    return mediaPipelineIter->second->setMute(mute);
+}
+
+bool MediaPipelineService::getMute(int sessionId, bool &mute)
+{
+    RIALTO_SERVER_LOG_DEBUG("Get mute requested, session id: %d", sessionId);
+
+    std::lock_guard<std::mutex> lock{m_mediaPipelineMutex};
+    auto mediaPipelineIter = m_mediaPipelines.find(sessionId);
+    if (mediaPipelineIter == m_mediaPipelines.end())
+    {
+        RIALTO_SERVER_LOG_ERROR("SEssion with id: %d does not exist", sessionId);
+        return false;
+    }
+    return mediaPipelineIter->second->getMute(mute);
+}
+
 std::vector<std::string> MediaPipelineService::getSupportedMimeTypes(MediaSourceType type)
 {
     return m_mediaPipelineCapabilities->getSupportedMimeTypes(type);

--- a/media/server/service/source/MediaPipelineService.h
+++ b/media/server/service/source/MediaPipelineService.h
@@ -72,6 +72,8 @@ public:
     bool renderFrame(int sessionId) override;
     bool setVolume(int sessionId, double volume) override;
     bool getVolume(int sessionId, double &volume) override;
+    bool setMute(int sessionId, bool mute) override;
+    bool getMute(int sessionId, bool &mute) override;
     std::vector<std::string> getSupportedMimeTypes(MediaSourceType type) override;
     bool isMimeTypeSupported(const std::string &mimeType) override;
 

--- a/proto/mediapipelinemodule.proto
+++ b/proto/mediapipelinemodule.proto
@@ -372,6 +372,37 @@ message GetVolumeResponse {
 }
 
 /**
+ * @fn void setMute(bool mute)
+ * @brief Set mute status of pipeline.
+ *
+ * @param[in] session_id  The id of the A/V session the request is for.
+ * @param[in] mute        Desired mute status, true=muted, false=not muted
+ *
+ */
+message SetMuteRequest {
+    required int32 session_id = 1;
+    required bool mute = 2;
+}
+message SetMuteResponse {
+}
+
+/**
+ * @fn void getMute(bool &mute)
+ * @brief Get current mute status of the pipeline
+ *
+ * @param[in]  session_id  The id of the A/V session the request is for.
+ * @param[out] mute      Current mute status
+ *
+ * @retval true on success false otherwise
+ */
+message GetMuteRequest {
+    required int32 session_id = 1;
+}
+message GetMuteResponse {
+    required bool mute = 1;
+}
+
+/**
  * @brief Event sent the playback state has changed.
  *
  * @param session_id   The id of the A/V session the status is for.
@@ -617,5 +648,19 @@ service MediaPipelineModule {
      * @see GetVolumeRequest
      */
     rpc getVolume(GetVolumeRequest) returns (GetVolumeResponse) {
+    }
+
+        /**
+     * @brief Set mute status of pipeline.
+     * @see SetMuteRequest
+     */
+    rpc setMute(SetMuteRequest) returns (SetMuteResponse) {
+    } 
+
+    /**
+     * @brief Get current mute status of the pipeline
+     * @see GetMuteRequest
+     */
+    rpc getMute(GetMuteRequest) returns (GetMuteResponse) {
     }
 }

--- a/tests/media/client/ipc/CMakeLists.txt
+++ b/tests/media/client/ipc/CMakeLists.txt
@@ -55,6 +55,8 @@ add_gtests (
         mediaPipelineIpc/RenderFrameTest.cpp
         mediaPipelineIpc/GetVolumeTest.cpp
         mediaPipelineIpc/SetVolumeTest.cpp
+        mediaPipelineIpc/GetMuteTest.cpp
+        mediaPipelineIpc/SetMuteTest.cpp
 
         # MediaPipelineCapabilitiesIpc tests
         mediaPipelineCapabilitiesIpc/MediaPipelineCapabilitiesIpcTest.cpp

--- a/tests/media/client/ipc/mediaPipelineIpc/GetMuteTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/GetMuteTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MediaPipelineIpcTestBase.h"
+
+MATCHER_P(GetMuteRequestMatcher, sessionId, "")
+{
+    const ::firebolt::rialto::GetMuteRequest *request = dynamic_cast<const ::firebolt::rialto::GetMuteRequest *>(arg);
+    return ((request->session_id() == sessionId));
+}
+
+class RialtoClientMediaPipelineIpcGetMuteTest : public MediaPipelineIpcTestBase
+{
+protected:
+    virtual void SetUp()
+    {
+        MediaPipelineIpcTestBase::SetUp();
+
+        createMediaPipelineIpc();
+    }
+
+    virtual void TearDown()
+    {
+        destroyMediaPipelineIpc();
+
+        MediaPipelineIpcTestBase::TearDown();
+    }
+};
+
+/**
+ * Test that getMute can be called successfully.
+ */
+TEST_F(RialtoClientMediaPipelineIpcGetMuteTest, Success)
+{
+    constexpr bool kMute{false};
+    expectIpcApiCallSuccess();
+
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("getMute"), m_controllerMock.get(),
+                                           GetMuteRequestMatcher(m_sessionId), _, m_blockingClosureMock.get()))
+        .WillOnce(Invoke(
+            [&](const google::protobuf::MethodDescriptor *, google::protobuf::RpcController *,
+                const google::protobuf::Message *, google::protobuf::Message *response, google::protobuf::Closure *)
+            {
+                ::firebolt::rialto::GetMuteResponse *resp = dynamic_cast<::firebolt::rialto::GetMuteResponse *>(response);
+                resp->set_mute(kMute);
+            }));
+
+    bool resultMute;
+    EXPECT_TRUE(m_mediaPipelineIpc->getMute(resultMute));
+    EXPECT_EQ(resultMute, kMute);
+}
+
+/**
+ * Test that getMute fails if the ipc channel disconnected.
+ */
+TEST_F(RialtoClientMediaPipelineIpcGetMuteTest, ChannelDisconnected)
+{
+    expectIpcApiCallDisconnected();
+    expectUnsubscribeEvents();
+
+    bool mute;
+    EXPECT_FALSE(m_mediaPipelineIpc->getMute(mute));
+
+    // Reattach channel on destroySession
+    EXPECT_CALL(*m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock)).RetiresOnSaturation();
+    expectSubscribeEvents();
+}
+
+/**
+ * Test that getMute fails if the ipc channel disconnected and succeeds if the channel is reconnected.
+ */
+TEST_F(RialtoClientMediaPipelineIpcGetMuteTest, ReconnectChannel)
+{
+    expectIpcApiCallReconnected();
+    expectUnsubscribeEvents();
+    expectSubscribeEvents();
+
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("getMute"), _, _, _, _));
+
+    bool mute;
+    EXPECT_TRUE(m_mediaPipelineIpc->getMute(mute));
+}
+
+/**
+ * Test that getMute fails when ipc fails.
+ */
+TEST_F(RialtoClientMediaPipelineIpcGetMuteTest, GetMuteFailure)
+{
+    expectIpcApiCallFailure();
+
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("getMute"), _, _, _, _));
+
+    bool mute;
+    EXPECT_FALSE(m_mediaPipelineIpc->getMute(mute));
+}

--- a/tests/media/client/ipc/mediaPipelineIpc/SetMuteTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/SetMuteTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MediaPipelineIpcTestBase.h"
+
+MATCHER_P2(SetMuteRequestMatcher, sessionId, mute, "")
+{
+    const ::firebolt::rialto::SetMuteRequest *request = dynamic_cast<const ::firebolt::rialto::SetMuteRequest *>(arg);
+    return ((request->session_id() == sessionId) && (request->mute() == mute));
+}
+
+class RialtoClientMediaPipelineIpcSetMuteTest : public MediaPipelineIpcTestBase
+{
+protected:
+    bool m_mute{false};
+
+    virtual void SetUp()
+    {
+        MediaPipelineIpcTestBase::SetUp();
+
+        createMediaPipelineIpc();
+    }
+
+    virtual void TearDown()
+    {
+        destroyMediaPipelineIpc();
+
+        MediaPipelineIpcTestBase::TearDown();
+    }
+};
+
+/**
+ * Test that setMute can be called successfully.
+ */
+TEST_F(RialtoClientMediaPipelineIpcSetMuteTest, Success)
+{
+    expectIpcApiCallSuccess();
+
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("setMute"), m_controllerMock.get(),
+                                           SetMuteRequestMatcher(m_sessionId, m_mute), _, m_blockingClosureMock.get()));
+
+    EXPECT_EQ(m_mediaPipelineIpc->setMute(m_mute), true);
+}
+
+/**
+ * Test that setMute fails if the ipc channel disconnected.
+ */
+TEST_F(RialtoClientMediaPipelineIpcSetMuteTest, ChannelDisconnected)
+{
+    expectIpcApiCallDisconnected();
+    expectUnsubscribeEvents();
+
+    EXPECT_EQ(m_mediaPipelineIpc->setMute(m_mute), false);
+
+    // Reattach channel on destroySession
+    EXPECT_CALL(*m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock)).RetiresOnSaturation();
+    expectSubscribeEvents();
+}
+
+/**
+ * Test that setMute fails if the ipc channel disconnected and succeeds if the channel is reconnected.
+ */
+TEST_F(RialtoClientMediaPipelineIpcSetMuteTest, ReconnectChannel)
+{
+    expectIpcApiCallReconnected();
+    expectUnsubscribeEvents();
+    expectSubscribeEvents();
+
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("setMute"), _, _, _, _));
+
+    EXPECT_EQ(m_mediaPipelineIpc->setMute(m_mute), true);
+}
+
+/**
+ * Test that setMute fails when ipc fails.
+ */
+TEST_F(RialtoClientMediaPipelineIpcSetMuteTest, SetMuteFailure)
+{
+    expectIpcApiCallFailure();
+
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("setMute"), _, _, _, _));
+
+    EXPECT_EQ(m_mediaPipelineIpc->setMute(m_mute), false);
+}

--- a/tests/media/client/main/CMakeLists.txt
+++ b/tests/media/client/main/CMakeLists.txt
@@ -35,6 +35,8 @@ add_gtests (
         mediaPipeline/RenderFrameTest.cpp
         mediaPipeline/SetVolumeTest.cpp
         mediaPipeline/GetVolumeTest.cpp
+        mediaPipeline/SetMuteTest.cpp
+        mediaPipeline/GetMuteTest.cpp
 
         # MediaPipelineCapabilities tests
         mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp

--- a/tests/media/client/main/mediaPipeline/GetMuteTest.cpp
+++ b/tests/media/client/main/mediaPipeline/GetMuteTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MediaPipelineTestBase.h"
+
+class RialtoClientMediaPipelineGetMuteTest : public MediaPipelineTestBase
+{
+protected:
+    bool m_mute{};
+
+    virtual void SetUp()
+    {
+        MediaPipelineTestBase::SetUp();
+
+        createMediaPipeline();
+    }
+
+    virtual void TearDown()
+    {
+        destroyMediaPipeline();
+
+        MediaPipelineTestBase::TearDown();
+    }
+};
+
+/**
+ * Test that getMute returns success if the IPC API succeeds.
+ */
+TEST_F(RialtoClientMediaPipelineGetMuteTest, getMuteSuccess)
+{
+    EXPECT_CALL(*m_mediaPipelineIpcMock, getMute(m_mute)).WillOnce(Return(true));
+
+    EXPECT_EQ(m_mediaPipeline->getMute(m_mute), true);
+}
+
+/**
+ * Test that getMute returns failure if the IPC API fails.
+ */
+TEST_F(RialtoClientMediaPipelineGetMuteTest, getMuteFailure)
+{
+    EXPECT_CALL(*m_mediaPipelineIpcMock, getMute(m_mute)).WillOnce(Return(false));
+
+    EXPECT_EQ(m_mediaPipeline->getMute(m_mute), false);
+}

--- a/tests/media/client/main/mediaPipeline/SetMuteTest.cpp
+++ b/tests/media/client/main/mediaPipeline/SetMuteTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MediaPipelineTestBase.h"
+
+class RialtoClientMediaPipelineSetMuteTest : public MediaPipelineTestBase
+{
+protected:
+    const bool m_kMute{false};
+
+    virtual void SetUp()
+    {
+        MediaPipelineTestBase::SetUp();
+
+        createMediaPipeline();
+    }
+
+    virtual void TearDown()
+    {
+        destroyMediaPipeline();
+
+        MediaPipelineTestBase::TearDown();
+    }
+};
+
+/**
+ * Test that setMute returns success if the IPC API succeeds.
+ */
+TEST_F(RialtoClientMediaPipelineSetMuteTest, setMuteSuccess)
+{
+    EXPECT_CALL(*m_mediaPipelineIpcMock, setMute(m_kMute)).WillOnce(Return(true));
+
+    EXPECT_EQ(m_mediaPipeline->setMute(m_kMute), true);
+}
+
+/**
+ * Test that setMute returns failure if the IPC API fails.
+ */
+TEST_F(RialtoClientMediaPipelineSetMuteTest, setMuteFailure)
+{
+    EXPECT_CALL(*m_mediaPipelineIpcMock, setMute(m_kMute)).WillOnce(Return(false));
+
+    EXPECT_EQ(m_mediaPipeline->setMute(m_kMute), false);
+}

--- a/tests/media/client/mocks/ipc/MediaPipelineIpcMock.h
+++ b/tests/media/client/mocks/ipc/MediaPipelineIpcMock.h
@@ -49,6 +49,8 @@ public:
     MOCK_METHOD(bool, renderFrame, (), (override));
     MOCK_METHOD(bool, setVolume, (double volume), (override));
     MOCK_METHOD(bool, getVolume, (double &volume), (override));
+    MOCK_METHOD(bool, setMute, (bool mute), (override));
+    MOCK_METHOD(bool, getMute, (bool &mute), (override));
 };
 } // namespace firebolt::rialto::client
 

--- a/tests/media/server/gstplayer/CMakeLists.txt
+++ b/tests/media/server/gstplayer/CMakeLists.txt
@@ -42,6 +42,7 @@ add_gtests(RialtoServerGstPlayerUnitTests
     genericPlayer/tasksTests/SetupSourceTest.cpp
     genericPlayer/tasksTests/SetVideoGeometryTest.cpp
     genericPlayer/tasksTests/SetVolumeTest.cpp
+    genericPlayer/tasksTests/SetMuteTest.cpp
     genericPlayer/tasksTests/ShutdownTest.cpp
     genericPlayer/tasksTests/StopTest.cpp
     genericPlayer/tasksTests/UnderflowTest.cpp

--- a/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -266,3 +266,12 @@ TEST_F(GstGenericPlayerTest, shouldReturnVolume)
     EXPECT_TRUE(m_sut->getVolume(resultVolume));
     EXPECT_EQ(resultVolume, kVolume);
 }
+
+TEST_F(GstGenericPlayerTest, shouldReturnMute)
+{
+    constexpr bool kMute{false};
+    bool resultMute{};
+    EXPECT_CALL(*m_gstWrapperMock, gstStreamVolumeGetMute(_)).WillOnce(Return(kMute));
+    EXPECT_TRUE(m_sut->getMute(resultMute));
+    EXPECT_EQ(resultMute, kMute);
+}

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
@@ -39,6 +39,7 @@
 #include "tasks/generic/ReadShmDataAndAttachSamples.h"
 #include "tasks/generic/RemoveSource.h"
 #include "tasks/generic/ReportPosition.h"
+#include "tasks/generic/SetMute.h"
 #include "tasks/generic/SetPlaybackRate.h"
 #include "tasks/generic/SetPosition.h"
 #include "tasks/generic/SetVideoGeometry.h"
@@ -209,6 +210,14 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetVolume)
     auto task = m_sut.createSetVolume(m_context, kVolume);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::SetVolume &>(*task));
+}
+
+TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetMute)
+{
+    constexpr bool kMute{false};
+    auto task = m_sut.createSetMute(m_context, kMute);
+    EXPECT_NE(task, nullptr);
+    EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::SetMute &>(*task));
 }
 
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateShutdown)

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/SetMuteTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/SetMuteTest.cpp
@@ -1,0 +1,58 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tasks/generic/SetMute.h"
+#include "GenericPlayerContext.h"
+#include "GstWrapperMock.h"
+#include <gst/gst.h>
+#include <gtest/gtest.h>
+
+using testing::_;
+using testing::Return;
+using testing::StrictMock;
+
+namespace
+{
+constexpr bool kMute{false};
+} // namespace
+
+class SetMuteTest : public testing::Test
+{
+public:
+    SetMuteTest() = default;
+
+    firebolt::rialto::server::GenericPlayerContext m_context;
+    std::shared_ptr<firebolt::rialto::server::GstWrapperMock> m_gstWrapper{
+        std::make_shared<StrictMock<firebolt::rialto::server::GstWrapperMock>>()};
+    GstElement m_pipeline{};
+};
+
+TEST_F(SetMuteTest, shouldFailToSetMuteWhenPipelineIsNull)
+{
+    firebolt::rialto::server::tasks::generic::SetMute task{m_context, m_gstWrapper, kMute};
+    task.execute();
+}
+
+TEST_F(SetMuteTest, shouldSetMute)
+{
+    m_context.pipeline = &m_pipeline;
+    EXPECT_CALL(*m_gstWrapper, gstStreamVolumeSetMute(_, kMute));
+    firebolt::rialto::server::tasks::generic::SetMute task{m_context, m_gstWrapper, kMute};
+    task.execute();
+}

--- a/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTests.cpp
+++ b/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTests.cpp
@@ -296,3 +296,27 @@ TEST_F(MediaPipelineModuleServiceTests, shouldFailToGetVolume)
     mediaPipelineServiceWillFailToGetVolume();
     sendGetVolumeRequestAndReceiveResponseWithoutVolumeMatch();
 }
+
+TEST_F(MediaPipelineModuleServiceTests, shouldSetMute)
+{
+    mediaPipelineServiceWillSetMute();
+    sendSetMuteRequestAndReceiveResponse();
+}
+
+TEST_F(MediaPipelineModuleServiceTests, shouldFailToSetMute)
+{
+    mediaPipelineServiceWillFailToSetMute();
+    sendSetMuteRequestAndReceiveResponse();
+}
+
+TEST_F(MediaPipelineModuleServiceTests, shouldGetMute)
+{
+    mediaPipelineServiceWillGetMute();
+    sendGetMuteRequestAndReceiveResponse();
+}
+
+TEST_F(MediaPipelineModuleServiceTests, shouldFailToGetMute)
+{
+    mediaPipelineServiceWillFailToGetMute();
+    sendGetMuteRequestAndReceiveResponseWithoutMuteMatch();
+}

--- a/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
+++ b/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
@@ -65,6 +65,7 @@ constexpr firebolt::rialto::NetworkState networkState{firebolt::rialto::NetworkS
 constexpr firebolt::rialto::QosInfo qosInfo{5u, 2u};
 constexpr double rate{1.5};
 constexpr double volume{0.7};
+constexpr bool mute{false};
 } // namespace
 
 MATCHER_P(AttachedSourceMatcher, source, "")
@@ -598,6 +599,36 @@ void MediaPipelineModuleServiceTests::mediaPipelineServiceWillFailToGetVolume()
     EXPECT_CALL(m_mediaPipelineServiceMock, getVolume(hardcodedSessionId, _)).WillOnce(Return(false));
 }
 
+void MediaPipelineModuleServiceTests::mediaPipelineServiceWillSetMute()
+{
+    expectRequestSuccess();
+    EXPECT_CALL(m_mediaPipelineServiceMock, setMute(hardcodedSessionId, mute)).WillOnce(Return(true));
+}
+
+void MediaPipelineModuleServiceTests::mediaPipelineServiceWillFailToSetMute()
+{
+    expectRequestFailure();
+    EXPECT_CALL(m_mediaPipelineServiceMock, setMute(hardcodedSessionId, mute)).WillOnce(Return(false));
+}
+
+void MediaPipelineModuleServiceTests::mediaPipelineServiceWillGetMute()
+{
+    expectRequestSuccess();
+    EXPECT_CALL(m_mediaPipelineServiceMock, getMute(hardcodedSessionId, _))
+        .WillOnce(Invoke(
+            [&](int, bool &mut)
+            {
+                mut = mute;
+                return true;
+            }));
+}
+
+void MediaPipelineModuleServiceTests::mediaPipelineServiceWillFailToGetMute()
+{
+    expectRequestFailure();
+    EXPECT_CALL(m_mediaPipelineServiceMock, getMute(hardcodedSessionId, _)).WillOnce(Return(false));
+}
+
 void MediaPipelineModuleServiceTests::mediaClientWillSendPlaybackStateChangedEvent()
 {
     EXPECT_CALL(*m_clientMock, sendEvent(PlaybackStateChangeEventMatcher(convertPlaybackState(playbackState))));
@@ -892,6 +923,39 @@ void MediaPipelineModuleServiceTests::sendGetVolumeRequestAndReceiveResponseWith
     request.set_session_id(hardcodedSessionId);
 
     m_service->getVolume(m_controllerMock.get(), &request, &response, m_closureMock.get());
+}
+
+void MediaPipelineModuleServiceTests::sendSetMuteRequestAndReceiveResponse()
+{
+    firebolt::rialto::SetMuteRequest request;
+    firebolt::rialto::SetMuteResponse response;
+
+    request.set_session_id(hardcodedSessionId);
+    request.set_mute(mute);
+
+    m_service->setMute(m_controllerMock.get(), &request, &response, m_closureMock.get());
+}
+
+void MediaPipelineModuleServiceTests::sendGetMuteRequestAndReceiveResponse()
+{
+    firebolt::rialto::GetMuteRequest request;
+    firebolt::rialto::GetMuteResponse response;
+
+    request.set_session_id(hardcodedSessionId);
+
+    m_service->getMute(m_controllerMock.get(), &request, &response, m_closureMock.get());
+
+    EXPECT_EQ(response.mute(), mute);
+}
+
+void MediaPipelineModuleServiceTests::sendGetMuteRequestAndReceiveResponseWithoutMuteMatch()
+{
+    firebolt::rialto::GetMuteRequest request;
+    firebolt::rialto::GetMuteResponse response;
+
+    request.set_session_id(hardcodedSessionId);
+
+    m_service->getMute(m_controllerMock.get(), &request, &response, m_closureMock.get());
 }
 
 void MediaPipelineModuleServiceTests::sendPlaybackStateChangedEvent()

--- a/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.h
+++ b/tests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.h
@@ -74,6 +74,10 @@ public:
     void mediaPipelineServiceWillFailToSetVolume();
     void mediaPipelineServiceWillGetVolume();
     void mediaPipelineServiceWillFailToGetVolume();
+    void mediaPipelineServiceWillSetMute();
+    void mediaPipelineServiceWillFailToSetMute();
+    void mediaPipelineServiceWillGetMute();
+    void mediaPipelineServiceWillFailToGetMute();
     void mediaClientWillSendPlaybackStateChangedEvent();
     void mediaClientWillSendNetworkStateChangedEvent();
     void mediaClientWillSendNeedMediaDataEvent(int sessionId);
@@ -103,6 +107,9 @@ public:
     void sendSetVolumeRequestAndReceiveResponse();
     void sendGetVolumeRequestAndReceiveResponse();
     void sendGetVolumeRequestAndReceiveResponseWithoutVolumeMatch();
+    void sendSetMuteRequestAndReceiveResponse();
+    void sendGetMuteRequestAndReceiveResponse();
+    void sendGetMuteRequestAndReceiveResponseWithoutMuteMatch();
     void sendPlaybackStateChangedEvent();
     void sendNetworkStateChangedEvent();
     void sendNeedMediaDataEvent();

--- a/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
+++ b/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
@@ -321,6 +321,71 @@ TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, GetVolumeSuccess)
 }
 
 /**
+ * Test that SetMute returns failure if the gstreamer player is not initialized
+ */
+TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetMuteFailureDueToUninitializedPlayer)
+{
+    const bool kMute{false};
+    mainThreadWillEnqueueTaskAndWait();
+    EXPECT_FALSE(m_mediaPipeline->setMute(kMute));
+}
+
+/**
+ * Test that SetMute returns failure if the gstreamer player is not initialized
+ */
+TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetMuteSuccess)
+{
+    const bool kMute{false};
+    loadGstPlayer();
+    mainThreadWillEnqueueTaskAndWait();
+
+    EXPECT_CALL(*m_gstPlayerMock, setMute(kMute));
+    EXPECT_TRUE(m_mediaPipeline->setMute(kMute));
+}
+
+/**
+ * Test that GetMute returns failure if the gstreamer player is not initialized
+ */
+TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, GetMuteFailureDueToUninitializedPlayer)
+{
+    mainThreadWillEnqueueTaskAndWait();
+    bool resultMute{};
+    EXPECT_FALSE(m_mediaPipeline->getMute(resultMute));
+}
+
+/**
+ * Test that GetMute returns failure if the gstreamer API fails
+ */
+TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, GetMuteFailure)
+{
+    loadGstPlayer();
+    mainThreadWillEnqueueTaskAndWait();
+    bool resultMute{};
+    EXPECT_CALL(*m_gstPlayerMock, getMute(_)).WillOnce(Return(false));
+    EXPECT_FALSE(m_mediaPipeline->getMute(resultMute));
+}
+
+/**
+ * Test that GetMute returns success if the gstreamer API succeeds and gets mute
+ */
+TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, GetMuteSuccess)
+{
+    constexpr bool kCurrentMute{false};
+    bool resultMute{};
+
+    loadGstPlayer();
+    mainThreadWillEnqueueTaskAndWait();
+    EXPECT_CALL(*m_gstPlayerMock, getMute(_))
+        .WillOnce(Invoke(
+            [&](bool &mut)
+            {
+                mut = kCurrentMute;
+                return true;
+            }));
+    EXPECT_TRUE(m_mediaPipeline->getMute(resultMute));
+    EXPECT_EQ(resultMute, kCurrentMute);
+}
+/**
  * Test that active requests are invalidated successfully
  */
 TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, InvalidateActiveRequestsSuccess)

--- a/tests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
+++ b/tests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
@@ -81,6 +81,8 @@ public:
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetVolume, (GenericPlayerContext & context, double volume),
                 (const, override));
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetMute, (GenericPlayerContext & context, bool mute),
+                (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createShutdown, (IGstGenericPlayerPrivate & player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createStop,
                 (GenericPlayerContext & context, IGstGenericPlayerPrivate &player), (const, override));

--- a/tests/media/server/mocks/gstplayer/GstGenericPlayerMock.h
+++ b/tests/media/server/mocks/gstplayer/GstGenericPlayerMock.h
@@ -49,6 +49,8 @@ public:
     MOCK_METHOD(void, renderFrame, (), (override));
     MOCK_METHOD(void, setVolume, (double volume), (override));
     MOCK_METHOD(bool, getVolume, (double &volume), (override));
+    MOCK_METHOD(void, setMute, (bool mute), (override));
+    MOCK_METHOD(bool, getMute, (bool &mute), (override));
 };
 } // namespace firebolt::rialto::server
 

--- a/tests/media/server/mocks/gstplayer/GstWrapperMock.h
+++ b/tests/media/server/mocks/gstplayer/GstWrapperMock.h
@@ -163,6 +163,8 @@ public:
                 (const, override));
     MOCK_METHOD(void, gstStreamVolumeSetVolume, (GstStreamVolume * volume, GstStreamVolumeFormat format, gdouble val),
                 (const, override));
+    MOCK_METHOD(gboolean, gstStreamVolumeGetMute, (GstStreamVolume * volume), (const, override));
+    MOCK_METHOD(void, gstStreamVolumeSetMute, (GstStreamVolume * volume, gboolean mute), (const, override));
     MOCK_METHOD(GstElement *, gstPipelineNew, (const gchar *name), (const, override));
     MOCK_METHOD(GstPluginFeature *, gstRegistryLookupFeature, (GstRegistry * registry, const char *name),
                 (const, override));

--- a/tests/media/server/mocks/main/MediaPipelineServerInternalMock.h
+++ b/tests/media/server/mocks/main/MediaPipelineServerInternalMock.h
@@ -50,6 +50,8 @@ public:
                 (uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment), (override));
     MOCK_METHOD(bool, setVolume, (double volume), (override));
     MOCK_METHOD(bool, getVolume, (double &volume), (override));
+    MOCK_METHOD(bool, setMute, (bool mute), (override));
+    MOCK_METHOD(bool, getMute, (bool &mute), (override));
 };
 } // namespace firebolt::rialto::server
 

--- a/tests/media/server/mocks/service/MediaPipelineServiceMock.h
+++ b/tests/media/server/mocks/service/MediaPipelineServiceMock.h
@@ -49,6 +49,8 @@ public:
     MOCK_METHOD(bool, renderFrame, (int), (override));
     MOCK_METHOD(bool, setVolume, (int sessionId, double volume), (override));
     MOCK_METHOD(bool, getVolume, (int sessionId, double &volume), (override));
+    MOCK_METHOD(bool, setMute, (int sessionId, bool mute), (override));
+    MOCK_METHOD(bool, getMute, (int sessionId, bool &mute), (override));
     MOCK_METHOD(std::vector<std::string>, getSupportedMimeTypes, (MediaSourceType type), (override));
     MOCK_METHOD(bool, isMimeTypeSupported, (const std::string &mimeType), (override));
 };

--- a/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTests.cpp
+++ b/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTests.cpp
@@ -393,3 +393,43 @@ TEST_F(MediaPipelineServiceTests, shouldGetVolume)
     mediaPipelineWillGetVolume();
     getVolumeShouldSucceed();
 }
+
+TEST_F(MediaPipelineServiceTests, shouldFailToSetMuteForNotExistingSession)
+{
+    createMediaPipelineShouldSuccess();
+    setMuteShouldFail();
+}
+
+TEST_F(MediaPipelineServiceTests, shouldFailToSetMute)
+{
+    initSession();
+    mediaPipelineWillFailToSetMute();
+    setMuteShouldFail();
+}
+
+TEST_F(MediaPipelineServiceTests, shouldSetMute)
+{
+    initSession();
+    mediaPipelineWillSetMute();
+    setMuteShouldSucceed();
+}
+
+TEST_F(MediaPipelineServiceTests, shouldFailToGetMuteForNotExistingSession)
+{
+    createMediaPipelineShouldSuccess();
+    getMuteShouldFail();
+}
+
+TEST_F(MediaPipelineServiceTests, shouldFailToGetMute)
+{
+    initSession();
+    mediaPipelineWillFailToGetMute();
+    getMuteShouldFail();
+}
+
+TEST_F(MediaPipelineServiceTests, shouldGetMute)
+{
+    initSession();
+    mediaPipelineWillGetMute();
+    getMuteShouldSucceed();
+}

--- a/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTestsFixture.cpp
+++ b/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTestsFixture.cpp
@@ -48,6 +48,7 @@ constexpr firebolt::rialto::MediaSourceStatus status{firebolt::rialto::MediaSour
 constexpr std::uint32_t needDataRequestId{17};
 constexpr std::uint32_t numFrames{1};
 constexpr double volume{0.7};
+constexpr bool mute{false};
 } // namespace
 
 namespace firebolt::rialto
@@ -234,6 +235,32 @@ void MediaPipelineServiceTests::mediaPipelineWillGetVolume()
 void MediaPipelineServiceTests::mediaPipelineWillFailToGetVolume()
 {
     EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(Return(false));
+}
+
+void MediaPipelineServiceTests::mediaPipelineWillSetMute()
+{
+    EXPECT_CALL(m_mediaPipelineMock, setMute(_)).WillOnce(Return(true));
+}
+
+void MediaPipelineServiceTests::mediaPipelineWillFailToSetMute()
+{
+    EXPECT_CALL(m_mediaPipelineMock, setMute(_)).WillOnce(Return(false));
+}
+
+void MediaPipelineServiceTests::mediaPipelineWillGetMute()
+{
+    EXPECT_CALL(m_mediaPipelineMock, getMute(_))
+        .WillOnce(Invoke(
+            [&](bool &mut)
+            {
+                mut = mute;
+                return true;
+            }));
+}
+
+void MediaPipelineServiceTests::mediaPipelineWillFailToGetMute()
+{
+    EXPECT_CALL(m_mediaPipelineMock, getMute(_)).WillOnce(Return(false));
 }
 
 void MediaPipelineServiceTests::mediaPipelineFactoryWillCreateMediaPipeline()
@@ -486,6 +513,28 @@ void MediaPipelineServiceTests::getVolumeShouldFail()
     EXPECT_FALSE(m_sut->getVolume(sessionId, targetVolume));
 }
 
+void MediaPipelineServiceTests::setMuteShouldSucceed()
+{
+    EXPECT_TRUE(m_sut->setMute(sessionId, mute));
+}
+
+void MediaPipelineServiceTests::setMuteShouldFail()
+{
+    EXPECT_FALSE(m_sut->setMute(sessionId, mute));
+}
+
+void MediaPipelineServiceTests::getMuteShouldSucceed()
+{
+    bool targetMute{};
+    EXPECT_TRUE(m_sut->getMute(sessionId, targetMute));
+    EXPECT_EQ(targetMute, mute);
+}
+
+void MediaPipelineServiceTests::getMuteShouldFail()
+{
+    bool targetMute{};
+    EXPECT_FALSE(m_sut->getMute(sessionId, targetMute));
+}
 void MediaPipelineServiceTests::clearMediaPipelines()
 {
     m_sut->clearMediaPipelines();

--- a/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTestsFixture.h
+++ b/tests/media/server/service/mediaPipelineService/MediaPipelineServiceTestsFixture.h
@@ -69,6 +69,10 @@ public:
     void mediaPipelineWillFailToSetVolume();
     void mediaPipelineWillGetVolume();
     void mediaPipelineWillFailToGetVolume();
+    void mediaPipelineWillSetMute();
+    void mediaPipelineWillFailToSetMute();
+    void mediaPipelineWillGetMute();
+    void mediaPipelineWillFailToGetMute();
 
     void mediaPipelineFactoryWillCreateMediaPipeline();
     void mediaPipelineFactoryWillReturnNullptr();
@@ -117,6 +121,10 @@ public:
     void setVolumeShouldFail();
     void getVolumeShouldSucceed();
     void getVolumeShouldFail();
+    void setMuteShouldSucceed();
+    void setMuteShouldFail();
+    void getMuteShouldSucceed();
+    void getMuteShouldFail();
     void clearMediaPipelines();
     void initSession();
 


### PR DESCRIPTION
Summary: RialtoMSEAudioSink should implement 'mute' from interface 'GstStreamVolume'
Type: Error Fix
Test Plan: Unit Tests
Jira: RIALTO-167