### PR TITLE
double registration fix

### DIFF
--- a/media/client/main/include/ClientController.h
+++ b/media/client/main/include/ClientController.h
@@ -91,6 +91,11 @@ private:
     ApplicationState m_currentState;
 
     /**
+     * @brief Flag indicating if registerRequest has to be sent to Rialto Server
+     */
+    bool m_registrationRequired;
+
+    /**
      * @brief The shared memory buffer handle.
      */
     std::shared_ptr<ISharedMemoryHandle> m_shmHandle;


### PR DESCRIPTION
Summary: Skip sending RegisterClient twice when not needed
Type: Fix
Test Plan: Unit Tests & Full Stack
Jira: None
