### PR TITLE
Client ipc recovery

### DIFF
--- a/media/client/ipc/include/IIpcClient.h
+++ b/media/client/ipc/include/IIpcClient.h
@@ -99,6 +99,13 @@ public:
      * @retval the rpc controller or null on error.
      */
     virtual std::shared_ptr<google::protobuf::RpcController> createRpcController() = 0;
+
+    /**
+     * @brief Reconnect channel.
+     *
+     * @retval true on success.
+     */
+    virtual bool reconnect() = 0;
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/include/IpcClient.h
+++ b/media/client/ipc/include/IpcClient.h
@@ -58,6 +58,8 @@ public:
 
     std::shared_ptr<google::protobuf::RpcController> createRpcController() override;
 
+    bool reconnect() override;
+
 protected:
     /**
      * @brief The ipc thread.

--- a/media/client/ipc/include/IpcModule.h
+++ b/media/client/ipc/include/IpcModule.h
@@ -110,6 +110,14 @@ protected:
      * @retval true if channel now connected, false otherwise.
      */
     bool reattachChannelIfRequired();
+
+private:
+    /**
+     * @brief Get connected IPC Channel
+     *
+     * @retval Ipc Channel if connected, nullptr otherwise
+     */
+    std::shared_ptr<ipc::IChannel> getConnectedChannel();
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/source/ControlIpc.cpp
+++ b/media/client/ipc/source/ControlIpc.cpp
@@ -90,13 +90,13 @@ ControlIpc::~ControlIpc()
 
 bool ControlIpc::getSharedMemory(int32_t &fd, uint32_t &size)
 {
-    std::shared_ptr<::firebolt::rialto::ControlModule_Stub> controlStub = m_controlStub;
-
     if (!reattachChannelIfRequired())
     {
         RIALTO_CLIENT_LOG_ERROR("Reattachment of the ipc channel failed, ipc disconnected");
         return false;
     }
+
+    std::shared_ptr<::firebolt::rialto::ControlModule_Stub> controlStub = m_controlStub;
 
     firebolt::rialto::GetSharedMemoryRequest request;
 
@@ -124,13 +124,13 @@ bool ControlIpc::getSharedMemory(int32_t &fd, uint32_t &size)
 bool ControlIpc::registerClient()
 {
     const auto kCurrentSchemaVersion{common::getCurrentSchemaVersion()};
-    std::shared_ptr<::firebolt::rialto::ControlModule_Stub> controlStub = m_controlStub;
 
     if (!reattachChannelIfRequired())
     {
         RIALTO_CLIENT_LOG_ERROR("Reattachment of the ipc channel failed, ipc disconnected");
         return false;
     }
+    std::shared_ptr<::firebolt::rialto::ControlModule_Stub> controlStub = m_controlStub;
 
     firebolt::rialto::RegisterClientRequest request;
     firebolt::rialto::RegisterClientResponse response;

--- a/media/client/ipc/source/IpcClient.cpp
+++ b/media/client/ipc/source/IpcClient.cpp
@@ -195,4 +195,14 @@ std::shared_ptr<google::protobuf::RpcController> IpcClient::createRpcController(
     return m_ipcControllerFactory->create();
 }
 
+bool IpcClient::reconnect()
+{
+    RIALTO_CLIENT_LOG_INFO("Trying to reconnect channel");
+    if (disconnect())
+    {
+        return connect();
+    }
+    return false;
+}
+
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/source/IpcModule.cpp
+++ b/media/client/ipc/source/IpcModule.cpp
@@ -67,7 +67,7 @@ bool IpcModule::attachChannel()
             return false;
         }
 
-        std::shared_ptr<ipc::IChannel> ipcChannel{getConnectedChannel()};
+        ipcChannel = getConnectedChannel();
         if (!ipcChannel)
         {
             RIALTO_CLIENT_LOG_ERROR("Failed to get the ipc channel");

--- a/media/server/ipc/source/ControlModuleService.cpp
+++ b/media/server/ipc/source/ControlModuleService.cpp
@@ -143,9 +143,9 @@ void ControlModuleService::registerClient(::google::protobuf::RpcController *con
         done->Run();
         return;
     }
+    const auto kCurrentSchemaVersion{common::getCurrentSchemaVersion()};
     if (request->has_client_schema_version())
     {
-        const auto kCurrentSchemaVersion{common::getCurrentSchemaVersion()};
         const firebolt::rialto::common::SchemaVersion kClientSchemaVersion{request->client_schema_version().major(),
                                                                            request->client_schema_version().minor(),
                                                                            request->client_schema_version().patch()};
@@ -169,6 +169,9 @@ void ControlModuleService::registerClient(::google::protobuf::RpcController *con
     m_controlService.addControl(controlId, controlClient);
     m_controlIds[ipcClient].insert(controlId);
     response->set_control_handle(controlId);
+    response->mutable_server_schema_version()->set_major(kCurrentSchemaVersion.major());
+    response->mutable_server_schema_version()->set_minor(kCurrentSchemaVersion.minor());
+    response->mutable_server_schema_version()->set_patch(kCurrentSchemaVersion.patch());
     done->Run();
 }
 

--- a/media/server/service/source/SessionServerManager.cpp
+++ b/media/server/service/source/SessionServerManager.cpp
@@ -231,6 +231,7 @@ bool SessionServerManager::switchToNotRunning()
     // Free resources before sending notification to ServerManager
     m_playbackService.switchToInactive();
     m_cdmService.switchToInactive();
+    m_controlService.setApplicationState(ApplicationState::UNKNOWN);
     stopService();
     if (m_applicationManagementServer->sendStateChangedEvent(common::SessionServerState::NOT_RUNNING))
     {

--- a/tests/media/client/ipc/controlIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/controlIpc/CreateTest.cpp
@@ -59,6 +59,7 @@ TEST_F(RialtoClientControlIpcCreateTest, CreateIpcChannelDisconnected)
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock));
     EXPECT_CALL(*m_channelMock, isConnected()).WillOnce(Return(false));
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false));
 
     EXPECT_THROW(m_controlIpc =
                      std::make_shared<ControlIpc>(&m_controlClientMock, m_ipcClientMock, m_eventThreadFactoryMock),

--- a/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.cpp
+++ b/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.cpp
@@ -38,6 +38,7 @@ void IpcModuleBase::expectInitIpcButAttachChannelFailure()
 {
     std::shared_ptr<StrictMock<ChannelMock>> channelMock;
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(channelMock)).RetiresOnSaturation();
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false)).RetiresOnSaturation();
 }
 
 void IpcModuleBase::expectAttachChannel()
