### PR TITLE
Rialto 395 Fix the unit test IpcClientTest_UnexpectedDisconnectWithNotification

### DIFF
--- a/media/client/ipc/source/IpcClient.cpp
+++ b/media/client/ipc/source/IpcClient.cpp
@@ -159,17 +159,11 @@ void IpcClient::processIpcThread()
     {
         RIALTO_CLIENT_LOG_ERROR("The ipc channel unexpectedly disconnected, destroying the channel");
 
-        // The test case IpcClientTest.UnexpectedDisconnectWithNotification
-        // will start to destroy the connection observer object
-        // after m_ipcChannel.reset(), therefore it's necessary
-        // to create a shared_ptr<> BEFORE calling m_ipcChannel.reset()
-        // in order to avoid a race (since m_connectionObserver is a weak_ptr)
-        std::shared_ptr<IConnectionObserver> connectionObserver{m_connectionObserver.lock()};
-
         // Safe to destroy the ipc objects in the ipc thread as the client has already disconnected.
         // This ensures the channel is destructed and that all ongoing ipc calls are unblocked.
         m_ipcChannel.reset();
 
+        auto connectionObserver{m_connectionObserver.lock()};
         if (connectionObserver)
         {
             connectionObserver->onConnectionBroken();

--- a/media/client/ipc/source/IpcClient.cpp
+++ b/media/client/ipc/source/IpcClient.cpp
@@ -160,11 +160,11 @@ void IpcClient::processIpcThread()
         RIALTO_CLIENT_LOG_ERROR("The ipc channel unexpectedly disconnected, destroying the channel");
 
         // The test case IpcClientTest.UnexpectedDisconnectWithNotification
-        // will start to destroy the shared_link<> to m_connectionObserver as
-        // soon as the ipcChannel is reset, therefore it's necessary
-        // to create another shared_link<> BEFORE calling m_ipcChannel.reset()
-        // in order to avoid a race since m_connectionObserver is a weak_link...
-        auto connectionObserver{m_connectionObserver.lock()};
+        // will start to destroy the connection observer object
+        // after m_ipcChannel.reset(), therefore it's necessary
+        // to create a shared_ptr<> BEFORE calling m_ipcChannel.reset()
+        // in order to avoid a race (since m_connectionObserver is a weak_ptr)
+        std::shared_ptr<IConnectionObserver> connectionObserver{m_connectionObserver.lock()};
 
         // Safe to destroy the ipc objects in the ipc thread as the client has already disconnected.
         // This ensures the channel is destructed and that all ongoing ipc calls are unblocked.

--- a/tests/media/client/ipc/ipcClient/IpcClientTest.cpp
+++ b/tests/media/client/ipc/ipcClient/IpcClientTest.cpp
@@ -115,11 +115,8 @@ TEST_F(IpcClientTest, UnexpectedDisconnectWithNotification)
                 return false;
             }));
 
-    EXPECT_CALL(*connectionObserverMock, onConnectionBroken()).WillOnce(Invoke(
-                                                                            [this, &connectionBrokenCallbackCalled]()
-            {
-                connectionBrokenCallbackCalled = true;
-            }));
+    EXPECT_CALL(*connectionObserverMock, onConnectionBroken())
+        .WillOnce(Invoke([this, &connectionBrokenCallbackCalled]() { connectionBrokenCallbackCalled = true; }));
     EXPECT_NO_THROW(m_sut = std::make_unique<IpcClient>(m_channelFactoryMock, m_controllerFactoryMock,
                                                         m_blockingClosureFactoryMock));
 
@@ -139,7 +136,8 @@ TEST_F(IpcClientTest, UnexpectedDisconnectWithNotification)
 
     // Wait for the callback
     unsigned int kWaitTimeMilliseconds = 5000;
-    for (unsigned int i=0; !connectionBrokenCallbackCalled && i<kWaitTimeMilliseconds; ++i) {
+    for (unsigned int i = 0; !connectionBrokenCallbackCalled && i < kWaitTimeMilliseconds; ++i)
+    {
         usleep(1000); // Sleep for one millisecond
     }
 

--- a/tests/media/client/ipc/ipcClient/IpcClientTest.cpp
+++ b/tests/media/client/ipc/ipcClient/IpcClientTest.cpp
@@ -123,9 +123,10 @@ TEST_F(IpcClientTest, UnexpectedDisconnectWithNotification)
     // Wait for the callback
     {
         std::unique_lock<std::mutex> locker(m_eventsLock);
-        std::chrono::duration kMaximumWaitTime{std::chrono::seconds(5)};
+        constexpr std::chrono::duration kMaximumWaitTime{std::chrono::seconds(5)};
         if (!connectionBrokenCallbackCalled)
         {
+            // The EXPECT_CALL() above will catch a timeout if one occurs
             m_eventsCond.wait_for(locker, kMaximumWaitTime);
         }
     }

--- a/tests/media/client/ipc/ipcClient/IpcClientTest.cpp
+++ b/tests/media/client/ipc/ipcClient/IpcClientTest.cpp
@@ -135,7 +135,7 @@ TEST_F(IpcClientTest, UnexpectedDisconnectWithNotification)
     }
 
     // Wait for the callback
-    unsigned int kWaitTimeMilliseconds = 5000;
+    constexpr unsigned int kWaitTimeMilliseconds = 5000;
     for (unsigned int i = 0; !connectionBrokenCallbackCalled && i < kWaitTimeMilliseconds; ++i)
     {
         usleep(1000); // Sleep for one millisecond


### PR DESCRIPTION
Summary: Fix the unit test "IpcClientTest_UnexpectedDisconnectWithNotification" (it intermittently fails)
Type:Fix
Test Plan: Ran unit tests and ran on Sky0 UK hardware 
Jira: RIALTO-395
