### PR TITLE
Fix socket leak in component tests

### DIFF
--- a/tests/componenttests/server/stubs/ServerManagerStub.cpp
+++ b/tests/componenttests/server/stubs/ServerManagerStub.cpp
@@ -38,6 +38,11 @@ ServerManagerStub::~ServerManagerStub()
     {
         m_ipcThread.join();
     }
+
+    // Shutdown and close the server socket
+    // Other socket will be closed by the ipc channel
+    shutdown(m_socks[0], SHUT_RDWR);
+    close(m_socks[0]);
 }
 
 void ServerManagerStub::ipcThread()


### PR DESCRIPTION
Summary: Close server socket in server component tests.
Type: Fix
Test Plan: Unittests, Component Tests.
Jira: NO-JIRA