@@ -75,6 +76,7 @@ void IpcModuleBase::expectIpcApiCallDisconnected()
 
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock)).RetiresOnSaturation();
     EXPECT_CALL(*m_channelMock, isConnected()).InSequence(m_isConnectedSeq).WillOnce(Return(false)).RetiresOnSaturation();
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false)).RetiresOnSaturation();
 }
 
 void IpcModuleBase::expectIpcApiCallReconnected()

--- a/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.cpp
+++ b/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.cpp
@@ -34,11 +34,29 @@ void IpcModuleBase::expectInitIpc()
     expectAttachChannel();
 }
 
+void IpcModuleBase::expectInitIpcWithReconnection()
+{
+    std::shared_ptr<StrictMock<ChannelMock>> channelMock;
+    EXPECT_CALL(m_ipcClientMock, getChannel())
+        .WillOnce(Return(channelMock))
+        .WillOnce(Return(m_channelMock))
+        .RetiresOnSaturation();
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(true)).RetiresOnSaturation();
+    EXPECT_CALL(*m_channelMock, isConnected()).InSequence(m_isConnectedSeq).WillOnce(Return(true)).RetiresOnSaturation();
+}
+
 void IpcModuleBase::expectInitIpcButAttachChannelFailure()
 {
     std::shared_ptr<StrictMock<ChannelMock>> channelMock;
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(channelMock)).RetiresOnSaturation();
     EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false)).RetiresOnSaturation();
