### PR TITLE
Handle pause during underflow and fix mediaKeys coredump

### DIFF
--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -220,6 +220,11 @@ struct GenericPlayerContext
      * Attribute can be used only in worker thread
      */
     bool wereAllSourcesAttached{false};
+
+    /**
+     * @brief Flag used to check if client is expecting playback to resume when recovering from an underflow.
+     */
+    bool resumeOnUnderflowRecovery{false};
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -680,7 +680,12 @@ void GstGenericPlayer::cancelUnderflow(bool &underflowFlag)
     underflowFlag = false;
     if (!m_context.audioUnderflowOccured && !m_context.videoUnderflowOccured)
     {
-        m_taskFactory->createPlay(*this)->execute();
+        if (m_context.resumeOnUnderflowRecovery)
+        {
+            // Resume if the client hasnt requested pause during the underflow
+            m_taskFactory->createPlay(*this)->execute();
+            m_context.resumeOnUnderflowRecovery = false;
+        }
         m_gstPlayerClient->notifyNetworkState(NetworkState::BUFFERED);
     }
 }

--- a/media/server/gstplayer/source/tasks/generic/Pause.cpp
+++ b/media/server/gstplayer/source/tasks/generic/Pause.cpp
@@ -36,6 +36,13 @@ Pause::~Pause()
 void Pause::execute() const
 {
     RIALTO_SERVER_LOG_DEBUG("Executing Pause");
+    if (m_context.videoUnderflowOccured || m_context.audioUnderflowOccured)
+    {
+        RIALTO_SERVER_LOG_INFO("Rialto is handling underflow, pipeline already paused");
+
+        // Playback should not resume when buffered
+        m_context.resumeOnUnderflowRecovery = false;
+    }
     m_player.stopPositionReportingAndCheckAudioUnderflowTimer();
     m_player.changePipelineState(GST_STATE_PAUSED);
     m_context.isPlaying = false;

--- a/media/server/gstplayer/source/tasks/generic/Underflow.cpp
+++ b/media/server/gstplayer/source/tasks/generic/Underflow.cpp
@@ -62,8 +62,6 @@ void Underflow::execute() const
     }
     else
     {
-        m_underflowFlag = true;
-
         Pause pauseTask{m_context, m_player};
         pauseTask.execute();
 

--- a/media/server/gstplayer/source/tasks/generic/Underflow.cpp
+++ b/media/server/gstplayer/source/tasks/generic/Underflow.cpp
@@ -49,7 +49,6 @@ void Underflow::execute() const
     {
         return;
     }
-    m_underflowFlag = true;
 
     // If the EOS has been raised, notify EndOfStream, not underflow.
     if (allSourcesEos())
@@ -65,6 +64,9 @@ void Underflow::execute() const
     {
         Pause pauseTask{m_context, m_player};
         pauseTask.execute();
+
+        m_underflowFlag = true;
+        m_context.resumeOnUnderflowRecovery = true;
         if (m_gstPlayerClient)
         {
             m_gstPlayerClient->notifyNetworkState(NetworkState::STALLED);

--- a/media/server/main/interface/IDecryptionService.h
+++ b/media/server/main/interface/IDecryptionService.h
@@ -36,7 +36,7 @@ public:
     virtual MediaKeyErrorStatus decrypt(int32_t keySessionId, GstBuffer *encrypted, GstBuffer *subSample,
                                         const uint32_t subSampleCount, GstBuffer *IV, GstBuffer *keyId,
                                         uint32_t initWithLast15, GstCaps *caps) = 0;
-    virtual bool isNetflixKeySystem(int32_t keySessionId) const = 0;
+    virtual bool isNetflixKeySystem(int32_t keySessionId) = 0;
     virtual MediaKeyErrorStatus selectKeyId(int32_t keySessionId, const std::vector<uint8_t> &keyId) = 0;
     virtual void incrementSessionIdUsageCounter(int32_t keySessionId) = 0;
     virtual void decrementSessionIdUsageCounter(int32_t keySessionId) = 0;

--- a/media/server/service/source/CdmService.cpp
+++ b/media/server/service/source/CdmService.cpp
@@ -461,7 +461,7 @@ MediaKeyErrorStatus CdmService::decrypt(int32_t keySessionId, GstBuffer *encrypt
                                           caps);
 }
 
-bool CdmService::isNetflixKeySystem(int32_t keySessionId) const
+bool CdmService::isNetflixKeySystem(int32_t keySessionId)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to check if key system is Netflix, key session id: %d", keySessionId);
 

--- a/media/server/service/source/CdmService.cpp
+++ b/media/server/service/source/CdmService.cpp
@@ -243,6 +243,8 @@ MediaKeyErrorStatus CdmService::getCdmKeySessionId(int mediaKeysHandle, int32_t 
 bool CdmService::containsKey(int mediaKeysHandle, int32_t keySessionId, const std::vector<uint8_t> &keyId)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to check if key is present: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -257,6 +259,8 @@ MediaKeyErrorStatus CdmService::setDrmHeader(int mediaKeysHandle, int32_t keySes
                                              const std::vector<uint8_t> &requestData)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to set drm header: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -270,6 +274,8 @@ MediaKeyErrorStatus CdmService::setDrmHeader(int mediaKeysHandle, int32_t keySes
 MediaKeyErrorStatus CdmService::deleteDrmStore(int mediaKeysHandle)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to delete drm store: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -282,6 +288,8 @@ MediaKeyErrorStatus CdmService::deleteDrmStore(int mediaKeysHandle)
 MediaKeyErrorStatus CdmService::deleteKeyStore(int mediaKeysHandle)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to delete key store: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -295,6 +303,8 @@ MediaKeyErrorStatus CdmService::deleteKeyStore(int mediaKeysHandle)
 MediaKeyErrorStatus CdmService::getDrmStoreHash(int mediaKeysHandle, std::vector<unsigned char> &drmStoreHash)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to get drm store hash: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -307,6 +317,8 @@ MediaKeyErrorStatus CdmService::getDrmStoreHash(int mediaKeysHandle, std::vector
 MediaKeyErrorStatus CdmService::getKeyStoreHash(int mediaKeysHandle, std::vector<unsigned char> &keyStoreHash)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to get key store hash: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -319,6 +331,8 @@ MediaKeyErrorStatus CdmService::getKeyStoreHash(int mediaKeysHandle, std::vector
 MediaKeyErrorStatus CdmService::getLdlSessionsLimit(int mediaKeysHandle, uint32_t &ldlLimit)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to get ldl sessions limit: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -331,6 +345,8 @@ MediaKeyErrorStatus CdmService::getLdlSessionsLimit(int mediaKeysHandle, uint32_
 MediaKeyErrorStatus CdmService::getLastDrmError(int mediaKeysHandle, int32_t keySessionId, uint32_t &errorCode)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to get last drm error: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -343,6 +359,8 @@ MediaKeyErrorStatus CdmService::getLastDrmError(int mediaKeysHandle, int32_t key
 MediaKeyErrorStatus CdmService::getDrmTime(int mediaKeysHandle, uint64_t &drmTime)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to get drm time: %d", mediaKeysHandle);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = m_mediaKeys.find(mediaKeysHandle);
     if (mediaKeysIter == m_mediaKeys.end())
     {
@@ -446,6 +464,8 @@ MediaKeyErrorStatus CdmService::decrypt(int32_t keySessionId, GstBuffer *encrypt
 bool CdmService::isNetflixKeySystem(int32_t keySessionId) const
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to check if key system is Netflix, key session id: %d", keySessionId);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = std::find_if(m_mediaKeys.begin(), m_mediaKeys.end(),
                                       [&](const auto &iter) { return iter.second->hasSession(keySessionId); });
     if (mediaKeysIter == m_mediaKeys.end())
@@ -459,6 +479,8 @@ bool CdmService::isNetflixKeySystem(int32_t keySessionId) const
 MediaKeyErrorStatus CdmService::selectKeyId(int32_t keySessionId, const std::vector<uint8_t> &keyId)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to select key id, key session id: %d", keySessionId);
+
+    std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
     auto mediaKeysIter = std::find_if(m_mediaKeys.begin(), m_mediaKeys.end(),
                                       [&](const auto &iter) { return iter.second->hasSession(keySessionId); });
     if (mediaKeysIter == m_mediaKeys.end())

--- a/media/server/service/source/CdmService.h
+++ b/media/server/service/source/CdmService.h
@@ -75,7 +75,7 @@ public:
     MediaKeyErrorStatus decrypt(int32_t keySessionId, GstBuffer *encrypted, GstBuffer *subSample,
                                 const uint32_t subSampleCount, GstBuffer *IV, GstBuffer *keyId, uint32_t initWithLast15,
                                 GstCaps *caps) override;
-    bool isNetflixKeySystem(int32_t keySessionId) const override;
+    bool isNetflixKeySystem(int32_t keySessionId) override;
     MediaKeyErrorStatus selectKeyId(int32_t keySessionId, const std::vector<uint8_t> &keyId) override;
     void incrementSessionIdUsageCounter(int32_t keySessionId) override;
     void decrementSessionIdUsageCounter(int32_t keySessionId) override;

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/PauseTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/PauseTest.cpp
@@ -40,3 +40,17 @@ TEST_F(PauseTest, shouldPause)
 
     EXPECT_FALSE(m_context.isPlaying);
 }
+
+TEST_F(PauseTest, shouldPauseDuringUnderflow)
+{
+    m_context.isPlaying = true;
+    m_context.videoUnderflowOccured = true;
+    m_context.resumeOnUnderflowRecovery = true;
+    EXPECT_CALL(m_gstPlayer, stopPositionReportingAndCheckAudioUnderflowTimer());
+    EXPECT_CALL(m_gstPlayer, changePipelineState(GST_STATE_PAUSED));
+    firebolt::rialto::server::tasks::generic::Pause task{m_context, m_gstPlayer};
+    task.execute();
+
+    EXPECT_FALSE(m_context.isPlaying);
+    EXPECT_FALSE(m_context.resumeOnUnderflowRecovery);
+}

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/UnderflowTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/UnderflowTest.cpp
@@ -66,6 +66,8 @@ TEST_F(UnderflowTest, shouldReportUnderflow)
 {
     bool underflowFlag{false};
     bool underflowEnabled{true};
+    m_context.resumeOnUnderflowRecovery = false;
+
     firebolt::rialto::server::tasks::generic::Underflow task{m_context, m_gstPlayer, &m_gstPlayerClient, underflowFlag,
                                                              underflowEnabled};
     EXPECT_CALL(m_gstPlayer, stopPositionReportingAndCheckAudioUnderflowTimer());
@@ -73,6 +75,7 @@ TEST_F(UnderflowTest, shouldReportUnderflow)
     EXPECT_CALL(m_gstPlayerClient, notifyNetworkState(firebolt::rialto::NetworkState::STALLED));
     task.execute();
     EXPECT_TRUE(underflowFlag);
+    EXPECT_TRUE(m_context.resumeOnUnderflowRecovery);
 }
 
 TEST_F(UnderflowTest, shouldNotReportEosWhenEosAlreadyNotified)

--- a/tests/media/server/mocks/main/DecryptionServiceMock.h
+++ b/tests/media/server/mocks/main/DecryptionServiceMock.h
@@ -35,7 +35,7 @@ public:
                 (int32_t keySessionId, GstBuffer *encrypted, GstBuffer *subSample, const uint32_t subSampleCount,
                  GstBuffer *IV, GstBuffer *keyId, uint32_t initWithLast15, GstCaps *caps),
                 (override));
-    MOCK_METHOD(bool, isNetflixKeySystem, (int32_t keySessionId), (const, override));
+    MOCK_METHOD(bool, isNetflixKeySystem, (int32_t keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, selectKeyId, (int32_t keySessionId, const std::vector<uint8_t> &keyId), (override));
     MOCK_METHOD(void, incrementSessionIdUsageCounter, (int32_t keySessionId), (override));
     MOCK_METHOD(void, decrementSessionIdUsageCounter, (int32_t keySessionId), (override));


### PR DESCRIPTION
Summary: Couple of fixes for issues seen on broadcom. Fixes the edge case where application is pausing playback during an underflow, playback should not resume on buffered. Fixes coredump seen during decryption, where some APIs were accessing m_mediaKeys while one is been deleted.
Type: BugFix
Test Plan: YouTube Cert Tests, Unittests
Jira: N/A