### PR TITLE
Increase preroll frames requested to 3

### DIFF
--- a/media/server/main/include/ShmUtils.h
+++ b/media/server/main/include/ShmUtils.h
@@ -25,7 +25,7 @@
 
 namespace firebolt::rialto::server
 {
-constexpr std::uint32_t kPrerollNumFrames{1};
+constexpr std::uint32_t kPrerollNumFrames{3};
 constexpr std::uint32_t kMaxFrames{24};
 constexpr std::uint32_t getMaxMetadataBytes()
 {

--- a/tests/media/server/main/mediaPipeline/CallbackTest.cpp
+++ b/tests/media/server/main/mediaPipeline/CallbackTest.cpp
@@ -88,7 +88,7 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyNeedMediaDataInPrerollingSta
 {
     auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
     int sourceId = attachSource(mediaSourceType, "video/h264");
-    int numFrames{1};
+    int numFrames{3};
 
     expectNotifyNeedData(mediaSourceType, sourceId, numFrames);
 

--- a/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
+++ b/tests/media/server/main/mediaPipeline/HaveDataTest.cpp
@@ -28,7 +28,7 @@ using ::testing::Throw;
 class RialtoServerMediaPipelineHaveDataTest : public MediaPipelineTestBase
 {
 protected:
-    const uint32_t m_kNumFrames{1};
+    const uint32_t m_kNumFrames{3};
     const uint32_t m_kNeedDataRequestId{0};
     const std::chrono::milliseconds m_kNeedMediaDataResendTimeout{100};
 

--- a/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
+++ b/tests/media/server/main/mediaPipeline/MiscellaneousFunctionsTest.cpp
@@ -163,10 +163,10 @@ TEST_F(RialtoServerMediaPipelineMiscellaneousFunctionsTest, SetPositionResetEos)
     EXPECT_TRUE(m_mediaPipeline->setPosition(m_kPosition));
 
     // Expect need data notified to client
-    expectNotifyNeedData(firebolt::rialto::MediaSourceType::VIDEO, videoSourceId, 1);
+    expectNotifyNeedData(firebolt::rialto::MediaSourceType::VIDEO, videoSourceId, 3);
     m_gstPlayerCallback->notifyNeedMediaData(firebolt::rialto::MediaSourceType::VIDEO);
 
-    expectNotifyNeedData(firebolt::rialto::MediaSourceType::AUDIO, audioSourceId, 1);
+    expectNotifyNeedData(firebolt::rialto::MediaSourceType::AUDIO, audioSourceId, 3);
     m_gstPlayerCallback->notifyNeedMediaData(firebolt::rialto::MediaSourceType::AUDIO);
 }
 

--- a/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
+++ b/tests/media/server/main/needMediaData/NeedMediaDataTestsFixture.cpp
@@ -30,7 +30,7 @@ constexpr int kSourceId{1};
 constexpr std::uint32_t kBufferLen{7 * 1024 * 1024};
 constexpr std::uint32_t kMetadataOffset{1024};
 constexpr int kRequestId{0};
-constexpr int kPrerollingNumFrames{1};
+constexpr int kPrerollingNumFrames{3};
 constexpr int kMaxFrames{24};
 constexpr int kMaxMetadataBytes{2500};
 } // namespace


### PR DESCRIPTION
Summary: Increase frames requested before prerolling to speed up buffering of content after seek.
Type: Bug
Test Plan: Unittests, YtCert Progressive Test Suite (RIALTO-25, RIALTO-5)
Jira: RIALTO-372