### PR TITLE
Use googletest in cppcheck

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -48,7 +48,7 @@ jobs:
       # Proccess returns error if failure detected
       - name: cppcheck command
         run: |
-              cppcheck -q -ibuild --enable=all --output-file=cppcheck_report.txt --std=c++17 --error-exitcode=1 --suppress-xml=cppcheck_suppressions.xml .
+              cppcheck -q -ibuild --enable=all --output-file=cppcheck_report.txt --std=c++17 --error-exitcode=1 --suppress-xml=cppcheck_suppressions.xml --library=googletest .
 
       # Upload logs on failure
       - name: Upload logs

--- a/cppcheck_suppressions.xml
+++ b/cppcheck_suppressions.xml
@@ -31,6 +31,18 @@
         <symbolName>rialto_mse_add_protection_metadata</symbolName>
     </suppress>
     <suppress>
+        <id>ctuOneDefinitionRuleViolation</id>
+        <fileName>tests/unittests/media/client/main/mediaPipeline/base/MediaPipelineTestBase.h</fileName>
+    </suppress>
+    <suppress>
+        <id>ctuOneDefinitionRuleViolation</id>
+        <fileName>tests/unittests/media/client/main/webAudioPlayer/base/WebAudioPlayerTestBase.h</fileName>
+    </suppress>
+    <suppress>
+        <id>ctuOneDefinitionRuleViolation</id>
+        <fileName>tests/unittests/media/client/main/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp</fileName>
+    </suppress>
+    <suppress>
         <id>unassignedVariable</id>
         <fileName>serverManager/service/source/ConfigHelper.cpp</fileName>
     </suppress>

--- a/cppcheck_suppressions.xml
+++ b/cppcheck_suppressions.xml
@@ -28,46 +28,15 @@
     </suppress>
     <suppress>
         <id>unusedFunction</id>
-        <symbolName>MATCHER_P5</symbolName>
-    </suppress>
-    <suppress>
-        <id>syntaxError</id>
-        <fileName>tests/unittests/serverManager/unittests/common/SessionServerAppTestsFixture.cpp</fileName>
-    </suppress>
-    <suppress>
-        <id>unusedFunction</id>
         <symbolName>rialto_mse_add_protection_metadata</symbolName>
-    </suppress>
-    <suppress>
-        <id>ctuOneDefinitionRuleViolation</id>
-        <fileName>tests/unittests/media/client/main/mediaPipeline/base/MediaPipelineTestBase.h</fileName>
-    </suppress>
-    <suppress>
-        <id>ctuOneDefinitionRuleViolation</id>
-        <fileName>tests/unittests/media/client/main/webAudioPlayer/base/WebAudioPlayerTestBase.h</fileName>
-    </suppress>
-    <suppress>
-        <id>ctuOneDefinitionRuleViolation</id>
-        <fileName>tests/unittests/media/client/main/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp</fileName>
     </suppress>
     <suppress>
         <id>unassignedVariable</id>
         <fileName>serverManager/service/source/ConfigHelper.cpp</fileName>
     </suppress>
-    <suppress>
-        <id>syntaxError</id>
-        <fileName>tests/componenttests/server/tests/mediaKeys/MediaKeysTest.cpp</fileName>
-    </suppress>
-    <suppress>
-        <id>syntaxError</id>
-        <fileName>tests/componenttests/server/tests/mediaPipeline/MediaPipelineTest.cpp</fileName>
-    </suppress>
-    <suppress>
+    <suppress> // Suppress all TEST and TEST_F googletest declarations as there use is not detected properly
         <id>unusedFunction</id>
