### PR TITLE
sigkill instead of sigterm

### DIFF
--- a/serverManager/common/source/SessionServerApp.cpp
+++ b/serverManager/common/source/SessionServerApp.cpp
@@ -262,7 +262,7 @@ void SessionServerApp::kill() const
 {
     if (m_pid > 0)
     {
-        m_linuxWrapper->kill(m_pid, SIGTERM);
+        m_linuxWrapper->kill(m_pid, SIGKILL);
     }
 }
 

--- a/tests/serverManager/unittests/common/SessionServerAppTestsFixture.cpp
+++ b/tests/serverManager/unittests/common/SessionServerAppTestsFixture.cpp
@@ -166,7 +166,7 @@ void SessionServerAppTests::willKillAppOnDestruction() const
 {
     auto killTimer{std::make_unique<StrictMock<firebolt::rialto::server::TimerMock>>()};
     EXPECT_CALL(m_timerMock, isActive()).WillOnce(Return(false));
-    EXPECT_CALL(m_linuxWrapperMock, kill(kPid, SIGTERM)).WillOnce(Return(0));
+    EXPECT_CALL(m_linuxWrapperMock, kill(kPid, SIGKILL)).WillOnce(Return(0));
     EXPECT_CALL(*killTimer, cancel());
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kKillTimeout, _, firebolt::rialto::common::TimerType::ONE_SHOT))
         .WillOnce(DoAll(InvokeArgument<1>(), Return(ByMove(std::move(killTimer)))));


### PR DESCRIPTION
Summary: Sigkill instead of sigterm for heavily deadlocked servers
Type: Fix
Test Plan: UT
Jira: None