### PR TITLE
Fix memcpy to shared memory

### DIFF
--- a/media/client/main/source/WebAudioPlayer.cpp
+++ b/media/client/main/source/WebAudioPlayer.cpp
@@ -201,7 +201,7 @@ bool WebAudioPlayer::writeBuffer(const uint32_t numberOfFrames, void *data)
     }
     else
     {
-        std::memcpy(shmHandle->getShm() + m_webAudioShmInfo->offsetMain, data, m_webAudioShmInfo->lengthMain);
+        std::memcpy(shmHandle->getShm() + m_webAudioShmInfo->offsetMain, data, dataLength);
     }
     return m_webAudioPlayerIpc->writeBuffer(numberOfFrames);
 }


### PR DESCRIPTION
Summary: Coredump found when copying the buffers to the shared memory due to copying invalid data size.
Type: Bugfix
Test Plan: NPLB Tests
Jira: RIALTO-68