### PR TITLE
Fix the upload of the coverage report to ghpages

### DIFF
--- a/.github/workflows/build_and_deploy_gh_pages.yml
+++ b/.github/workflows/build_and_deploy_gh_pages.yml
@@ -63,7 +63,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Build and test build_ut'
+          check-name: 'Runs the coverage report'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
 


### PR DESCRIPTION
Summary: Wait for the correct job to finish before uploading the coverage report to ghpages.
Type: Bug
Test Plan: N/A
Jira: RIALTO-111