### PR TITLE
Add catagory name to gst logs

### DIFF
--- a/media/server/gstplayer/source/GstLogForwarding.cpp
+++ b/media/server/gstplayer/source/GstLogForwarding.cpp
@@ -81,7 +81,7 @@ void gstreamerLogFunction(GstDebugCategory *category, GstDebugLevel level, const
         break;
     }
     }
-    ss << "M:" << file << " F:" << function << ":" << line;
+    ss << "C:" << gst_debug_category_get_name(category) << " M:" << file << " F:" << function << ":" << line;
     if (object)
     {
         if (GST_IS_PAD(object) && GST_OBJECT_NAME(object) && GST_OBJECT_PARENT(object) &&


### PR DESCRIPTION
Summary: Print the category name of the logging component.
Type: Feature
Test Plan: Youtube Cert Tests
Jira: N/A