### PR TITLE
treat setState timeout as failure

### DIFF
--- a/serverManager/common/source/SessionServerApp.cpp
+++ b/serverManager/common/source/SessionServerApp.cpp
@@ -261,7 +261,7 @@ void SessionServerApp::kill() const
 {
     if (m_pid > 0)
     {
-        m_linuxWrapper->kill(m_pid, SIGKILL);
+        m_linuxWrapper->kill(m_pid, SIGTERM);
     }
 }
 

--- a/serverManager/common/source/SessionServerAppManager.h
+++ b/serverManager/common/source/SessionServerAppManager.h
@@ -74,6 +74,8 @@ private:
     const std::unique_ptr<ISessionServerApp> &
     launchSessionServer(const std::string &appName, const firebolt::rialto::common::SessionServerState &initialState,
                         const firebolt::rialto::common::AppConfig &appConfig);
+    void handleStateChangeFailure(const std::unique_ptr<ISessionServerApp> &sessionServer,
+                                  const firebolt::rialto::common::SessionServerState &state);
     const std::unique_ptr<ISessionServerApp> &preloadSessionServer();
     const std::unique_ptr<ISessionServerApp> &getPreloadedServer() const;
     const std::unique_ptr<ISessionServerApp> &getServerByAppName(const std::string &appName) const;

--- a/tests/serverManager/unittests/common/SessionServerAppManagerTests.cpp
+++ b/tests/serverManager/unittests/common/SessionServerAppManagerTests.cpp
@@ -79,8 +79,21 @@ TEST_F(SessionServerAppManagerTests, SetSessionServerStateShouldReturnFalseWhenU
     sessionServerWillLaunch(firebolt::rialto::common::SessionServerState::INACTIVE);
     ASSERT_TRUE(triggerInitiateApplication(firebolt::rialto::common::SessionServerState::INACTIVE));
     sessionServerChangeStateWillFail(firebolt::rialto::common::SessionServerState::ACTIVE);
+    sessionServerWontBePreloaded();
+    sessionServerWillIndicateStateChange(firebolt::rialto::common::SessionServerState::ERROR);
     ASSERT_FALSE(triggerSetSessionServerState(firebolt::rialto::common::SessionServerState::ACTIVE));
     sessionServerWillKillRunningApplication();
+}
+
+TEST_F(SessionServerAppManagerTests, SetSessionServerStateToNotRunningShouldReturnFalseAndKillAppWhenUnableToSendMessage)
+{
+    sessionServerWillLaunch(firebolt::rialto::common::SessionServerState::INACTIVE);
+    ASSERT_TRUE(triggerInitiateApplication(firebolt::rialto::common::SessionServerState::INACTIVE));
+    sessionServerChangeStateWillFail(firebolt::rialto::common::SessionServerState::NOT_RUNNING);
+    sessionServerWillKillRunningApplication();
+    sessionServerWillIndicateStateChange(firebolt::rialto::common::SessionServerState::NOT_RUNNING);
+    clientWillBeRemoved();
+    ASSERT_FALSE(triggerSetSessionServerState(firebolt::rialto::common::SessionServerState::NOT_RUNNING));
 }
 
 TEST_F(SessionServerAppManagerTests, SetSessionServerStateShouldReturnTrueWhenStateIsChanged)

--- a/tests/serverManager/unittests/common/SessionServerAppTestsFixture.cpp
+++ b/tests/serverManager/unittests/common/SessionServerAppTestsFixture.cpp
@@ -166,7 +166,7 @@ void SessionServerAppTests::willKillAppOnDestruction() const
 {
     auto killTimer{std::make_unique<StrictMock<firebolt::rialto::server::TimerMock>>()};
     EXPECT_CALL(m_timerMock, isActive()).WillOnce(Return(false));
-    EXPECT_CALL(m_linuxWrapperMock, kill(kPid, SIGKILL)).WillOnce(Return(0));
+    EXPECT_CALL(m_linuxWrapperMock, kill(kPid, SIGTERM)).WillOnce(Return(0));
     EXPECT_CALL(*killTimer, cancel());
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kKillTimeout, _, firebolt::rialto::common::TimerType::ONE_SHOT))
         .WillOnce(DoAll(InvokeArgument<1>(), Return(ByMove(std::move(killTimer)))));


### PR DESCRIPTION
Summary: Added handling of SetState message timeouts to fix orphaned rialto servers problem
Type: Fix
Test Plan: UT and Fullstack
Jira: RIALTO-334