### PR TITLE
Remove valgrind caching

### DIFF
--- a/.github/workflows/build_ut.yml
+++ b/.github/workflows/build_ut.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Setup github for python 3.8
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/build_ut.yml
+++ b/.github/workflows/build_ut.yml
@@ -74,16 +74,9 @@ jobs:
           sudo make install
 
       # Installation of protobuf
-      - name: Install protobuf 
+      - name: Install protobuf
         run: |
           sudo apt-get install protobuf-compiler
-
-      # If this job was cancelled by protobuf install, the cache is likely corrupt
-      # See instructions on how to reset the cache - https://wiki.rdkcentral.com/display/ASP/Github+workflow+Failures
-      - name: Is Cancelled
-        if: cancelled()
-        run: |
-          echo "If this job was cancelled due to 'Install protobuf library' timeout, the cache is likely corrupt and needs deleting! (see https://wiki.rdkcentral.com/display/ASP/Github+workflow+Failures)" >> $GITHUB_STEP_SUMMARY
 
       # Run the build script
       - name: build_ut.py script

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -53,7 +53,7 @@ jobs:
 
       # Setup github for python 3.8
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -53,7 +53,7 @@ jobs:
 
       # Setup github for python 3.8
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/native_rialto_build.yml
+++ b/.github/workflows/native_rialto_build.yml
@@ -23,7 +23,6 @@ jobs:
           sudo apt-get install libunwind-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev libgstreamer1.0-dev
 
       - name: Install protobuf
-        timeout-minutes: 2
         run: |
           sudo apt-get install protobuf-compiler
 
@@ -47,7 +46,7 @@ jobs:
       - name: Upload Logs on Failure
         uses: actions/upload-artifact@v3
         if: failure()
-        with: 
+        with:
           name: Output Logs
           path: |
             output_file.txt

--- a/.github/workflows/valgrind_ut.yml
+++ b/.github/workflows/valgrind_ut.yml
@@ -37,45 +37,9 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
-  # This job downloads and caches valgrind to speed up execution
-  # An updated version of valgrind is required, the default version for ubuntu-18.04 is
-  # v3.13.0 which does not support F_ADD_SEALS.
-  download-valgrind:
-    name: Download and Cache Valgrind
-    # Runs on ubuntu
-    runs-on: ubuntu-22.04
-
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04 ]
-        
-    # Timeout after
-    timeout-minutes: 10
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    # Protobuf isnt cached if any steps fail, hence it is isolated in its own job
-    steps:
-      # Setup github for valgrind 3.19.0
-      - name: Cache valgrind library
-        id: cache-valgrind
-        uses: actions/cache@v3
-        with:
-          path: valgrind-3.19.0
-          key: ${{ runner.os }}-valgrind-${{ matrix.os }}
-      - name: Build valgrind library
-        if: steps.cache-valgrind.outputs.cache-hit != 'true'
-        run: |
-          wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2
-          tar xvf valgrind-3.19.0.tar.bz2
-          cd valgrind-3.19.0
-          ./configure
-          make
-
   # This job sets up the repo with the dependancies then runs the tests with valgrind
   valgrind-test:
     name: Build and test build_ut with valgrind
-    # Wait for protobuf and valgrind to be cached first
-    needs: [download-valgrind]
     # Runs on ubuntu
     runs-on: ubuntu-22.04
 
@@ -112,35 +76,13 @@ jobs:
         run: |
           sudo apt-get install libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-x gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio
 
-      # Setup valgrind 3.19.0
-      # Valgrind should always be cached here
-      - name: Cache valgrind library
-        id: cache-valgrind
-        uses: actions/cache@v3
-        with:
-          path: valgrind-3.19.0
-          key: ${{ runner.os }}-valgrind-${{ matrix.os }}
-      - name: Check cache
-        if: steps.cache-valgrind.outputs.cache-hit != 'true'
-        run: |
-          exit 1
-      - name: Install valgrind library
-        run: |
-          cd valgrind-3.19.0
-          sudo make install
-          sudo cp /usr/local/bin/valgrind /usr/bin/
-
       - name: Install protobuf
-        timeout-minutes: 2
         run: |
           sudo apt-get install protobuf-compiler
 
-      # If this job was cancelled by protobuf install, the cache is likely corrupt
-      # See instructions on how to reset the cache - https://wiki.rdkcentral.com/display/ASP/Github+workflow+Failures
-      - name: Is Cancelled
-        if: cancelled()
+      - name: Install valgrind library
         run: |
-          echo "If this job was cancelled due to 'Install protobuf library' timeout, the cache is likely corrupt and needs deleting! (see https://wiki.rdkcentral.com/display/ASP/Github+workflow+Failures)" >> $GITHUB_STEP_SUMMARY
+          sudo apt-get install valgrind
 
       # Run the build script with valgrind
       - name: Run unittests with valgrind

--- a/.github/workflows/valgrind_ut.yml
+++ b/.github/workflows/valgrind_ut.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Setup github for python 3.8
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 


### PR DESCRIPTION
Summary: Removes the caching of specific version of valgrind. Now that we have updated to Ubuntu 22 we can just install the recommended version.
Type: Feature
Test Plan: Valgrind UTs
Jira: RIALTO-263