+}
+
+void IpcModuleBase::expectInitIpcButNotConnectedChannelAfterReconnect()
+{
+    std::shared_ptr<StrictMock<ChannelMock>> channelMock;
+    EXPECT_CALL(m_ipcClientMock, getChannel()).WillRepeatedly(Return(channelMock)).RetiresOnSaturation();
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(true)).RetiresOnSaturation();
 }
 
 void IpcModuleBase::expectAttachChannel()

--- a/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.h
+++ b/tests/media/client/ipc/ipcModuleBase/IpcModuleBase.h
@@ -58,8 +58,10 @@ protected:
     Sequence m_isConnectedSeq;
 
     void expectInitIpc();
+    void expectInitIpcWithReconnection();
     void expectInitIpcFailure();
     void expectInitIpcButAttachChannelFailure();
+    void expectInitIpcButNotConnectedChannelAfterReconnect();
     void expectAttachChannel();
     void expectIpcApiCallDisconnected();
     void expectIpcApiCallReconnected();

--- a/tests/media/client/ipc/mediaKeysCapabilitiesIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaKeysCapabilitiesIpc/CreateTest.cpp
@@ -62,6 +62,7 @@ TEST_F(RialtoClientCreateMediaKeysCapabilitiesIpcTest, CreateIpcChannelDisconnec
 {
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock));
     EXPECT_CALL(*m_channelMock, isConnected()).WillOnce(Return(false));
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false));
 
     EXPECT_THROW(m_mediaKeysCapabilitiesIpc = std::make_unique<MediaKeysCapabilitiesIpc>(m_ipcClientMock),
                  std::runtime_error);

--- a/tests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
@@ -74,6 +74,7 @@ TEST_F(RialtoClientCreateMediaKeysIpcTest, CreateIpcChannelDisconnected)
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock));
     EXPECT_CALL(*m_channelMock, isConnected()).WillOnce(Return(false));
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false));
 
     EXPECT_THROW(m_mediaKeysIpc = std::make_unique<MediaKeysIpc>(m_keySystem, m_ipcClientMock, m_eventThreadFactoryMock),
                  std::runtime_error);