-        <fileName>tests/componenttests/server/common/MessageBuilders.cpp</fileName>
-    </suppress>
-    <suppress>
-        <id>unusedFunction</id>
-        <fileName>tests/componenttests/server/tests/mediaPipeline/MediaPipelineTestFixture.cpp</fileName>
+        <fileName>tests/*</fileName>
+        <symbolName>__*</symbolName>
     </suppress>
 </suppressions>

--- a/tests/componenttests/client/stubs/ControlModuleStub.cpp
+++ b/tests/componenttests/client/stubs/ControlModuleStub.cpp
@@ -43,7 +43,7 @@ convertApplicationState(const firebolt::rialto::ApplicationState &state)
 }
 } // namespace
 
-namespace firebolt::rialto::ct::stub
+namespace firebolt::rialto::client::ct
 {
 ControlModuleStub::ControlModuleStub(const std::shared_ptr<::firebolt::rialto::ControlModule> &controlModuleMock)
     : m_controlModuleMock{controlModuleMock}
@@ -64,4 +64,4 @@ void ControlModuleStub::notifyApplicationStateEvent(const int32_t controlId,
     getClient()->sendEvent(event);
 }
 
-} // namespace firebolt::rialto::ct::stub
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/stubs/ControlModuleStub.h
+++ b/tests/componenttests/client/stubs/ControlModuleStub.h
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_CT_STUB_CONTROL_MODULE_STUB_H_
-#define FIREBOLT_RIALTO_CT_STUB_CONTROL_MODULE_STUB_H_
+#ifndef FIREBOLT_RIALTO_CLIENT_CT_CONTROL_MODULE_STUB_H_
+#define FIREBOLT_RIALTO_CLIENT_CT_CONTROL_MODULE_STUB_H_
 
 #include "ControlCommon.h"
 #include "IIpcServer.h"
 #include "controlmodule.pb.h"
 #include <memory>
 
-namespace firebolt::rialto::ct::stub
+namespace firebolt::rialto::client::ct
 {
 class ControlModuleStub
 {
@@ -42,6 +42,6 @@ public:
 protected:
     std::shared_ptr<::firebolt::rialto::ControlModule> m_controlModuleMock;
 };
-} // namespace firebolt::rialto::ct::stub
+} // namespace firebolt::rialto::client::ct
 
-#endif // FIREBOLT_RIALTO_CT_STUB_CONTROL_MODULE_STUB_H_
+#endif // FIREBOLT_RIALTO_CLIENT_CT_CONTROL_MODULE_STUB_H_

--- a/tests/componenttests/client/stubs/MediaPipelineModuleStub.cpp
+++ b/tests/componenttests/client/stubs/MediaPipelineModuleStub.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-namespace firebolt::rialto::ct::stub
+namespace firebolt::rialto::client::ct
 {
 MediaPipelineModuleStub::MediaPipelineModuleStub(
     const std::shared_ptr<::firebolt::rialto::MediaPipelineModule> &mediaPipelineModuleMock)
@@ -73,4 +73,4 @@ void MediaPipelineModuleStub::notifyNeedMediaDataEvent(int sessionId, int32_t so
     getClient()->sendEvent(event);
 }
 
-} // namespace firebolt::rialto::ct::stub
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/stubs/MediaPipelineModuleStub.h
+++ b/tests/componenttests/client/stubs/MediaPipelineModuleStub.h
@@ -16,9 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef FIREBOLT_RIALTO_CT_STUB_MEDIA_PIPELINE_MODULE_STUB_H_
-#define FIREBOLT_RIALTO_CT_STUB_MEDIA_PIPELINE_MODULE_STUB_H_
+#ifndef FIREBOLT_RIALTO_CLIENT_CT_MEDIA_PIPELINE_MODULE_STUB_H_
+#define FIREBOLT_RIALTO_CLIENT_CT_MEDIA_PIPELINE_MODULE_STUB_H_
 
 #include "IIpcServer.h"
 #include "MediaCommon.h"
@@ -26,7 +25,7 @@
 #include "mediapipelinemodule.pb.h"
 #include <memory>
 
-namespace firebolt::rialto::ct::stub
+namespace firebolt::rialto::client::ct
 {
 class MediaPipelineModuleStub
 {
@@ -46,6 +45,6 @@ public:
 protected:
     std::shared_ptr<::firebolt::rialto::MediaPipelineModule> m_mediaPipelineModuleMock;
 };
-} // namespace firebolt::rialto::ct::stub
+} // namespace firebolt::rialto::client::ct
 
-#endif // FIREBOLT_RIALTO_CT_STUB_MEDIA_PIPELINE_MODULE_STUB_H_
+#endif // FIREBOLT_RIALTO_CLIENT_CT_MEDIA_PIPELINE_MODULE_STUB_H_

--- a/tests/componenttests/client/stubs/ServerStub.cpp
+++ b/tests/componenttests/client/stubs/ServerStub.cpp
@@ -24,7 +24,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-namespace firebolt::rialto::ct::stub
+namespace firebolt::rialto::client::ct
 {
 void ServerStub::clientDisconnected(const std::shared_ptr<::firebolt::rialto::ipc::IClient> &client)
 {
@@ -120,4 +120,4 @@ std::shared_ptr<::firebolt::rialto::ipc::IClient> &ServerStub::getClient()
     return m_client;
 }
 
-} // namespace firebolt::rialto::ct::stub
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/stubs/ServerStub.h
+++ b/tests/componenttests/client/stubs/ServerStub.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_CT_STUB_SERVER_STUB_H_
-#define FIREBOLT_RIALTO_CT_STUB_SERVER_STUB_H_
+#ifndef FIREBOLT_RIALTO_CLIENT_CT_SERVER_STUB_H_
+#define FIREBOLT_RIALTO_CLIENT_CT_SERVER_STUB_H_
 
 #include "ControlModuleStub.h"
 #include "IIpcServer.h"
@@ -28,7 +28,7 @@
 #include <memory>
 #include <thread>
 
-namespace firebolt::rialto::ct::stub
+namespace firebolt::rialto::client::ct
 {
 class ServerStub : public ControlModuleStub, public MediaPipelineModuleStub
 {
@@ -53,6 +53,6 @@ private:
     void waitForClientConnect() override;
     std::shared_ptr<::firebolt::rialto::ipc::IClient> &getClient() override;
 };
-} // namespace firebolt::rialto::ct::stub
+} // namespace firebolt::rialto::client::ct
 
-#endif // FIREBOLT_RIALTO_CT_STUB_SERVER_STUB_H_
+#endif // FIREBOLT_RIALTO_CLIENT_CT_SERVER_STUB_H_

--- a/tests/componenttests/client/tests/base/ClientComponentTest.cpp
+++ b/tests/componenttests/client/tests/base/ClientComponentTest.cpp
@@ -67,6 +67,8 @@ constexpr firebolt::rialto::MediaPlayerShmInfo kShmInfoAudio{1000, 101000, 10200
 constexpr firebolt::rialto::MediaPlayerShmInfo kShmInfoWebAudio{1000, 112000, 113000, 10000};
 } // namespace
 
+namespace firebolt::rialto::client::ct
+{
 ClientComponentTest::ClientComponentTest()
     : MediaPipelineTestMethods(kShmInfoAudio, kShmInfoVideo),
       m_serverStub{std::make_shared<ServerStub>(m_controlModuleMock, m_mediaPipelineModuleMock)}
@@ -160,3 +162,4 @@ void ClientComponentTest::stopApplication()
     disconnectServer();
     waitEvent();
 }
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/base/ClientComponentTest.h
+++ b/tests/componenttests/client/tests/base/ClientComponentTest.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef CLIENT_COMPONENT_TEST_H_
-#define CLIENT_COMPONENT_TEST_H_
+#ifndef FIREBOLT_RIALTO_CLIENT_CT_CLIENT_COMPONENT_TEST_H_
+#define FIREBOLT_RIALTO_CLIENT_CT_CLIENT_COMPONENT_TEST_H_
 
 #include "ControlTestMethods.h"
 #include "MediaPipelineTestMethods.h"
@@ -35,8 +35,9 @@ using ::testing::StrictMock;
 using ::testing::WithArgs;
 
 using namespace firebolt::rialto;
-using namespace firebolt::rialto::ct::stub;
 
+namespace firebolt::rialto::client::ct
+{
 class ClientComponentTest : public ::testing::Test, public ControlTestMethods, public MediaPipelineTestMethods
 {
 public:
@@ -72,5 +73,6 @@ private:
     void initRealShm();
     void termRealShm();
 };
+} // namespace firebolt::rialto::client::ct
 
-#endif // CLIENT_COMPONENT_TEST_H_
+#endif // FIREBOLT_RIALTO_CLIENT_CT_CLIENT_COMPONENT_TEST_H_

--- a/tests/componenttests/client/tests/base/ControlTestMethods.cpp
+++ b/tests/componenttests/client/tests/base/ControlTestMethods.cpp
@@ -25,6 +25,8 @@ namespace
 constexpr int32_t kControlId = 1;
 } // namespace
 
+namespace firebolt::rialto::client::ct
+{
 ControlTestMethods::ControlTestMethods()
     : m_controlClientMock{std::make_shared<StrictMock<ControlClientMock>>()},
       m_controlModuleMock{std::make_shared<StrictMock<ControlModuleMock>>()}
@@ -87,3 +89,4 @@ void ControlTestMethods::sendNotifyApplicationStateRunning()
     getServerStub()->notifyApplicationStateEvent(kControlId, ApplicationState::RUNNING);
     waitEvent();
 }
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/base/ControlTestMethods.h
+++ b/tests/componenttests/client/tests/base/ControlTestMethods.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef CONTROL_TEST_METHODS_H_
-#define CONTROL_TEST_METHODS_H_
+#ifndef FIREBOLT_RIALTO_CLIENT_CT_CONTROL_TEST_METHODS_H_
+#define FIREBOLT_RIALTO_CLIENT_CT_CONTROL_TEST_METHODS_H_
 
 #include "ControlClientMock.h"
 #include "ControlModuleMock.h"
@@ -36,8 +36,9 @@ using ::testing::StrictMock;
 using ::testing::WithArgs;
 
 using namespace firebolt::rialto;
-using namespace firebolt::rialto::ct::stub;
 
+namespace firebolt::rialto::client::ct
+{
 class ControlTestMethods
 {
 public:
@@ -72,5 +73,6 @@ protected:
     virtual void *getShmAddress() = 0;
     virtual uint32_t getShmSize() = 0;
 };
+} // namespace firebolt::rialto::client::ct
 
-#endif // CONTROL_TEST_METHODS_H_
+#endif // FIREBOLT_RIALTO_CLIENT_CT_CONTROL_TEST_METHODS_H_

--- a/tests/componenttests/client/tests/base/MediaPipelineTestMethods.cpp
+++ b/tests/componenttests/client/tests/base/MediaPipelineTestMethods.cpp
@@ -54,6 +54,8 @@ constexpr int64_t kDuration = 1;
 firebolt::rialto::Fraction kFrameRate = {1, 1};
 } // namespace
 
+namespace firebolt::rialto::client::ct
+{
 MediaPipelineTestMethods::MediaPipelineTestMethods(const MediaPlayerShmInfo &audioShmInfo,
                                                    const MediaPlayerShmInfo &videoShmInfo)
     : m_mediaPipelineClientMock{std::make_shared<StrictMock<MediaPipelineClientMock>>()},
@@ -686,3 +688,4 @@ void MediaPipelineTestMethods::endAudioVideoMediaSession()
     MediaPipelineTestMethods::shouldDestroyMediaSession();
     MediaPipelineTestMethods::destroyMediaPipeline();
 }
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/base/MediaPipelineTestMethods.h
+++ b/tests/componenttests/client/tests/base/MediaPipelineTestMethods.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_MEDIA_PIPELINE_TEST_METHODS_H_
-#define FIREBOLT_RIALTO_MEDIA_PIPELINE_TEST_METHODS_H_
+#ifndef FIREBOLT_RIALTO_CLIENT_CT_MEDIA_PIPELINE_TEST_METHODS_H_
+#define FIREBOLT_RIALTO_CLIENT_CT_MEDIA_PIPELINE_TEST_METHODS_H_
 
 #include "IMediaPipeline.h"
 #include "MediaPipelineClientMock.h"
@@ -39,7 +39,6 @@ using ::testing::StrictMock;
 using ::testing::WithArgs;
 
 using namespace firebolt::rialto;
-using namespace firebolt::rialto::ct::stub;
 
 // Forward declare metadata so we dont have to include proto file
 namespace firebolt::rialto
@@ -47,6 +46,8 @@ namespace firebolt::rialto
 class MediaSegmentMetadata;
 };
 
+namespace firebolt::rialto::client::ct
+{
 class MediaPipelineTestMethods
 {
 public:
@@ -161,5 +162,6 @@ private:
     void checkHasNoExtraData(const MediaSegmentMetadata &metadata);
     void checkSegmentData(const MediaSegmentMetadata &metadata, uint8_t *dataPtr, const std::string &expectedSegmentData);
 };
+} // namespace firebolt::rialto::client::ct
 
-#endif // FIREBOLT_RIALTO_MEDIA_PIPELINE_TEST_METHODS_H_
+#endif // FIREBOLT_RIALTO_CLIENT_CT_MEDIA_PIPELINE_TEST_METHODS_H_

--- a/tests/componenttests/client/tests/control/ApplicationStateChangeTest.cpp
+++ b/tests/componenttests/client/tests/control/ApplicationStateChangeTest.cpp
@@ -20,6 +20,8 @@
 #include "ClientComponentTest.h"
 #include <gtest/gtest.h>
 
+namespace firebolt::rialto::client::ct
+{
 class ApplicationStateChangeTest : public ClientComponentTest
 {
 };
@@ -106,3 +108,4 @@ TEST_F(ApplicationStateChangeTest, lifecycle)
     ClientComponentTest::disconnectServer();
     ClientComponentTest::waitEvent();
 }
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/mse/AudioVideoPlaybackSequenceTest.cpp
+++ b/tests/componenttests/client/tests/mse/AudioVideoPlaybackSequenceTest.cpp
@@ -20,6 +20,8 @@
 #include "ClientComponentTest.h"
 #include <gtest/gtest.h>
 
+namespace firebolt::rialto::client::ct
+{
 class AudioVideoPlaybackSequenceTest : public ClientComponentTest
 {
 public:
@@ -256,3 +258,4 @@ TEST_F(AudioVideoPlaybackSequenceTest, playback)
     MediaPipelineTestMethods::shouldDestroyMediaSession();
     MediaPipelineTestMethods::destroyMediaPipeline();
 }
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/mse/AudioVideoPlaybackWriteSegmentsTest.cpp
+++ b/tests/componenttests/client/tests/mse/AudioVideoPlaybackWriteSegmentsTest.cpp
@@ -20,6 +20,8 @@
 #include "ClientComponentTest.h"
 #include <gtest/gtest.h>
 
+namespace firebolt::rialto::client::ct
+{
 class AudioVideoPlaybackWriteSegmentsTest : public ClientComponentTest
 {
 public:
@@ -263,3 +265,4 @@ TEST_F(AudioVideoPlaybackWriteSegmentsTest, playback)
     MediaPipelineTestMethods::shouldHaveDataAfterPreroll();
     MediaPipelineTestMethods::haveDataOk();
 }
+} // namespace firebolt::rialto::client::ct


### PR DESCRIPTION
Summary: Link googletest to cppcheck so that it expands the macros properly, add a generic suppression of unused test cases and use ct namespace in client component tests.
Type: Feature
Test Plan: Unittests, Component Tests.
Jira: RIALTO-412