### PR TITLE
Disable xrun for amlhalasink

### DIFF
--- a/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
@@ -92,6 +92,11 @@ void SetupElement::execute() const
     {
         // Wait for video so that the audio aligns at the starting point with timeout of 4000ms.
         m_glibWrapper->gObjectSet(m_element, "wait-video", TRUE, "a-wait-timeout", 4000, nullptr);
+
+        // Xrun occasionally pauses the underlying sink due to unstable playback, but the rest of the pipeline
+        // remains in the playing state. This causes problems with the synchronization of gst element and rialto
+        // ultimately hangs waiting for pipeline termination.
+        m_glibWrapper->gObjectSet(m_element, "disable-xrun", TRUE, nullptr);
     }
 
     if (isVideoDecoder(*m_gstWrapper, m_element))

--- a/tests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
+++ b/tests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
@@ -140,7 +140,7 @@ TEST_F(SetupElementTest, shouldSetupVideoElementWithPendingGeometry)
     task.execute();
 }
 
-TEST_F(SetupElementTest, shouldSetupVideoElementWithWaitVideo)
+TEST_F(SetupElementTest, shouldSetupVideoElementForAmlhalasink)
 {
     firebolt::rialto::server::tasks::generic::SetupElement task{m_context, m_gstWrapper, m_glibWrapper, m_gstPlayer,
                                                                 &m_element};
@@ -148,6 +148,7 @@ TEST_F(SetupElementTest, shouldSetupVideoElementWithWaitVideo)
     EXPECT_CALL(*m_glibWrapper, gStrHasPrefix(_, CharStrMatcher("amlhalasink"))).WillOnce(Return(true));
     EXPECT_CALL(*m_glibWrapper, gObjectSetStub(G_OBJECT(&m_element), CharStrMatcher("wait-video")));
     EXPECT_CALL(*m_glibWrapper, gObjectSetStub(G_OBJECT(&m_element), CharStrMatcher("a-wait-timeout")));
+    EXPECT_CALL(*m_glibWrapper, gObjectSetStub(G_OBJECT(&m_element), CharStrMatcher("disable-xrun")));
     expectSetupVideoElement();
     task.execute();
 }


### PR DESCRIPTION
Summary: Rialto was hanging because the amlhalasink sink in the server pipeline was been paused by xrun, while the rest of the pipeline remained playing. This causes issues with the termination of the pipeline as the elements states are not synchronised. The approach of disabling xrun is the same as that in wpe webkit RDKTV-16244.
Type: BugFix
Test Plan: YouTube Cert Tests
Jira: RIALTO-231