--- a/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
@@ -96,6 +96,7 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateIpcChannelDisconnected)
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock));
     EXPECT_CALL(*m_channelMock, isConnected()).WillOnce(Return(false));
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false));
 
     EXPECT_THROW(m_mediaPipelineIpc = std::make_unique<MediaPipelineIpc>(m_clientMock, m_videoReq, m_ipcClientMock,
                                                                          m_eventThreadFactoryMock),

--- a/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
@@ -76,11 +76,55 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateDestroy)
 }
 
 /**
+ * Test that a MediaPipelineIpc object can be created successfully with channel reconnection.
+ */
+TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateDestroyWithReconnection)
+{
+    /* create media player */
+    expectInitIpcWithReconnection();
+    expectSubscribeEvents();
+    expectIpcApiCallSuccess();
+
+    EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createSession"), m_controllerMock.get(),
+                                           createSessionRequestMatcher(m_videoReq.maxWidth, m_videoReq.maxHeight), _,
+                                           m_blockingClosureMock.get()))
+        .WillOnce(WithArgs<3>(Invoke(this, &MediaPipelineIpcTestBase::setCreateSessionResponse)));
+
+    EXPECT_NO_THROW(m_mediaPipelineIpc = std::make_unique<MediaPipelineIpc>(m_clientMock, m_videoReq, m_ipcClientMock,
+                                                                            m_eventThreadFactoryMock));
+    EXPECT_NE(m_mediaPipelineIpc, nullptr);
+
+    /* destroy media player */
+    expectIpcApiCallSuccess();
+    expectUnsubscribeEvents();
+
+    EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("destroySession"), m_controllerMock.get(),
+                                           destroySessionRequestMatcher(m_sessionId), _, m_blockingClosureMock.get()));
+
+    m_mediaPipelineIpc.reset();
+    EXPECT_EQ(m_mediaPipelineIpc, nullptr);
+}
+
+/**
  * Test that a MediaPipelineIpc object not created when the ipc channel has not been created.
  */
 TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateNoIpcChannel)
 {
     expectInitIpcButAttachChannelFailure();
+    EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
+
+    EXPECT_THROW(m_mediaPipelineIpc = std::make_unique<MediaPipelineIpc>(m_clientMock, m_videoReq, m_ipcClientMock,
+                                                                         m_eventThreadFactoryMock),
+                 std::runtime_error);
+}
+
+/**
+ * Test that a MediaPipelineIpc object not created when the ipc channel has not been created after reconnection.
+ */
+TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateNoIpcChannelAfterReconnect)
+{
+    expectInitIpcButNotConnectedChannelAfterReconnect();
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
 
     EXPECT_THROW(m_mediaPipelineIpc = std::make_unique<MediaPipelineIpc>(m_clientMock, m_videoReq, m_ipcClientMock,

--- a/tests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
+++ b/tests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
@@ -100,6 +100,7 @@ TEST_F(RialtoClientCreateWebAudioPlayerIpcTest, CreateIpcChannelDisconnected)
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(m_ipcClientMock, getChannel()).WillOnce(Return(m_channelMock));
     EXPECT_CALL(*m_channelMock, isConnected()).WillOnce(Return(false));
+    EXPECT_CALL(m_ipcClientMock, reconnect()).WillOnce(Return(false));
 
     EXPECT_THROW(m_webAudioPlayerIpc = std::make_unique<WebAudioPlayerIpc>(m_clientMock, m_audioMimeType, m_priority,
                                                                            &m_config, m_ipcClientMock,

--- a/tests/media/client/main/clientController/CreateTest.cpp
+++ b/tests/media/client/main/clientController/CreateTest.cpp
@@ -54,7 +54,6 @@ TEST_F(ClientControllerCreateTest, CreateDestroy)
 
     // Create
     EXPECT_CALL(*m_controlIpcFactoryMock, getControlIpc(_)).WillOnce(Return(m_controlIpcMock));
-    EXPECT_CALL(*m_controlIpcMock, registerClient()).WillOnce(Return(true));
 
     EXPECT_NO_THROW(controller = std::make_unique<ClientController>(m_controlIpcFactoryMock));
 
@@ -67,17 +66,6 @@ TEST_F(ClientControllerCreateTest, CreateControlIpcFailure)
     std::unique_ptr<IClientController> controller;
 
     EXPECT_CALL(*m_controlIpcFactoryMock, getControlIpc(_)).WillOnce(Return(nullptr));
-
-    EXPECT_THROW(controller = std::make_unique<ClientController>(m_controlIpcFactoryMock), std::runtime_error);
-    EXPECT_EQ(controller, nullptr);
-}
-
-TEST_F(ClientControllerCreateTest, CreateControlRegisterClientFailure)
-{
-    std::unique_ptr<IClientController> controller;
-
-    EXPECT_CALL(*m_controlIpcFactoryMock, getControlIpc(_)).WillOnce(Return(m_controlIpcMock));
-    EXPECT_CALL(*m_controlIpcMock, registerClient()).WillOnce(Return(false));
 
     EXPECT_THROW(controller = std::make_unique<ClientController>(m_controlIpcFactoryMock), std::runtime_error);
     EXPECT_EQ(controller, nullptr);

--- a/tests/media/client/main/clientController/MemoryManagementTest.cpp
+++ b/tests/media/client/main/clientController/MemoryManagementTest.cpp
@@ -55,7 +55,6 @@ protected:
         m_fd = memfd_create("memfdfile", 0);
 
         EXPECT_CALL(*m_controlIpcFactoryMock, getControlIpc(_)).WillOnce(Return(m_controlIpcMock));
-        EXPECT_CALL(*m_controlIpcMock, registerClient()).WillOnce(Return(true));
         EXPECT_NO_THROW(m_sut = std::make_unique<ClientController>(m_controlIpcFactoryMock));
     }
 
@@ -137,6 +136,7 @@ TEST_F(ClientControllerMemoryManagementTest, SwitchToInactiveWithMemoryTerminati
 TEST_F(ClientControllerMemoryManagementTest, SwitchStatesWithClientNotification)
 {
     ApplicationState appState;
+    EXPECT_CALL(*m_controlIpcMock, registerClient()).WillOnce(Return(true));
     m_sut->registerClient(&m_controlClientMock, appState);
     EXPECT_EQ(ApplicationState::UNKNOWN, appState);
     EXPECT_CALL(*m_controlIpcMock, getSharedMemory(_, _))
@@ -153,6 +153,7 @@ TEST_F(ClientControllerMemoryManagementTest, SwitchStatesWithClientNotification)
 TEST_F(ClientControllerMemoryManagementTest, SwitchStatesWithoutClientNotification)
 {
     ApplicationState appState;
+    EXPECT_CALL(*m_controlIpcMock, registerClient()).WillOnce(Return(true));
     m_sut->registerClient(&m_controlClientMock, appState);
     m_sut->unregisterClient(&m_controlClientMock);
     EXPECT_CALL(*m_controlIpcMock, getSharedMemory(_, _))
@@ -177,7 +178,7 @@ TEST_F(ClientControllerMemoryManagementTest, RegisterClientInRunningState)
     EXPECT_NE(nullptr, m_sut->getSharedMemoryHandle()->getShm());
 }
 
-TEST_F(ClientControllerMemoryManagementTest, SwitchToInvalidStateShouldFail)
+TEST_F(ClientControllerMemoryManagementTest, SwitchToUnknown)
 {
     EXPECT_CALL(*m_controlIpcMock, getSharedMemory(_, _))
         .WillOnce(DoAll(SetArgReferee<0>(m_fd), SetArgReferee<1>(m_size), Return(true)));
@@ -185,6 +186,5 @@ TEST_F(ClientControllerMemoryManagementTest, SwitchToInvalidStateShouldFail)
     EXPECT_NE(nullptr, m_sut->getSharedMemoryHandle());
     EXPECT_NE(nullptr, m_sut->getSharedMemoryHandle()->getShm());
     changeAppState(ApplicationState::UNKNOWN);
-    EXPECT_NE(nullptr, m_sut->getSharedMemoryHandle());
-    EXPECT_NE(nullptr, m_sut->getSharedMemoryHandle()->getShm());
+    EXPECT_EQ(nullptr, m_sut->getSharedMemoryHandle());
 }

--- a/tests/media/client/mocks/ipc/IpcClientMock.h
+++ b/tests/media/client/mocks/ipc/IpcClientMock.h
@@ -35,6 +35,7 @@ public:
     MOCK_METHOD(std::weak_ptr<ipc::IChannel>, getChannel, (), (override, const));
     MOCK_METHOD(std::shared_ptr<ipc::IBlockingClosure>, createBlockingClosure, (), (override));
     MOCK_METHOD(std::shared_ptr<google::protobuf::RpcController>, createRpcController, (), (override));
+    MOCK_METHOD(bool, reconnect, (), (override));
 };
 } // namespace firebolt::rialto::client
 

--- a/tests/media/server/service/sessionServerManager/SessionServerManagerTestsFixture.cpp
+++ b/tests/media/server/service/sessionServerManager/SessionServerManagerTestsFixture.cpp
@@ -254,6 +254,7 @@ void SessionServerManagerTests::willFailToSetStateNotRunning()
 {
     EXPECT_CALL(m_playbackServiceMock, switchToInactive());
     EXPECT_CALL(m_cdmServiceMock, switchToInactive());
+    EXPECT_CALL(m_controlServiceMock, setApplicationState(ApplicationState::UNKNOWN));
     EXPECT_CALL(m_applicationManagementServerMock, sendStateChangedEvent(SessionServerState::NOT_RUNNING))
         .WillOnce(Return(false));
 }
@@ -262,6 +263,7 @@ void SessionServerManagerTests::willSetStateNotRunning()
 {
     EXPECT_CALL(m_playbackServiceMock, switchToInactive());
     EXPECT_CALL(m_cdmServiceMock, switchToInactive());
+    EXPECT_CALL(m_controlServiceMock, setApplicationState(ApplicationState::UNKNOWN));
     EXPECT_CALL(m_applicationManagementServerMock, sendStateChangedEvent(SessionServerState::NOT_RUNNING))
         .WillOnce(Return(true));
 }


### PR DESCRIPTION
Summary: Rialto Client recovery functionality - client will be able to recover after unexpected server restart
Type: Feature
Test Plan: UT and Fullstack
Jira: RIALTO-334