### PR TITLE
Notify decrypt errors

### DIFF
--- a/media/client/ipc/include/MediaPipelineIpc.h
+++ b/media/client/ipc/include/MediaPipelineIpc.h
@@ -171,6 +171,13 @@ private:
     void onBufferUnderflow(const std::shared_ptr<firebolt::rialto::BufferUnderflowEvent> &event);
 
     /**
+     * @brief 
+     *
+     * @param[in] event : 
+     */
+    void onPlaybackError(const std::shared_ptr<firebolt::rialto::PlaybackErrorEvent> &event);
+
+    /**
      * @brief Create a new player session.
      *
      * @param[in] videoRequirements : The video decoder requirements for the MediaPipeline session.

--- a/media/client/ipc/include/MediaPipelineIpc.h
+++ b/media/client/ipc/include/MediaPipelineIpc.h
@@ -171,9 +171,9 @@ private:
     void onBufferUnderflow(const std::shared_ptr<firebolt::rialto::BufferUnderflowEvent> &event);
 
     /**
-     * @brief 
+     * @brief Handler for a playback error notification from the server.
      *
-     * @param[in] event : 
+     * @param[in] event : The playback error event structure.
      */
     void onPlaybackError(const std::shared_ptr<firebolt::rialto::PlaybackErrorEvent> &event);
 

--- a/media/client/ipc/interface/IMediaPipelineIpcClient.h
+++ b/media/client/ipc/interface/IMediaPipelineIpcClient.h
@@ -97,7 +97,7 @@ public:
     virtual void notifyBufferUnderflow(int32_t sourceId) = 0;
 
     /**
-     * @brief Notifies the client that a none fatal error has occurred in the player.
+     * @brief Notifies the client that a non-fatal error has occurred in the player.
      *
      * PlaybackState remains unchanged when an error occurs.
      *

--- a/media/client/ipc/interface/IMediaPipelineIpcClient.h
+++ b/media/client/ipc/interface/IMediaPipelineIpcClient.h
@@ -97,11 +97,12 @@ public:
     virtual void notifyBufferUnderflow(int32_t sourceId) = 0;
     
     /**
-     * @brief 
+     * @brief Notifies the client that a none fatal error has occurred in the player.
      *
-     * 
+     * PlaybackState remains unchanged when an error occurs.
      *
-     * @param[in] sourceId  : 
+     * @param[in] sourceId  : The id of the source that produced the error.
+     * @param[in] error     : The type of error that occurred.
      */
     virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) = 0;
 };

--- a/media/client/ipc/interface/IMediaPipelineIpcClient.h
+++ b/media/client/ipc/interface/IMediaPipelineIpcClient.h
@@ -95,7 +95,7 @@ public:
      * @param[in] sourceId  : The id of the source that produced the buffer underflow
      */
     virtual void notifyBufferUnderflow(int32_t sourceId) = 0;
-    
+
     /**
      * @brief Notifies the client that a none fatal error has occurred in the player.
      *
@@ -104,7 +104,7 @@ public:
      * @param[in] sourceId  : The id of the source that produced the error.
      * @param[in] error     : The type of error that occurred.
      */
-    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) = 0;
+    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) = 0;
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/interface/IMediaPipelineIpcClient.h
+++ b/media/client/ipc/interface/IMediaPipelineIpcClient.h
@@ -104,7 +104,7 @@ public:
      * @param[in] sourceId  : The id of the source that produced the error.
      * @param[in] error     : The type of error that occurred.
      */
-    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) = 0;
+    virtual void notifyPlaybackError(int32_t sourceId, PlaybackError error) = 0;
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/interface/IMediaPipelineIpcClient.h
+++ b/media/client/ipc/interface/IMediaPipelineIpcClient.h
@@ -95,6 +95,15 @@ public:
      * @param[in] sourceId  : The id of the source that produced the buffer underflow
      */
     virtual void notifyBufferUnderflow(int32_t sourceId) = 0;
+    
+    /**
+     * @brief 
+     *
+     * 
+     *
+     * @param[in] sourceId  : 
+     */
+    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) = 0;
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/main/include/MediaPipeline.h
+++ b/media/client/main/include/MediaPipeline.h
@@ -147,6 +147,8 @@ public:
 
     void notifyBufferUnderflow(int32_t sourceId) override;
 
+    void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) override;
+
     bool renderFrame() override;
 
     bool setVolume(double volume) override;

--- a/media/client/main/include/MediaPipeline.h
+++ b/media/client/main/include/MediaPipeline.h
@@ -147,7 +147,7 @@ public:
 
     void notifyBufferUnderflow(int32_t sourceId) override;
 
-    void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) override;
+    void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) override;
 
     bool renderFrame() override;
 

--- a/media/client/main/include/MediaPipeline.h
+++ b/media/client/main/include/MediaPipeline.h
@@ -147,7 +147,7 @@ public:
 
     void notifyBufferUnderflow(int32_t sourceId) override;
 
-    void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) override;
+    void notifyPlaybackError(int32_t sourceId, PlaybackError error) override;
 
     bool renderFrame() override;
 

--- a/media/client/main/source/MediaPipeline.cpp
+++ b/media/client/main/source/MediaPipeline.cpp
@@ -695,4 +695,15 @@ void MediaPipeline::notifyBufferUnderflow(int32_t sourceId)
     }
 }
 
+void MediaPipeline::notifyPlaybackError(int32_t sourceId, const PlaybackError& error)
+{
+    RIALTO_CLIENT_LOG_DEBUG("entry:");
+
+    std::shared_ptr<IMediaPipelineClient> client = m_mediaPipelineClient.lock();
+    if (client)
+    {
+        client->notifyPlaybackError(sourceId, error);
+    }
+}
+
 }; // namespace firebolt::rialto::client

--- a/media/client/main/source/MediaPipeline.cpp
+++ b/media/client/main/source/MediaPipeline.cpp
@@ -695,7 +695,7 @@ void MediaPipeline::notifyBufferUnderflow(int32_t sourceId)
     }
 }
 
-void MediaPipeline::notifyPlaybackError(int32_t sourceId, const PlaybackError& error)
+void MediaPipeline::notifyPlaybackError(int32_t sourceId, const PlaybackError &error)
 {
     RIALTO_CLIENT_LOG_DEBUG("entry:");
 

--- a/media/client/main/source/MediaPipeline.cpp
+++ b/media/client/main/source/MediaPipeline.cpp
@@ -695,7 +695,7 @@ void MediaPipeline::notifyBufferUnderflow(int32_t sourceId)
     }
 }
 
-void MediaPipeline::notifyPlaybackError(int32_t sourceId, const PlaybackError &error)
+void MediaPipeline::notifyPlaybackError(int32_t sourceId, PlaybackError error)
 {
     RIALTO_CLIENT_LOG_DEBUG("entry:");
 

--- a/media/public/include/IMediaPipelineClient.h
+++ b/media/public/include/IMediaPipelineClient.h
@@ -202,8 +202,8 @@ public:
      *
      * PlaybackState remains unchanged when an error occurs.
      *
-     * @param[in] sourceId  : The id of the source that produced the error occured.
-     * @param[in] error     : The type of error that has occured.
+     * @param[in] sourceId  : The id of the source that produced the error.
+     * @param[in] error     : The type of error that occured.
      */
     virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) = 0;
 };

--- a/media/public/include/IMediaPipelineClient.h
+++ b/media/public/include/IMediaPipelineClient.h
@@ -196,6 +196,16 @@ public:
      * @param[in] sourceId  : The id of the source that produced the buffer underflow
      */
     virtual void notifyBufferUnderflow(int32_t sourceId) = 0;
+
+    /**
+     * @brief Notifies the client that a none fatal error has occured in the player.
+     *
+     * PlaybackState remains unchanged when an error occurs.
+     *
+     * @param[in] sourceId  : The id of the source that produced the error occured.
+     * @param[in] error     : The type of error that has occured.
+     */
+    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) = 0;
 };
 
 }; // namespace firebolt::rialto

--- a/media/public/include/IMediaPipelineClient.h
+++ b/media/public/include/IMediaPipelineClient.h
@@ -198,14 +198,14 @@ public:
     virtual void notifyBufferUnderflow(int32_t sourceId) = 0;
 
     /**
-     * @brief Notifies the client that a none fatal error has occured in the player.
+     * @brief Notifies the client that a none fatal error has occurred in the player.
      *
      * PlaybackState remains unchanged when an error occurs.
      *
      * @param[in] sourceId  : The id of the source that produced the error.
      * @param[in] error     : The type of error that occured.
      */
-    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) = 0;
+    virtual void notifyPlaybackError(int32_t sourceId, PlaybackError error) = 0;
 };
 
 }; // namespace firebolt::rialto

--- a/media/public/include/IMediaPipelineClient.h
+++ b/media/public/include/IMediaPipelineClient.h
@@ -205,7 +205,7 @@ public:
      * @param[in] sourceId  : The id of the source that produced the error.
      * @param[in] error     : The type of error that occured.
      */
-    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) = 0;
+    virtual void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) = 0;
 };
 
 }; // namespace firebolt::rialto

--- a/media/public/include/IMediaPipelineClient.h
+++ b/media/public/include/IMediaPipelineClient.h
@@ -198,7 +198,7 @@ public:
     virtual void notifyBufferUnderflow(int32_t sourceId) = 0;
 
     /**
-     * @brief Notifies the client that a none fatal error has occurred in the player.
+     * @brief Notifies the client that a non-fatal error has occurred in the player.
      *
      * PlaybackState remains unchanged when an error occurs.
      *

--- a/media/public/include/MediaCommon.h
+++ b/media/public/include/MediaCommon.h
@@ -382,7 +382,7 @@ struct CodecData
 enum class PlaybackError
 {
     UNKNOWN,
-    DECRYPTION, /* Player failed to decrypt a buffer and the frame has been dropped */ 
+    DECRYPTION, /* Player failed to decrypt a buffer and the frame has been dropped */
 };
 
 } // namespace firebolt::rialto

--- a/media/public/include/MediaCommon.h
+++ b/media/public/include/MediaCommon.h
@@ -376,6 +376,15 @@ struct CodecData
     CodecDataType type{CodecDataType::BUFFER}; /**< The codec data type */
 };
 
+/**
+ * @brief None fatel asynchronous errors reported by the player.
+ */
+enum class PlaybackError
+{
+    UNKNOWN,
+    DECRYPTION, /* Player failed to decrypt a buffer and the frame has been dropped */ 
+};
+
 } // namespace firebolt::rialto
 
 #endif // FIREBOLT_RIALTO_MEDIA_COMMON_H_

--- a/media/server/gstplayer/include/GstDecryptorPrivate.h
+++ b/media/server/gstplayer/include/GstDecryptorPrivate.h
@@ -21,9 +21,9 @@
 #define FIREBOLT_RIALTO_SERVER_GST_DECRYPTOR_PRIVATE_H_
 
 #include "IDecryptionService.h"
+#include "IGlibWrapper.h"
 #include "IGstProtectionMetadataHelper.h"
 #include "IGstWrapper.h"
-#include "IGlibWrapper.h"
 #include <gst/gst.h>
 #include <memory>
 

--- a/media/server/gstplayer/include/GstDecryptorPrivate.h
+++ b/media/server/gstplayer/include/GstDecryptorPrivate.h
@@ -23,6 +23,7 @@
 #include "IDecryptionService.h"
 #include "IGstProtectionMetadataHelper.h"
 #include "IGstWrapper.h"
+#include "IGlibWrapper.h"
 #include <gst/gst.h>
 #include <memory>
 
@@ -34,11 +35,13 @@ public:
     /**
      * @brief The constructor.
 
-     * @param[in] parentElement     : The parent decryptor element.
-     * @param[in] gstWrapperFactory : The gstreamer wrapper factory.
+     * @param[in] parentElement         : The parent decryptor element.
+     * @param[in] gstWrapperFactory     : The gstreamer wrapper factory.
+     * @param[in] glibWrapperFactory    : The glib wrapper factory.
      */
     GstRialtoDecryptorPrivate(GstBaseTransform *parentElement,
-                              const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapperFactory> &gstWrapperFactory);
+                              const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapperFactory> &gstWrapperFactory,
+                              const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapperFactory> &glibWrapperFactory);
 
     /**
      * @brief Decrypts the gst buffer.
@@ -69,6 +72,11 @@ private:
      * @brief The gstreamer wrapper object.
      */
     std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
+
+    /**
+     * @brief The glib wrapper object.
+     */
+    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
 
     /**
      * @brief The parent decryptor element.

--- a/media/server/gstplayer/include/IGstDecryptorElementFactory.h
+++ b/media/server/gstplayer/include/IGstDecryptorElementFactory.h
@@ -46,6 +46,9 @@ public:
     /**
      * @brief Creates a IGstDecryptorElement.
      *
+     * @param[in] decryptionService : The service used to decrypt frames.
+     * @param[in] gstWrapper        : The gstreamer wrapper.
+     *
      * @retval a decryptor element instance or null on error.
      */
     virtual GstElement *

--- a/media/server/gstplayer/interface/IGstGenericPlayerClient.h
+++ b/media/server/gstplayer/interface/IGstGenericPlayerClient.h
@@ -151,7 +151,7 @@ public:
     virtual void notifyBufferUnderflow(MediaSourceType mediaSourceType) = 0;
 
     /**
-     * @brief Notifies the client that a none fatal error has occurred in the player.
+     * @brief Notifies the client that a non-fatal error has occurred in the player.
      *
      * PlaybackState remains unchanged when an error occurs.
      *

--- a/media/server/gstplayer/interface/IGstGenericPlayerClient.h
+++ b/media/server/gstplayer/interface/IGstGenericPlayerClient.h
@@ -149,6 +149,16 @@ public:
      * @param[in] mediaSourceType  : The type of the source that produced the buffer underflow
      */
     virtual void notifyBufferUnderflow(MediaSourceType mediaSourceType) = 0;
+
+    /**
+     * @brief Notifies the client that a none fatal error has occured in the player.
+     *
+     * PlaybackState remains unchanged when an error occurs.
+     *
+     * @param[in] mediaSourceType  : The type of the source that produced the error.
+     * @param[in] error            : The type of error that occured.
+     */
+    virtual void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError& error) = 0;
 };
 
 }; // namespace firebolt::rialto::server

--- a/media/server/gstplayer/interface/IGstGenericPlayerClient.h
+++ b/media/server/gstplayer/interface/IGstGenericPlayerClient.h
@@ -151,14 +151,14 @@ public:
     virtual void notifyBufferUnderflow(MediaSourceType mediaSourceType) = 0;
 
     /**
-     * @brief Notifies the client that a none fatal error has occured in the player.
+     * @brief Notifies the client that a none fatal error has occurred in the player.
      *
      * PlaybackState remains unchanged when an error occurs.
      *
      * @param[in] mediaSourceType  : The type of the source that produced the error.
-     * @param[in] error            : The type of error that occured.
+     * @param[in] error            : The type of error that occurred.
      */
-    virtual void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError &error) = 0;
+    virtual void notifyPlaybackError(MediaSourceType mediaSourceType, PlaybackError error) = 0;
 };
 
 }; // namespace firebolt::rialto::server

--- a/media/server/gstplayer/interface/IGstGenericPlayerClient.h
+++ b/media/server/gstplayer/interface/IGstGenericPlayerClient.h
@@ -158,7 +158,7 @@ public:
      * @param[in] mediaSourceType  : The type of the source that produced the error.
      * @param[in] error            : The type of error that occured.
      */
-    virtual void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError& error) = 0;
+    virtual void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError &error) = 0;
 };
 
 }; // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstDecryptor.cpp
+++ b/media/server/gstplayer/source/GstDecryptor.cpp
@@ -231,9 +231,11 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
 {
     GstRialtoDecryptor *self = GST_RIALTO_DECRYPTOR(m_decryptorElement);
     GstRialtoProtectionData *protectionData = m_metadataWrapper->getProtectionMetadataData(buffer);
+    GstFlowReturn returnStatus = GST_BASE_TRANSFORM_FLOW_DROPPED; // By default drop frame on failure 
     if (!protectionData)
     {
         GST_TRACE_OBJECT(self, "Clear sample");
+        returnStatus = GST_FLOW_OK;
     }
     else
     {
@@ -295,6 +297,7 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
                 else
                 {
                     GST_TRACE_OBJECT(self, "Decryption successful");
+                    returnStatus = GST_FLOW_OK;
                 }
             }
 #else
@@ -325,6 +328,7 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
             else
             {
                 GST_TRACE_OBJECT(self, "Decryption successful");
+                returnStatus = GST_FLOW_OK;
             }
 #endif
         }

--- a/media/server/gstplayer/source/GstDecryptor.cpp
+++ b/media/server/gstplayer/source/GstDecryptor.cpp
@@ -125,7 +125,8 @@ static void gst_rialto_decryptor_init(GstRialtoDecryptor *self) // NOLINT(build/
         reinterpret_cast<GstRialtoDecryptorPrivate *>(gst_rialto_decryptor_get_instance_private(self));
     GstBaseTransform *base = GST_BASE_TRANSFORM(self);
 
-    self->priv = new (priv) GstRialtoDecryptorPrivate(base, firebolt::rialto::wrappers::IGstWrapperFactory::getFactory(), firebolt::rialto::wrappers::IGlibWrapperFactory::getFactory());
+    self->priv = new (priv) GstRialtoDecryptorPrivate(base, firebolt::rialto::wrappers::IGstWrapperFactory::getFactory(),
+                                                      firebolt::rialto::wrappers::IGlibWrapperFactory::getFactory());
 
     gst_base_transform_set_in_place(base, TRUE);
     gst_base_transform_set_passthrough(base, FALSE);
@@ -237,7 +238,7 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
 {
     GstRialtoDecryptor *self = GST_RIALTO_DECRYPTOR(m_decryptorElement);
     GstRialtoProtectionData *protectionData = m_metadataWrapper->getProtectionMetadataData(buffer);
-    GstFlowReturn returnStatus = GST_BASE_TRANSFORM_FLOW_DROPPED; // By default drop frame on failure 
+    GstFlowReturn returnStatus = GST_BASE_TRANSFORM_FLOW_DROPPED; // By default drop frame on failure
     if (!protectionData)
     {
         GST_TRACE_OBJECT(self, "Clear sample");
@@ -344,10 +345,13 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
 
     if (GST_BASE_TRANSFORM_FLOW_DROPPED == returnStatus)
     {
-        // Notify dropped frame upstream as a non-fatal message 
+        // Notify dropped frame upstream as a non-fatal message
         std::string message = "Failed to decrypt buffer, dropping frame and continuing";
         GError *gError{m_glibWrapper->gErrorNewLiteral(GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT, message.c_str())};
-        gboolean result = m_gstWrapper->gstElementPostMessage(GST_ELEMENT_CAST(self), m_gstWrapper->gstMessageNewWarning(GST_OBJECT_CAST(self), gError, message.c_str()));
+        gboolean result =
+            m_gstWrapper->gstElementPostMessage(GST_ELEMENT_CAST(self),
+                                                m_gstWrapper->gstMessageNewWarning(GST_OBJECT_CAST(self), gError,
+                                                                                   message.c_str()));
         if (!result)
         {
             GST_WARNING_OBJECT(self, "Could not post decrypt warning");

--- a/media/server/gstplayer/source/GstDecryptor.cpp
+++ b/media/server/gstplayer/source/GstDecryptor.cpp
@@ -336,8 +336,7 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
         m_metadataWrapper->removeProtectionMetadata(buffer);
     }
 
-    // pass it through even in case of failed decryption
-    return GST_FLOW_OK;
+    return returnStatus;
 }
 
 GstStructure *GstRialtoDecryptorPrivate::createProtectionMetaInfo(GstRialtoProtectionData *protectionData)

--- a/media/server/gstplayer/source/GstDecryptor.cpp
+++ b/media/server/gstplayer/source/GstDecryptor.cpp
@@ -336,6 +336,14 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
         m_metadataWrapper->removeProtectionMetadata(buffer);
     }
 
+    if (GST_BASE_TRANSFORM_FLOW_DROPPED == returnStatus)
+    {
+        // Notify dropped frame upstream as a non-fatal message 
+        std::string message = "Failed to decrypt buffer, dropping frame and continuing";
+        GError *gError{g_error_new_literal(GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT, message.c_str())};
+        gst_element_post_message(GST_ELEMENT_CAST(self), gst_message_new_warning(GST_OBJECT_CAST(self), gError, message.c_str()));
+        g_error_free(gError);
+    }
     return returnStatus;
 }
 

--- a/media/server/gstplayer/source/GstDecryptor.cpp
+++ b/media/server/gstplayer/source/GstDecryptor.cpp
@@ -336,6 +336,13 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
         m_metadataWrapper->removeProtectionMetadata(buffer);
     }
 
+    static int i = 0;
+    if (i == 5)
+    {
+        returnStatus = GST_BASE_TRANSFORM_FLOW_DROPPED;
+    }
+    i++;
+
     if (GST_BASE_TRANSFORM_FLOW_DROPPED == returnStatus)
     {
         // Notify dropped frame upstream as a non-fatal message 

--- a/media/server/gstplayer/source/GstDecryptor.cpp
+++ b/media/server/gstplayer/source/GstDecryptor.cpp
@@ -342,19 +342,16 @@ GstFlowReturn GstRialtoDecryptorPrivate::decrypt(GstBuffer *buffer, GstCaps *cap
         m_metadataWrapper->removeProtectionMetadata(buffer);
     }
 
-    static int i = 0;
-    if (i == 5)
-    {
-        returnStatus = GST_BASE_TRANSFORM_FLOW_DROPPED;
-    }
-    i++;
-
     if (GST_BASE_TRANSFORM_FLOW_DROPPED == returnStatus)
     {
         // Notify dropped frame upstream as a non-fatal message 
         std::string message = "Failed to decrypt buffer, dropping frame and continuing";
         GError *gError{m_glibWrapper->gErrorNewLiteral(GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT, message.c_str())};
-        m_gstWrapper->gstElementPostMessage(GST_ELEMENT_CAST(self), m_gstWrapper->gstMessageNewWarning(GST_OBJECT_CAST(self), gError, message.c_str()));
+        gboolean result = m_gstWrapper->gstElementPostMessage(GST_ELEMENT_CAST(self), m_gstWrapper->gstMessageNewWarning(GST_OBJECT_CAST(self), gError, message.c_str()));
+        if (!result)
+        {
+            GST_WARNING_OBJECT(self, "Could not post decrypt warning");
+        }
         m_glibWrapper->gErrorFree(gError);
     }
     return returnStatus;

--- a/media/server/gstplayer/source/GstDispatcherThread.cpp
+++ b/media/server/gstplayer/source/GstDispatcherThread.cpp
@@ -61,7 +61,7 @@ void GstDispatcherThread::gstBusEventHandler(GstElement *pipeline)
         GstMessage *message =
             m_gstWrapper->gstBusTimedPopFiltered(bus, 100 * GST_MSECOND,
                                                  static_cast<GstMessageType>(GST_MESSAGE_STATE_CHANGED | GST_MESSAGE_QOS |
-                                                                             GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+                                                                             GST_MESSAGE_EOS | GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
 
         if (message)
         {

--- a/media/server/gstplayer/source/GstDispatcherThread.cpp
+++ b/media/server/gstplayer/source/GstDispatcherThread.cpp
@@ -60,8 +60,9 @@ void GstDispatcherThread::gstBusEventHandler(GstElement *pipeline)
     {
         GstMessage *message =
             m_gstWrapper->gstBusTimedPopFiltered(bus, 100 * GST_MSECOND,
-                                                 static_cast<GstMessageType>(GST_MESSAGE_STATE_CHANGED | GST_MESSAGE_QOS |
-                                                                             GST_MESSAGE_EOS | GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
+                                                 static_cast<GstMessageType>(GST_MESSAGE_STATE_CHANGED |
+                                                                             GST_MESSAGE_QOS | GST_MESSAGE_EOS |
+                                                                             GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
 
         if (message)
         {

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -201,7 +201,7 @@ void HandleBusMessage::execute() const
         PlaybackError rialtoError = PlaybackError::UNKNOWN;
         GError *err = nullptr;
         gchar *debug = nullptr;
-        gst_message_parse_warning(m_message, &err, &debug);
+        m_gstWrapper->gstMessageParseWarning(m_message, &err, &debug);
     
         if ((err->domain == GST_STREAM_ERROR) && (err->code == GST_STREAM_ERROR_DECRYPT))
         {
@@ -218,18 +218,21 @@ void HandleBusMessage::execute() const
         if ((PlaybackError::UNKNOWN != rialtoError) && (m_gstPlayerClient))
         {
             const gchar* mimetype = nullptr;
-            GstPad* srcpad = gst_element_get_static_pad(GST_ELEMENT(GST_MESSAGE_SRC(m_message)), "src");
+            GstPad* srcpad = m_gstWrapper->gstElementGetStaticPad(GST_ELEMENT(GST_MESSAGE_SRC(m_message)), "src");
             if (srcpad)
             {
-                GstCaps* caps = gst_pad_get_current_caps(srcpad);
+                GstCaps* caps = m_gstWrapper->gstPadGetCurrentCaps(srcpad);
                 if (caps)
                 {
-                    GstStructure* structure = gst_caps_get_structure(caps, 0);
-                    mimetype = gst_structure_get_name(structure);
-                    g_object_unref(caps);
-                    g_object_unref(structure);
+                    GstStructure* structure = m_gstWrapper->gstCapsGetStructure(caps, 0);
+                    if (structure)
+                    {
+                        mimetype = m_gstWrapper->gstStructureGetName(structure);
+                        m_glibWrapper->gObjectUnref(structure);
+                    }
+                    m_glibWrapper->gObjectUnref(caps);
                 }
-                g_object_unref(srcpad);
+                m_glibWrapper->gObjectUnref(srcpad);
             }
 
             if (mimetype)

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -202,29 +202,29 @@ void HandleBusMessage::execute() const
         GError *err = nullptr;
         gchar *debug = nullptr;
         m_gstWrapper->gstMessageParseWarning(m_message, &err, &debug);
-    
+
         if ((err->domain == GST_STREAM_ERROR) && (err->code == GST_STREAM_ERROR_DECRYPT))
         {
             RIALTO_SERVER_LOG_WARN("Decrypt error %s - %d: %s (%s)", GST_OBJECT_NAME(GST_MESSAGE_SRC(m_message)),
-                                    err->code, err->message, debug);
+                                   err->code, err->message, debug);
             rialtoError = PlaybackError::DECRYPTION;
         }
         else
         {
-            RIALTO_SERVER_LOG_WARN("Unknown warning, ignoring %s - %d: %s (%s)", GST_OBJECT_NAME(GST_MESSAGE_SRC(m_message)),
-                                    err->code, err->message, debug);
+            RIALTO_SERVER_LOG_WARN("Unknown warning, ignoring %s - %d: %s (%s)",
+                                   GST_OBJECT_NAME(GST_MESSAGE_SRC(m_message)), err->code, err->message, debug);
         }
 
         if ((PlaybackError::UNKNOWN != rialtoError) && (m_gstPlayerClient))
         {
-            const gchar* mimetype = nullptr;
-            GstPad* srcpad = m_gstWrapper->gstElementGetStaticPad(GST_ELEMENT(GST_MESSAGE_SRC(m_message)), "src");
+            const gchar *mimetype = nullptr;
+            GstPad *srcpad = m_gstWrapper->gstElementGetStaticPad(GST_ELEMENT(GST_MESSAGE_SRC(m_message)), "src");
             if (srcpad)
             {
-                GstCaps* caps = m_gstWrapper->gstPadGetCurrentCaps(srcpad);
+                GstCaps *caps = m_gstWrapper->gstPadGetCurrentCaps(srcpad);
                 if (caps)
                 {
-                    GstStructure* structure = m_gstWrapper->gstCapsGetStructure(caps, 0);
+                    GstStructure *structure = m_gstWrapper->gstCapsGetStructure(caps, 0);
                     if (structure)
                     {
                         mimetype = m_gstWrapper->gstStructureGetName(structure);
@@ -239,11 +239,13 @@ void HandleBusMessage::execute() const
             {
                 if (g_strrstr(mimetype, "video"))
                 {
-                    m_gstPlayerClient->notifyPlaybackError(firebolt::rialto::MediaSourceType::VIDEO, PlaybackError::DECRYPTION);
+                    m_gstPlayerClient->notifyPlaybackError(firebolt::rialto::MediaSourceType::VIDEO,
+                                                           PlaybackError::DECRYPTION);
                 }
                 else if (g_strrstr(mimetype, "audio"))
                 {
-                    m_gstPlayerClient->notifyPlaybackError(firebolt::rialto::MediaSourceType::AUDIO, PlaybackError::DECRYPTION);
+                    m_gstPlayerClient->notifyPlaybackError(firebolt::rialto::MediaSourceType::AUDIO,
+                                                           PlaybackError::DECRYPTION);
                 }
                 else
                 {

--- a/media/server/ipc/include/MediaPipelineClient.h
+++ b/media/server/ipc/include/MediaPipelineClient.h
@@ -45,7 +45,7 @@ public:
     void notifyCancelNeedMediaData(int32_t sourceId) override;
     void notifyQos(int32_t sourceId, const QosInfo &qosInfo) override;
     void notifyBufferUnderflow(int32_t sourceId) override;
-    void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) override;
+    void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) override;
 
 private:
     int m_sessionId;

--- a/media/server/ipc/include/MediaPipelineClient.h
+++ b/media/server/ipc/include/MediaPipelineClient.h
@@ -45,6 +45,7 @@ public:
     void notifyCancelNeedMediaData(int32_t sourceId) override;
     void notifyQos(int32_t sourceId, const QosInfo &qosInfo) override;
     void notifyBufferUnderflow(int32_t sourceId) override;
+    void notifyPlaybackError(int32_t sourceId, const PlaybackError& error) override;
 
 private:
     int m_sessionId;

--- a/media/server/ipc/include/MediaPipelineClient.h
+++ b/media/server/ipc/include/MediaPipelineClient.h
@@ -45,7 +45,7 @@ public:
     void notifyCancelNeedMediaData(int32_t sourceId) override;
     void notifyQos(int32_t sourceId, const QosInfo &qosInfo) override;
     void notifyBufferUnderflow(int32_t sourceId) override;
-    void notifyPlaybackError(int32_t sourceId, const PlaybackError &error) override;
+    void notifyPlaybackError(int32_t sourceId, PlaybackError error) override;
 
 private:
     int m_sessionId;

--- a/media/server/ipc/source/MediaPipelineClient.cpp
+++ b/media/server/ipc/source/MediaPipelineClient.cpp
@@ -240,7 +240,7 @@ void MediaPipelineClient::notifyBufferUnderflow(int32_t sourceId)
     m_ipcClient->sendEvent(event);
 }
 
-void MediaPipelineClient::notifyPlaybackError(int32_t sourceId, const PlaybackError &error)
+void MediaPipelineClient::notifyPlaybackError(int32_t sourceId, PlaybackError error)
 {
     RIALTO_SERVER_LOG_DEBUG("Sending notifyPlaybackError...");
 

--- a/media/server/ipc/source/MediaPipelineClient.cpp
+++ b/media/server/ipc/source/MediaPipelineClient.cpp
@@ -246,6 +246,7 @@ void MediaPipelineClient::notifyPlaybackError(int32_t sourceId, const PlaybackEr
     RIALTO_SERVER_LOG_DEBUG("Sending notifyPlaybackError...");
 
     auto event = std::make_shared<firebolt::rialto::PlaybackErrorEvent>();
+    event->set_session_id(m_sessionId);
     event->set_source_id(sourceId);
     event->set_error(convertPlaybackError(error));
 

--- a/media/server/ipc/source/MediaPipelineClient.cpp
+++ b/media/server/ipc/source/MediaPipelineClient.cpp
@@ -113,6 +113,23 @@ convertNetworkState(const firebolt::rialto::NetworkState &networkState)
     }
     return firebolt::rialto::NetworkStateChangeEvent_NetworkState_UNKNOWN;
 }
+
+firebolt::rialto::PlaybackErrorEvent_PlaybackError
+convertPlaybackError(const firebolt::rialto::PlaybackError &playbackError)
+{
+    switch (playbackError)
+    {
+    case firebolt::rialto::PlaybackError::UNKNOWN:
+    {
+        return firebolt::rialto::PlaybackErrorEvent_PlaybackError_UNKNOWN;
+    }
+    case firebolt::rialto::PlaybackError::DECRYPTION:
+    {
+        return firebolt::rialto::PlaybackErrorEvent_PlaybackError_DECRYPTION;
+    }
+    }
+    return firebolt::rialto::PlaybackErrorEvent_PlaybackError_UNKNOWN;
+}
 } // namespace
 
 namespace firebolt::rialto::server::ipc
@@ -227,5 +244,11 @@ void MediaPipelineClient::notifyBufferUnderflow(int32_t sourceId)
 void MediaPipelineClient::notifyPlaybackError(int32_t sourceId, const PlaybackError& error)
 {
     RIALTO_SERVER_LOG_DEBUG("Sending notifyPlaybackError...");
+
+    auto event = std::make_shared<firebolt::rialto::PlaybackErrorEvent>();
+    event->set_source_id(sourceId);
+    event->set_error(convertPlaybackError(error));
+
+    m_ipcClient->sendEvent(event);
 }
 } // namespace firebolt::rialto::server::ipc

--- a/media/server/ipc/source/MediaPipelineClient.cpp
+++ b/media/server/ipc/source/MediaPipelineClient.cpp
@@ -114,8 +114,7 @@ convertNetworkState(const firebolt::rialto::NetworkState &networkState)
     return firebolt::rialto::NetworkStateChangeEvent_NetworkState_UNKNOWN;
 }
 
-firebolt::rialto::PlaybackErrorEvent_PlaybackError
-convertPlaybackError(const firebolt::rialto::PlaybackError &playbackError)
+firebolt::rialto::PlaybackErrorEvent_PlaybackError convertPlaybackError(const firebolt::rialto::PlaybackError &playbackError)
 {
     switch (playbackError)
     {
@@ -241,7 +240,7 @@ void MediaPipelineClient::notifyBufferUnderflow(int32_t sourceId)
     m_ipcClient->sendEvent(event);
 }
 
-void MediaPipelineClient::notifyPlaybackError(int32_t sourceId, const PlaybackError& error)
+void MediaPipelineClient::notifyPlaybackError(int32_t sourceId, const PlaybackError &error)
 {
     RIALTO_SERVER_LOG_DEBUG("Sending notifyPlaybackError...");
 

--- a/media/server/ipc/source/MediaPipelineClient.cpp
+++ b/media/server/ipc/source/MediaPipelineClient.cpp
@@ -223,4 +223,9 @@ void MediaPipelineClient::notifyBufferUnderflow(int32_t sourceId)
 
     m_ipcClient->sendEvent(event);
 }
+
+void MediaPipelineClient::notifyPlaybackError(int32_t sourceId, const PlaybackError& error)
+{
+    RIALTO_SERVER_LOG_DEBUG("Sending notifyPlaybackError...");
+}
 } // namespace firebolt::rialto::server::ipc

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -148,6 +148,8 @@ public:
 
     void notifyBufferUnderflow(MediaSourceType mediaSourceType) override;
 
+    void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError& error) override;
+
 protected:
     /**
      * @brief The media player client.

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -148,7 +148,7 @@ public:
 
     void notifyBufferUnderflow(MediaSourceType mediaSourceType) override;
 
-    void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError &error) override;
+    void notifyPlaybackError(MediaSourceType mediaSourceType, PlaybackError error) override;
 
 protected:
     /**

--- a/media/server/main/include/MediaPipelineServerInternal.h
+++ b/media/server/main/include/MediaPipelineServerInternal.h
@@ -148,7 +148,7 @@ public:
 
     void notifyBufferUnderflow(MediaSourceType mediaSourceType) override;
 
-    void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError& error) override;
+    void notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError &error) override;
 
 protected:
     /**

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -991,6 +991,27 @@ void MediaPipelineServerInternal::notifyBufferUnderflow(MediaSourceType mediaSou
     m_mainThread->enqueueTask(m_mainThreadClientId, task);
 }
 
+void MediaPipelineServerInternal::notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError& error)
+{
+    RIALTO_SERVER_LOG_DEBUG("entry:");
+
+    auto task = [&, mediaSourceType, error]()
+    {
+        if (m_mediaPipelineClient)
+        {
+            const auto kSourceIter = m_attachedSources.find(mediaSourceType);
+            if (m_attachedSources.cend() == kSourceIter)
+            {
+                RIALTO_SERVER_LOG_WARN("Playback error notification failed - sourceId not found");
+                return;
+            }
+            m_mediaPipelineClient->notifyPlaybackError(kSourceIter->second, error);
+        }
+    };
+
+    m_mainThread->enqueueTask(m_mainThreadClientId, task);
+}
+
 void MediaPipelineServerInternal::scheduleNotifyNeedMediaData(MediaSourceType mediaSourceType)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -991,7 +991,7 @@ void MediaPipelineServerInternal::notifyBufferUnderflow(MediaSourceType mediaSou
     m_mainThread->enqueueTask(m_mainThreadClientId, task);
 }
 
-void MediaPipelineServerInternal::notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError& error)
+void MediaPipelineServerInternal::notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError &error)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
 

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -991,7 +991,7 @@ void MediaPipelineServerInternal::notifyBufferUnderflow(MediaSourceType mediaSou
     m_mainThread->enqueueTask(m_mainThreadClientId, task);
 }
 
-void MediaPipelineServerInternal::notifyPlaybackError(MediaSourceType mediaSourceType, const PlaybackError &error)
+void MediaPipelineServerInternal::notifyPlaybackError(MediaSourceType mediaSourceType, PlaybackError error)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
 

--- a/proto/mediapipelinemodule.proto
+++ b/proto/mediapipelinemodule.proto
@@ -538,7 +538,7 @@ message BufferUnderflowEvent {
 }
 
 /**
- * @brief Event sent by the server when a none fatal error has occurred in the player.
+ * @brief Event sent by the server when a non-fatalrror has occurred in the player.
  *
  * @param session_id        The id of the A/V session the request is for.
  * @param source_id         The id of the media source the request is for.

--- a/proto/mediapipelinemodule.proto
+++ b/proto/mediapipelinemodule.proto
@@ -538,6 +538,24 @@ message BufferUnderflowEvent {
 }
 
 /**
+ * @brief 
+ *
+ * @param source_id         The id of the media source the request is for.
+ *
+ * This is sent by the server whenever buffer underflow occurs
+ */
+message PlaybackErrorEvent {
+    enum PlaybackError {
+        UNKNOWN = 0;            ///< An unknown or undefined network state.
+        DECRYPTION = 1;         ///< Player failed to decrypt a buffer and the frame has been dropped.
+    }
+
+    optional int32 session_id = 1 [default = -1];
+    optional int32 source_id = 2 [default = -1];
+    optional PlaybackError error = 3;
+}
+
+/**
  * @brief Requests RialtoClient to change its log levels
  *
  * @param[in]  defaultLogLevels       Desired default log level

--- a/proto/mediapipelinemodule.proto
+++ b/proto/mediapipelinemodule.proto
@@ -538,11 +538,11 @@ message BufferUnderflowEvent {
 }
 
 /**
- * @brief 
+ * @brief Event sent by the server when a none fatal error has occurred in the player.
  *
+ * @param session_id        The id of the A/V session the request is for.
  * @param source_id         The id of the media source the request is for.
- *
- * This is sent by the server whenever buffer underflow occurs
+ * @param error             The type of error that occurred.
  */
 message PlaybackErrorEvent {
     enum PlaybackError {

--- a/proto/mediapipelinemodule.proto
+++ b/proto/mediapipelinemodule.proto
@@ -538,7 +538,7 @@ message BufferUnderflowEvent {
 }
 
 /**
- * @brief Event sent by the server when a non-fatalrror has occurred in the player.
+ * @brief Event sent by the server when a non-fatal error has occurred in the player.
  *
  * @param session_id        The id of the A/V session the request is for.
  * @param source_id         The id of the media source the request is for.

--- a/tests/common/externalLibraryMocks/GlibWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GlibWrapperMock.h
@@ -99,7 +99,7 @@ public:
     MOCK_METHOD(int, gStrcmp0, (const char *str1, const char *str2), (const, override));
     MOCK_METHOD(gpointer, gValueGetObject, (const GValue *value), (const, override));
     MOCK_METHOD(void, gValueUnset, (GValue * value), (const, override));
-    MOCK_METHOD(GError*, gErrorNewLiteral, (GQuark domain, gint code, const gchar* message), (const, override));
+    MOCK_METHOD(GError *, gErrorNewLiteral, (GQuark domain, gint code, const gchar *message), (const, override));
 };
 } // namespace firebolt::rialto::wrappers
 

--- a/tests/common/externalLibraryMocks/GlibWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GlibWrapperMock.h
@@ -99,6 +99,7 @@ public:
     MOCK_METHOD(int, gStrcmp0, (const char *str1, const char *str2), (const, override));
     MOCK_METHOD(gpointer, gValueGetObject, (const GValue *value), (const, override));
     MOCK_METHOD(void, gValueUnset, (GValue * value), (const, override));
+    MOCK_METHOD(GError*, gErrorNewLiteral, (GQuark domain, gint code, const gchar* message), (const, override));
 };
 } // namespace firebolt::rialto::wrappers
 

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -188,6 +188,10 @@ public:
     MOCK_METHOD(void, gstIteratorFree, (GstIterator * it), (const, override));
     MOCK_METHOD(gboolean, gstElementPostMessage, (GstElement * element, GstMessage * message), (const, override));
     MOCK_METHOD(GstMessage *, gstMessageNewWarning, (GstObject * src, GError * error, const gchar * debug), (const, override));
+    MOCK_METHOD(void, gstMessageParseWarning, (GstMessage * message, GError ** gerror, gchar ** debug), (const, override));
+    MOCK_METHOD(GstCaps *, gstPadGetCurrentCaps, (GstPad * pad), (const, override));
+    MOCK_METHOD(GstStructure *, gstCapsGetStructure, (const GstCaps * caps, guint index), (const, override));
+    MOCK_METHOD(const gchar *, gstStructureGetName, (const GstStructure * structure), (const, override));
 
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -186,6 +186,8 @@ public:
     MOCK_METHOD(GstIterator *, gstBinIterateSinks, (GstBin * bin), (const, override));
     MOCK_METHOD(GstIteratorResult, gstIteratorNext, (GstIterator * it, GValue *elem), (const, override));
     MOCK_METHOD(void, gstIteratorFree, (GstIterator * it), (const, override));
+    MOCK_METHOD(gboolean, gstElementPostMessage, (GstElement * element, GstMessage * message), (const, override));
+    MOCK_METHOD(GstMessage *, gstMessageNewWarning, (GstObject * src, GError * error, const gchar * debug), (const, override));
 
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -186,12 +186,13 @@ public:
     MOCK_METHOD(GstIterator *, gstBinIterateSinks, (GstBin * bin), (const, override));
     MOCK_METHOD(GstIteratorResult, gstIteratorNext, (GstIterator * it, GValue *elem), (const, override));
     MOCK_METHOD(void, gstIteratorFree, (GstIterator * it), (const, override));
-    MOCK_METHOD(gboolean, gstElementPostMessage, (GstElement * element, GstMessage * message), (const, override));
-    MOCK_METHOD(GstMessage *, gstMessageNewWarning, (GstObject * src, GError * error, const gchar * debug), (const, override));
-    MOCK_METHOD(void, gstMessageParseWarning, (GstMessage * message, GError ** gerror, gchar ** debug), (const, override));
+    MOCK_METHOD(gboolean, gstElementPostMessage, (GstElement * element, GstMessage *message), (const, override));
+    MOCK_METHOD(GstMessage *, gstMessageNewWarning, (GstObject * src, GError *error, const gchar *debug),
+                (const, override));
+    MOCK_METHOD(void, gstMessageParseWarning, (GstMessage * message, GError **gerror, gchar **debug), (const, override));
     MOCK_METHOD(GstCaps *, gstPadGetCurrentCaps, (GstPad * pad), (const, override));
-    MOCK_METHOD(GstStructure *, gstCapsGetStructure, (const GstCaps * caps, guint index), (const, override));
-    MOCK_METHOD(const gchar *, gstStructureGetName, (const GstStructure * structure), (const, override));
+    MOCK_METHOD(GstStructure *, gstCapsGetStructure, (const GstCaps *caps, guint index), (const, override));
+    MOCK_METHOD(const gchar *, gstStructureGetName, (const GstStructure *structure), (const, override));
 
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {

--- a/tests/common/protoUtils/MediaPipelineProtoUtils.h
+++ b/tests/common/protoUtils/MediaPipelineProtoUtils.h
@@ -183,4 +183,20 @@ convertNetworkState(const firebolt::rialto::NetworkState &kNetworkState)
     return firebolt::rialto::NetworkStateChangeEvent_NetworkState_UNKNOWN;
 }
 
+firebolt::rialto::PlaybackErrorEvent_PlaybackError
+convertPlaybackError(const firebolt::rialto::PlaybackError &playbackError)
+{
+    switch (playbackError)
+    {
+    case firebolt::rialto::PlaybackError::UNKNOWN:
+    {
+        return firebolt::rialto::PlaybackErrorEvent_PlaybackError_UNKNOWN;
+    }
+    case firebolt::rialto::PlaybackError::DECRYPTION:
+    {
+        return firebolt::rialto::PlaybackErrorEvent_PlaybackError_DECRYPTION;
+    }
+    }
+    return firebolt::rialto::PlaybackErrorEvent_PlaybackError_UNKNOWN;
+}
 #endif // MEDIA_PIPELINE_PROTO_UTILS_H_

--- a/tests/common/protoUtils/MediaPipelineProtoUtils.h
+++ b/tests/common/protoUtils/MediaPipelineProtoUtils.h
@@ -183,7 +183,7 @@ convertNetworkState(const firebolt::rialto::NetworkState &kNetworkState)
     return firebolt::rialto::NetworkStateChangeEvent_NetworkState_UNKNOWN;
 }
 
-firebolt::rialto::PlaybackErrorEvent_PlaybackError
+inline firebolt::rialto::PlaybackErrorEvent_PlaybackError
 convertPlaybackError(const firebolt::rialto::PlaybackError &playbackError)
 {
     switch (playbackError)

--- a/tests/common/publicClientMocks/MediaPipelineClientMock.h
+++ b/tests/common/publicClientMocks/MediaPipelineClientMock.h
@@ -46,7 +46,7 @@ public:
     MOCK_METHOD(void, notifyCancelNeedMediaData, (int32_t sourceId), (override));
     MOCK_METHOD(void, notifyQos, (int32_t sourceId, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (int32_t sourceId), (override));
-    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError& error), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError &error), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/common/publicClientMocks/MediaPipelineClientMock.h
+++ b/tests/common/publicClientMocks/MediaPipelineClientMock.h
@@ -46,6 +46,7 @@ public:
     MOCK_METHOD(void, notifyCancelNeedMediaData, (int32_t sourceId), (override));
     MOCK_METHOD(void, notifyQos, (int32_t sourceId, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (int32_t sourceId), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError& error), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/common/publicClientMocks/MediaPipelineClientMock.h
+++ b/tests/common/publicClientMocks/MediaPipelineClientMock.h
@@ -46,7 +46,7 @@ public:
     MOCK_METHOD(void, notifyCancelNeedMediaData, (int32_t sourceId), (override));
     MOCK_METHOD(void, notifyQos, (int32_t sourceId, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (int32_t sourceId), (override));
-    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError &error), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, PlaybackError error), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/componenttests/client/CMakeLists.txt
+++ b/tests/componenttests/client/CMakeLists.txt
@@ -65,6 +65,7 @@ add_gtests (
         tests/mse/UnderflowNotificationTest.cpp
         tests/mse/QosNotificationTest.cpp
         tests/mse/RemoveAudioPlaybackTest.cpp
+        tests/mse/PlaybackErrorNotificationTest.cpp
 
         # EME Component tests
         tests/eme/SessionReadyForDecryptionTest.cpp

--- a/tests/componenttests/client/stubs/MediaPipelineModuleStub.cpp
+++ b/tests/componenttests/client/stubs/MediaPipelineModuleStub.cpp
@@ -105,4 +105,15 @@ void MediaPipelineModuleStub::notifyBufferUnderflowEvent(int sessionId, int32_t 
     getClient()->sendEvent(event);
 }
 
+void MediaPipelineModuleStub::notifyPlaybackErrorEvent(int sessionId, int32_t sourceId, PlaybackError error)
+{
+    waitForClientConnect();
+
+    auto event = std::make_shared<firebolt::rialto::PlaybackErrorEvent>();
+    event->set_session_id(sessionId);
+    event->set_source_id(sourceId);
+    event->set_error(convertPlaybackError(error));
+    getClient()->sendEvent(event);
+}
+
 } // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/stubs/MediaPipelineModuleStub.h
+++ b/tests/componenttests/client/stubs/MediaPipelineModuleStub.h
@@ -40,6 +40,7 @@ public:
     void notifyPositionChangeEvent(int sessionId, int64_t position);
     void notifyQosEvent(int sessionId, int32_t sourceId, const ::firebolt::rialto::QosInfo &qosInfo);
     void notifyBufferUnderflowEvent(int sessionId, int32_t sourceId);
+    void notifyPlaybackErrorEvent(int sessionId, int32_t sourceId, PlaybackError error);
 
     // Client helpers
     virtual void waitForClientConnect() = 0;

--- a/tests/componenttests/client/tests/base/MediaPipelineTestMethods.cpp
+++ b/tests/componenttests/client/tests/base/MediaPipelineTestMethods.cpp
@@ -1242,6 +1242,30 @@ void MediaPipelineTestMethods::sendNotifyBufferUnderflowVideo()
     waitEvent();
 }
 
+void MediaPipelineTestMethods::shouldNotifyPlaybackErrorAudio()
+{
+    EXPECT_CALL(*m_mediaPipelineClientMock, notifyPlaybackError(kAudioSourceId, PlaybackError::DECRYPTION))
+        .WillOnce(Invoke(this, &MediaPipelineTestMethods::notifyEvent));
+}
+
+void MediaPipelineTestMethods::shouldNotifyPlaybackErrorVideo()
+{
+    EXPECT_CALL(*m_mediaPipelineClientMock, notifyPlaybackError(kVideoSourceId, PlaybackError::DECRYPTION))
+        .WillOnce(Invoke(this, &MediaPipelineTestMethods::notifyEvent));
+}
+
+void MediaPipelineTestMethods::sendNotifyPlaybackErrorAudio()
+{
+    getServerStub()->notifyPlaybackErrorEvent(kSessionId, kAudioSourceId, PlaybackError::DECRYPTION);
+    waitEvent();
+}
+
+void MediaPipelineTestMethods::sendNotifyPlaybackErrorVideo()
+{
+    getServerStub()->notifyPlaybackErrorEvent(kSessionId, kVideoSourceId, PlaybackError::DECRYPTION);
+    waitEvent();
+}
+
 void MediaPipelineTestMethods::shouldGetPosition(const int64_t position)
 {
     EXPECT_CALL(*m_mediaPipelineModuleMock, getPosition(_, getPositionRequestMatcher(kSessionId), _, _))

--- a/tests/componenttests/client/tests/base/MediaPipelineTestMethods.h
+++ b/tests/componenttests/client/tests/base/MediaPipelineTestMethods.h
@@ -145,6 +145,8 @@ protected:
     void shouldNotifyQosVideo();
     void shouldNotifyBufferUnderflowAudio();
     void shouldNotifyBufferUnderflowVideo();
+    void shouldNotifyPlaybackErrorAudio();
+    void shouldNotifyPlaybackErrorVideo();
 
     // Api methods
     void createMediaPipeline();
@@ -229,6 +231,8 @@ protected:
     void sendNotifyQosVideo();
     void sendNotifyBufferUnderflowAudio();
     void sendNotifyBufferUnderflowVideo();
+    void sendNotifyPlaybackErrorAudio();
+    void sendNotifyPlaybackErrorVideo();
 
     // Check methods
     void checkMseAudioSegmentWritten(int32_t segmentId);

--- a/tests/componenttests/client/tests/mse/PlaybackErrorNotificationTest.cpp
+++ b/tests/componenttests/client/tests/mse/PlaybackErrorNotificationTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ClientComponentTest.h"
+#include <gtest/gtest.h>
+
+namespace firebolt::rialto::client::ct
+{
+class PlaybackErrorNotificationTest : public ClientComponentTest
+{
+public:
+    PlaybackErrorNotificationTest() : ClientComponentTest()
+    {
+        ClientComponentTest::startApplicationRunning();
+        MediaPipelineTestMethods::startAudioVideoMediaSessionPrerollPaused();
+
+        // Play
+        MediaPipelineTestMethods::shouldPlay();
+        MediaPipelineTestMethods::play();
+        MediaPipelineTestMethods::shouldNotifyPlaybackStatePlaying();
+        MediaPipelineTestMethods::sendNotifyPlaybackStatePlaying();
+    }
+
+    ~PlaybackErrorNotificationTest()
+    {
+        MediaPipelineTestMethods::endAudioVideoMediaSession();
+        ClientComponentTest::stopApplication();
+    }
+};
+
+/*
+ * Component Test: PlaybackError Notification
+ * Test Objective:
+ *  Test the PlaybackError notification for all sources.
+ *
+ * Sequence Diagrams:
+ *  TODO
+ *
+ * Test Setup:
+ *  Language: C++
+ *  Testing Framework: Google Test
+ *  Components: MediaPipeline
+ *
+ * Test Initialize:
+ *  Create memory region for the shared buffer.
+ *  Create a server that handles Control IPC requests.
+ *  Initalise the control state to running for this test application.
+ *  Initalise a audio video media session playing.
+ *
+ * Test Steps:
+ *  Step 1: Notify playback error audio
+ *   Server notifies the client playback error for audio.
+ *   Expect that the playback error notification is propagated to the client.
+ *   Check source & playback error.
+ *
+ *  Step 2: Notify playback error video
+ *   Server notify the client playback error for video.
+ *   Expect that the playback error notification is propagated to the client.
+ *   Check source & playback error.
+ *
+ * Test Tear-down:
+ *  Terminate the media session.
+ *  Memory region created for the shared buffer is closed.
+ *  Server is terminated.
+ *
+ * Expected Results:
+ *  PlaybackError notifications for audio or video are handled by rialto client and the information is sent to the application.
+ *
+ * Code:
+ */
+TEST_F(PlaybackErrorNotificationTest, notifications)
+{
+    // Step 1: Notify playback error audio
+    MediaPipelineTestMethods::shouldNotifyPlaybackErrorAudio();
+    MediaPipelineTestMethods::sendNotifyPlaybackErrorAudio();
+
+    // Step 2: Notify playback error video
+    MediaPipelineTestMethods::shouldNotifyPlaybackErrorVideo();
+    MediaPipelineTestMethods::sendNotifyPlaybackErrorVideo();
+}
+} // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/mse/PlaybackErrorNotificationTest.cpp
+++ b/tests/componenttests/client/tests/mse/PlaybackErrorNotificationTest.cpp
@@ -50,12 +50,12 @@ public:
  *  Test the PlaybackError notification for all sources.
  *
  * Sequence Diagrams:
- *  TODO
+ * Non-fatal Errors - https://wiki.rdkcentral.com/display/ASP/Rialto+Playback+Design
  *
  * Test Setup:
  *  Language: C++
  *  Testing Framework: Google Test
- *  Components: MediaPipeline
+ *  Components: MediaPipelineClient
  *
  * Test Initialize:
  *  Create memory region for the shared buffer.
@@ -67,12 +67,10 @@ public:
  *  Step 1: Notify playback error audio
  *   Server notifies the client playback error for audio.
  *   Expect that the playback error notification is propagated to the client.
- *   Check source & playback error.
  *
  *  Step 2: Notify playback error video
  *   Server notify the client playback error for video.
  *   Expect that the playback error notification is propagated to the client.
- *   Check source & playback error.
  *
  * Test Tear-down:
  *  Terminate the media session.

--- a/tests/componenttests/server/stubs/GstreamerStub.cpp
+++ b/tests/componenttests/server/stubs/GstreamerStub.cpp
@@ -71,7 +71,8 @@ void GstreamerStub::setupPipeline()
     EXPECT_CALL(*m_gstWrapperMock,
                 gstBusTimedPopFiltered(m_bus, 100 * GST_MSECOND,
                                        static_cast<GstMessageType>(GST_MESSAGE_STATE_CHANGED | GST_MESSAGE_QOS |
-                                                                   GST_MESSAGE_EOS | GST_MESSAGE_ERROR | GST_MESSAGE_WARNING)))
+                                                                   GST_MESSAGE_EOS | GST_MESSAGE_ERROR |
+                                                                   GST_MESSAGE_WARNING)))
         .WillRepeatedly(Invoke(
             [&](GstBus *bus, GstClockTime timeout, GstMessageType types)
             {
@@ -142,11 +143,10 @@ void GstreamerStub::sendQos(GstElement *src)
     m_cv.notify_one();
 }
 
-void GstreamerStub::sendWarning(GstElement *src, GError *error, const gchar * debug)
+void GstreamerStub::sendWarning(GstElement *src, GError *error, const gchar *debug)
 {
     std::unique_lock lock(m_mutex);
-    m_message =
-        gst_message_new_warning(GST_OBJECT(src), error, debug);
+    m_message = gst_message_new_warning(GST_OBJECT(src), error, debug);
     m_cv.notify_one();
 }
 

--- a/tests/componenttests/server/stubs/GstreamerStub.cpp
+++ b/tests/componenttests/server/stubs/GstreamerStub.cpp
@@ -71,7 +71,7 @@ void GstreamerStub::setupPipeline()
     EXPECT_CALL(*m_gstWrapperMock,
                 gstBusTimedPopFiltered(m_bus, 100 * GST_MSECOND,
                                        static_cast<GstMessageType>(GST_MESSAGE_STATE_CHANGED | GST_MESSAGE_QOS |
-                                                                   GST_MESSAGE_EOS | GST_MESSAGE_ERROR)))
+                                                                   GST_MESSAGE_EOS | GST_MESSAGE_ERROR | GST_MESSAGE_WARNING)))
         .WillRepeatedly(Invoke(
             [&](GstBus *bus, GstClockTime timeout, GstMessageType types)
             {

--- a/tests/componenttests/server/stubs/GstreamerStub.cpp
+++ b/tests/componenttests/server/stubs/GstreamerStub.cpp
@@ -141,4 +141,13 @@ void GstreamerStub::sendQos(GstElement *src)
         gst_message_new_qos(GST_OBJECT(src), kLive, kRunningTime, kStreamTime, kQosInfo.processed, kQosInfo.dropped);
     m_cv.notify_one();
 }
+
+void GstreamerStub::sendWarning(GstElement *src, GError *error, const gchar * debug)
+{
+    std::unique_lock lock(m_mutex);
+    m_message =
+        gst_message_new_warning(GST_OBJECT(src), error, debug);
+    m_cv.notify_one();
+}
+
 } // namespace firebolt::rialto::server::ct

--- a/tests/componenttests/server/stubs/GstreamerStub.h
+++ b/tests/componenttests/server/stubs/GstreamerStub.h
@@ -47,7 +47,7 @@ public:
     void needData(GstAppSrc *appSrc, guint dataLength);
     void sendEos();
     void sendQos(GstElement *src);
-    void sendWarning(GstElement *src, GError *error, const gchar * debug);
+    void sendWarning(GstElement *src, GError *error, const gchar *debug);
 
 private:
     std::shared_ptr<testing::StrictMock<wrappers::GlibWrapperMock>> m_glibWrapperMock;

--- a/tests/componenttests/server/stubs/GstreamerStub.h
+++ b/tests/componenttests/server/stubs/GstreamerStub.h
@@ -47,6 +47,7 @@ public:
     void needData(GstAppSrc *appSrc, guint dataLength);
     void sendEos();
     void sendQos(GstElement *src);
+    void sendWarning(GstElement *src, GError *error, const gchar * debug);
 
 private:
     std::shared_ptr<testing::StrictMock<wrappers::GlibWrapperMock>> m_glibWrapperMock;

--- a/tests/componenttests/server/tests/CMakeLists.txt
+++ b/tests/componenttests/server/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_gtests (
         mediaPipeline/VolumeTest.cpp
         mediaPipeline/WriteSegmentsTest.cpp
         mediaPipeline/RemoveAudioPlaybackTest.cpp
+        mediaPipeline/NonFatalPlayerErrorUpdatesTest.cpp
         mediaKeys/MediaKeysTestMethods.cpp
         mediaKeys/MediaKeysTest.cpp
         mediaKeys/SessionReadyForDecryptionTest.cpp
@@ -72,6 +73,7 @@ target_include_directories(
         $<TARGET_PROPERTY:RialtoIpcServerStub,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoIpcServer,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoServerMain,INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:RialtoTestCommonProtoUtils,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 target_link_libraries(

--- a/tests/componenttests/server/tests/mediaPipeline/NonFatalPlayerErrorUpdatesTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/NonFatalPlayerErrorUpdatesTest.cpp
@@ -109,7 +109,7 @@ private:
  *  Test that after non-fatal errors on the gstreamer pipeline via GST_MESSAGE_WARNING are handled succcesfully.
  *
  * Sequence Diagrams:
- *  TODO
+ *  Non-fatal Errors - https://wiki.rdkcentral.com/display/ASP/Rialto+Playback+Design
  *
  * Test Setup:
  *  Language: C++

--- a/tests/componenttests/server/tests/mediaPipeline/NonFatalPlayerErrorUpdatesTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/NonFatalPlayerErrorUpdatesTest.cpp
@@ -19,8 +19,8 @@
 
 #include "Constants.h"
 #include "ExpectMessage.h"
-#include "MediaPipelineTest.h"
 #include "MediaPipelineProtoUtils.h"
+#include "MediaPipelineTest.h"
 
 using testing::_;
 using testing::DoAll;
@@ -38,7 +38,7 @@ const std::string kVideoMimeType{"video/x-h264"};
 
 MATCHER_P2(gstWarningMatcher, error, debug, "")
 {
-    GstMessage* message = GST_MESSAGE_CAST(arg);
+    GstMessage *message = GST_MESSAGE_CAST(arg);
     return (message->type == GST_MESSAGE_WARNING);
 }
 
@@ -55,7 +55,7 @@ public:
         m_err.domain = domain;
         m_err.code = code;
         m_err.message = m_debug;
-    
+
         EXPECT_CALL(*m_gstWrapperMock, gstMessageParseWarning(gstWarningMatcher(m_err, m_debug), _, _))
             .WillOnce(DoAll(SetArgPointee<1>(&m_err), SetArgPointee<2>(m_debug)));
         EXPECT_CALL(*m_glibWrapperMock, gFree(m_debug));
@@ -69,17 +69,13 @@ public:
         // Warning executed on the bus thread, wait for it to complete
         waitWorker();
     }
-    
-    void willGetMimeType(const char* mimeType)
+
+    void willGetMimeType(const char *mimeType)
     {
-        EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(GST_ELEMENT(&m_src), StrEq("src")))
-            .WillOnce(Return(&m_srcpad));
-        EXPECT_CALL(*m_gstWrapperMock, gstPadGetCurrentCaps(&m_srcpad))
-            .WillOnce(Return(&m_caps));
-        EXPECT_CALL(*m_gstWrapperMock, gstCapsGetStructure(&m_caps, 0))
-            .WillOnce(Return(&m_structure));
-        EXPECT_CALL(*m_gstWrapperMock, gstStructureGetName(&m_structure))
-            .WillOnce(Return(mimeType));
+        EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(GST_ELEMENT(&m_src), StrEq("src"))).WillOnce(Return(&m_srcpad));
+        EXPECT_CALL(*m_gstWrapperMock, gstPadGetCurrentCaps(&m_srcpad)).WillOnce(Return(&m_caps));
+        EXPECT_CALL(*m_gstWrapperMock, gstCapsGetStructure(&m_caps, 0)).WillOnce(Return(&m_structure));
+        EXPECT_CALL(*m_gstWrapperMock, gstStructureGetName(&m_structure)).WillOnce(Return(mimeType));
         EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&m_structure));
         EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&m_caps));
         EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&m_srcpad));

--- a/tests/componenttests/server/tests/mediaPipeline/PlaybackErrorUpdatesTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/PlaybackErrorUpdatesTest.cpp
@@ -1,0 +1,261 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Constants.h"
+#include "ExpectMessage.h"
+#include "MediaPipelineTest.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::Return;
+using testing::SetArgPointee;
+
+namespace
+{
+constexpr unsigned kFramesToPush{1};
+constexpr int kFrameCountInPausedState{3};
+const std::string kAudioSourceName{"Audio"};
+const std::string kVideoSourceName{"Video"};
+} // namespace
+
+namespace firebolt::rialto::server::ct
+{
+class QosUpdatesTest : public MediaPipelineTest
+{
+public:
+    QosUpdatesTest() = default;
+    ~QosUpdatesTest() override = default;
+
+    void willQos(const std::string &sourceName)
+    {
+        EXPECT_CALL(*m_gstWrapperMock, gstMessageParseQos(_, _, _, _, _, _));
+        EXPECT_CALL(*m_gstWrapperMock, gstMessageParseQosStats(_, _, _, _))
+            .WillOnce(DoAll(SetArgPointee<1>(GST_FORMAT_BUFFERS), SetArgPointee<2>(kQosInfo.processed),
+                            SetArgPointee<3>(kQosInfo.dropped)));
+        EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return(sourceName.c_str()));
+    }
+
+    void qos(int sourceId)
+    {
+        ExpectMessage<QosEvent> expectedQos{m_clientStub};
+
+        m_gstreamerStub.sendQos(&m_src);
+
+        auto receivedQos = expectedQos.getMessage();
+        ASSERT_TRUE(receivedQos);
+        EXPECT_EQ(receivedQos->session_id(), m_sessionId);
+        EXPECT_EQ(receivedQos->source_id(), sourceId);
+        EXPECT_EQ(receivedQos->qos_info().processed(), kQosInfo.processed);
+        EXPECT_EQ(receivedQos->qos_info().dropped(), kQosInfo.dropped);
+    }
+
+private:
+    GstElement m_src{};
+};
+
+/*
+ * Component Test: Qos Updates Test
+ * Test Objective:
+ *  Test the notifyQos API. After receiving GST_MESSAGE_QOS, RialtoServer should send notifyQos to RialtoClient
+ *
+ * Sequence Diagrams:
+ *  Create, Destroy - https://wiki.rdkcentral.com/pages/viewpage.action?pageId=226375556
+ *  Quality of Service
+ *   - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams
+ *
+ * Test Setup:
+ *  Language: C++
+ *  Testing Framework: Google Test
+ *  Components: MediaPipeline
+ *
+ * Test Initialize:
+ *  Set Rialto Server to Active
+ *  Connect Rialto Client Stub
+ *  Map Shared Memory
+ *
+ * Test Steps:
+ *  Step 1: Create a new media session
+ *   Send CreateSessionRequest to Rialto Server
+ *   Expect that successful CreateSessionResponse is received
+ *   Save returned session id
+ *
+ *  Step 2: Load content
+ *   Send LoadRequest to Rialto Server
+ *   Expect that successful LoadResponse is received
+ *   Expect that GstPlayer instance is created.
+ *   Expect that client is notified that the NetworkState has changed to BUFFERING.
+ *
+ *  Step 3: Attach all sources
+ *   Attach the audio source.
+ *   Expect that audio source is attached.
+ *   Attach the video source.
+ *   Expect that video source is attached.
+ *   Expect that rialto source is setup
+ *   Expect that all sources are attached.
+ *   Expect that the Playback state has changed to IDLE.
+ *
+ *  Step 4: Pause
+ *   Pause the content.
+ *   Expect that gstreamer pipeline is paused.
+ *   Expect that server notifies the client that the Network state has changed to PAUSED.
+ *
+ *  Step 5: Write 1 audio frame
+ *   Gstreamer Stub notifies, that it needs audio data
+ *   Expect that server notifies the client that it needs 3 frames of audio data.
+ *   Write 1 frame of audio data to the shared buffer.
+ *   Send HaveData message
+ *   Expect that server notifies the client that it needs 3 frames of audio data.
+ *
+ *  Step 6: Write 1 video frame
+ *   Gstreamer Stub notifies, that it needs video data
+ *   Expect that server notifies the client that it needs 3 frames of video data.
+ *   Write 1 frame of video data to the shared buffer.
+ *   Send HaveData message
+ *   Expect that server notifies the client that it needs 3 frames of video data.
+ *
+ *  Step 7: Notify buffered
+ *   Expect that server notifies the client that the Network state has changed to BUFFERED.
+ *
+ *  Step 8: Play
+ *   Play the content.
+ *   Expect that gstreamer pipeline is in playing state
+ *   Expect that server notifies the client that the Playback state has changed to PLAYING.
+ *
+ *  Step 9: Audio QoS
+ *   GST_MESSAGE_QOS should be received from audio source
+ *   Rialto Server should send NotifyQos to Rialto Client
+ *
+ *  Step 10: Video QoS
+ *   GST_MESSAGE_QOS should be received from video source
+ *   Rialto Server should send NotifyQos to Rialto Client
+ *
+ *  Step 11: End of audio stream
+ *   Send audio haveData with one frame and EOS status
+ *   Expect that Gstreamer is notified about end of stream
+ *
+ *  Step 12: End of video stream
+ *   Send video haveData with one frame and EOS status
+ *   Expect that Gstreamer is notified about end of stream
+ *
+ *  Step 13: Notify end of stream
+ *   Simulate, that gst_message_eos is received by Rialto Server
+ *   Expect that server notifies the client that the Network state has changed to END_OF_STREAM.
+ *
+ *  Step 14: Remove sources
+ *   Remove the audio source.
+ *   Expect that audio source is removed.
+ *   Remove the video source.
+ *   Expect that video source is removed.
+ *
+ *  Step 15: Stop
+ *   Stop the playback.
+ *   Expect that stop propagated to the gstreamer pipeline.
+ *   Expect that server notifies the client that the Playback state has changed to STOPPED.
+ *
+ *  Step 16: Destroy media session
+ *   Send DestroySessionRequest.
+ *   Expect that the session is destroyed on the server.
+ *
+ * Test Teardown:
+ *  Memory region created for the shared buffer is unmapped.
+ *  Server is terminated.
+ *
+ * Expected Results:
+ *  Qos information from GStreamer is forwarded to Rialto Client
+ *
+ * Code:
+ */
+TEST_F(QosUpdatesTest, QosUpdates)
+{
+    // Step 1: Create a new media session
+    createSession();
+
+    // Step 2: Load content
+    gstPlayerWillBeCreated();
+    load();
+
+    // Step 3: Attach all sources
+    audioSourceWillBeAttached();
+    attachAudioSource();
+    videoSourceWillBeAttached();
+    attachVideoSource();
+    sourceWillBeSetup();
+    setupSource();
+    willSetupAndAddSource(&m_audioAppSrc);
+    willSetupAndAddSource(&m_videoAppSrc);
+    willFinishSetupAndAddSource();
+    indicateAllSourcesAttached();
+
+    // Step 4: Pause
+    willPause();
+    pause();
+
+    // Step 5: Write 1 audio frame
+    // Step 6: Write 1 video frame
+    // Step 7: Notify buffered
+    gstNeedData(&m_audioAppSrc, kFrameCountInPausedState);
+    gstNeedData(&m_videoAppSrc, kFrameCountInPausedState);
+    {
+        ExpectMessage<firebolt::rialto::NetworkStateChangeEvent> expectedNetworkStateChange{m_clientStub};
+
+        pushAudioData(kFramesToPush, kFrameCountInPausedState);
+        pushVideoData(kFramesToPush, kFrameCountInPausedState);
+
+        auto receivedNetworkStateChange{expectedNetworkStateChange.getMessage()};
+        ASSERT_TRUE(receivedNetworkStateChange);
+        EXPECT_EQ(receivedNetworkStateChange->session_id(), m_sessionId);
+        EXPECT_EQ(receivedNetworkStateChange->state(), ::firebolt::rialto::NetworkStateChangeEvent_NetworkState_BUFFERED);
+    }
+
+    // Step 8: Play
+    willPlay();
+    play();
+
+    // Step 9: Audio QoS
+    willQos(kAudioSourceName);
+    qos(m_audioSourceId);
+
+    // Step 10: Video QoS
+    willQos(kVideoSourceName);
+    qos(m_videoSourceId);
+
+    // Step 11: End of audio stream
+    // Step 12: End of video stream
+    willEos(&m_audioAppSrc);
+    eosAudio(kFramesToPush);
+    willEos(&m_videoAppSrc);
+    eosVideo(kFramesToPush);
+
+    // Step 13: Notify end of stream
+    gstNotifyEos();
+    willRemoveAudioSource();
+
+    // Step 14: Remove sources
+    removeSource(m_audioSourceId);
+    removeSource(m_videoSourceId);
+
+    // Step 15: Stop
+    willStop();
+    stop();
+
+    // Step 16: Destroy media session
+    gstPlayerWillBeDestructed();
+    destroySession();
+}
+} // namespace firebolt::rialto::server::ct

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/CallbackTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/CallbackTest.cpp
@@ -133,3 +133,35 @@ TEST_F(RialtoClientMediaPipelineIpcCallbackTest, InvalidSessionIdQos)
 
     m_qosCb(updateQosEvent);
 }
+
+/**
+ * Test that a playback error notification over IPC is forwarded to the client.
+ */
+TEST_F(RialtoClientMediaPipelineIpcCallbackTest, NotifyPlaybackError)
+{
+    auto updatePlaybackErrorEvent = std::make_shared<firebolt::rialto::PlaybackErrorEvent>();
+    updatePlaybackErrorEvent->set_session_id(m_sessionId);
+    updatePlaybackErrorEvent->set_source_id(m_sourceId);
+    updatePlaybackErrorEvent->set_error(firebolt::rialto::PlaybackErrorEvent_PlaybackError_DECRYPTION);
+
+    EXPECT_CALL(*m_eventThreadMock, addImpl(_)).WillOnce(Invoke([](std::function<void()> &&func) { func(); }));
+
+    EXPECT_CALL(*m_clientMock, notifyPlaybackError(m_sourceId, PlaybackError::DECRYPTION));
+
+    m_playbackErrorCb(updatePlaybackErrorEvent);
+}
+
+/**
+ * Test that if the session id of the event is not the same as the playback session the event will be ignored.
+ */
+TEST_F(RialtoClientMediaPipelineIpcCallbackTest, InvalidSessionIdPlaybackError)
+{
+    auto updatePlaybackErrorEvent = std::make_shared<firebolt::rialto::PlaybackErrorEvent>();
+    updatePlaybackErrorEvent->set_session_id(-1);
+    updatePlaybackErrorEvent->set_source_id(m_sourceId);
+    updatePlaybackErrorEvent->set_error(firebolt::rialto::PlaybackErrorEvent_PlaybackError_DECRYPTION);
+
+    EXPECT_CALL(*m_eventThreadMock, addImpl(_)).WillOnce(Invoke([](std::function<void()> &&func) { func(); }));
+
+    m_playbackErrorCb(updatePlaybackErrorEvent);
+}

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/base/MediaPipelineIpcTestBase.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/base/MediaPipelineIpcTestBase.cpp
@@ -112,6 +112,15 @@ void MediaPipelineIpcTestBase::expectSubscribeEvents()
                 return static_cast<int>(EventTags::BufferUnderflowEvent);
             }))
         .RetiresOnSaturation();
+    EXPECT_CALL(*m_channelMock, subscribeImpl("firebolt.rialto.PlaybackErrorEvent", _, _))
+        .WillOnce(Invoke(
+            [this](const std::string &eventName, const google::protobuf::Descriptor *descriptor,
+                   std::function<void(const std::shared_ptr<google::protobuf::Message> &msg)> &&handler)
+            {
+                m_playbackErrorCb = std::move(handler);
+                return static_cast<int>(EventTags::PlaybackErrorEvent);
+            }))
+        .RetiresOnSaturation();
 }
 
 void MediaPipelineIpcTestBase::expectUnsubscribeEvents()
@@ -122,6 +131,7 @@ void MediaPipelineIpcTestBase::expectUnsubscribeEvents()
     EXPECT_CALL(*m_channelMock, unsubscribe(static_cast<int>(EventTags::NeedMediaDataEvent))).WillOnce(Return(true));
     EXPECT_CALL(*m_channelMock, unsubscribe(static_cast<int>(EventTags::QosEvent))).WillOnce(Return(true));
     EXPECT_CALL(*m_channelMock, unsubscribe(static_cast<int>(EventTags::BufferUnderflowEvent))).WillOnce(Return(true));
+    EXPECT_CALL(*m_channelMock, unsubscribe(static_cast<int>(EventTags::PlaybackErrorEvent))).WillOnce(Return(true));
 }
 
 void MediaPipelineIpcTestBase::destroyMediaPipelineIpc()

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/base/MediaPipelineIpcTestBase.h
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/base/MediaPipelineIpcTestBase.h
@@ -64,7 +64,8 @@ protected:
         NetworkStateChangeEvent,
         NeedMediaDataEvent,
         QosEvent,
-        BufferUnderflowEvent
+        BufferUnderflowEvent,
+        PlaybackErrorEvent
     };
 
     // Callbacks
@@ -74,6 +75,7 @@ protected:
     std::function<void(const std::shared_ptr<google::protobuf::Message> &msg)> m_positionChangeCb;
     std::function<void(const std::shared_ptr<google::protobuf::Message> &msg)> m_qosCb;
     std::function<void(const std::shared_ptr<google::protobuf::Message> &msg)> m_bufferUnderflowCb;
+    std::function<void(const std::shared_ptr<google::protobuf::Message> &msg)> m_playbackErrorCb;
 
     void SetUp();
     void TearDown();

--- a/tests/unittests/media/client/main/mediaPipeline/CallbackTest.cpp
+++ b/tests/unittests/media/client/main/mediaPipeline/CallbackTest.cpp
@@ -72,3 +72,16 @@ TEST_F(RialtoClientMediaPipelineCallbackTest, NotifyQos)
 
     m_mediaPipelineCallback->notifyQos(sourceId, qosInfo);
 }
+
+/**
+ * Test a notification of playback error is forwarded to the registered client.
+ */
+TEST_F(RialtoClientMediaPipelineCallbackTest, NotifyPlaybackError)
+{
+    int32_t sourceId = 1;
+    PlaybackError error = PlaybackError::DECRYPTION;
+
+    EXPECT_CALL(*m_mediaPipelineClientMock, notifyPlaybackError(sourceId, error));
+
+    m_mediaPipelineCallback->notifyPlaybackError(sourceId, error);
+}

--- a/tests/unittests/media/client/mocks/ipc/MediaPipelineIpcClientMock.h
+++ b/tests/unittests/media/client/mocks/ipc/MediaPipelineIpcClientMock.h
@@ -41,6 +41,7 @@ public:
     MOCK_METHOD(void, notifyPosition, (int64_t position), (override));
     MOCK_METHOD(void, notifyQos, (int32_t sourceId, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (int32_t sourceId), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError& error), (override));
 };
 } // namespace firebolt::rialto::client
 

--- a/tests/unittests/media/client/mocks/ipc/MediaPipelineIpcClientMock.h
+++ b/tests/unittests/media/client/mocks/ipc/MediaPipelineIpcClientMock.h
@@ -41,7 +41,7 @@ public:
     MOCK_METHOD(void, notifyPosition, (int64_t position), (override));
     MOCK_METHOD(void, notifyQos, (int32_t sourceId, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (int32_t sourceId), (override));
-    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError &error), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, PlaybackError error), (override));
 };
 } // namespace firebolt::rialto::client
 

--- a/tests/unittests/media/client/mocks/ipc/MediaPipelineIpcClientMock.h
+++ b/tests/unittests/media/client/mocks/ipc/MediaPipelineIpcClientMock.h
@@ -41,7 +41,7 @@ public:
     MOCK_METHOD(void, notifyPosition, (int64_t position), (override));
     MOCK_METHOD(void, notifyQos, (int32_t sourceId, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (int32_t sourceId), (override));
-    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError& error), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, const PlaybackError &error), (override));
 };
 } // namespace firebolt::rialto::client
 

--- a/tests/unittests/media/server/gstplayer/decryptor/CreateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/decryptor/CreateTest.cpp
@@ -19,6 +19,8 @@
 #include "GstDecryptorPrivate.h"
 #include "GstWrapperFactoryMock.h"
 #include "GstWrapperMock.h"
+#include "GlibWrapperFactoryMock.h"
+#include "GlibWrapperMock.h"
 #include <gtest/gtest.h>
 
 using namespace firebolt::rialto;
@@ -32,12 +34,16 @@ class RialtoServerCreateDecryptorPrivateTest : public ::testing::Test
 {
 protected:
     std::shared_ptr<StrictMock<GstWrapperFactoryMock>> m_gstWrapperFactoryMock;
+    std::shared_ptr<StrictMock<GlibWrapperFactoryMock>> m_glibWrapperFactoryMock;
     std::shared_ptr<StrictMock<GstWrapperMock>> m_gstWrapperMock;
+    std::shared_ptr<StrictMock<GlibWrapperMock>> m_glibWrapperMock;
     GstBaseTransform m_decryptorBase = {};
 
     RialtoServerCreateDecryptorPrivateTest()
         : m_gstWrapperFactoryMock(std::make_shared<StrictMock<GstWrapperFactoryMock>>()),
-          m_gstWrapperMock(std::make_shared<StrictMock<GstWrapperMock>>())
+          m_glibWrapperFactoryMock(std::make_shared<StrictMock<GlibWrapperFactoryMock>>()),
+          m_gstWrapperMock(std::make_shared<StrictMock<GstWrapperMock>>()),
+          m_glibWrapperMock(std::make_shared<StrictMock<GlibWrapperMock>>())
     {
     }
 };
@@ -50,9 +56,10 @@ TEST_F(RialtoServerCreateDecryptorPrivateTest, Create)
     std::unique_ptr<GstRialtoDecryptorPrivate> gstRialtoDecryptorPrivate;
 
     EXPECT_CALL(*m_gstWrapperFactoryMock, getGstWrapper()).WillOnce(Return(m_gstWrapperMock));
+    EXPECT_CALL(*m_glibWrapperFactoryMock, getGlibWrapper()).WillOnce(Return(m_glibWrapperMock));
 
     EXPECT_NO_THROW(gstRialtoDecryptorPrivate =
-                        std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock));
+                        std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock));
     EXPECT_NE(gstRialtoDecryptorPrivate, nullptr);
 }
 
@@ -66,6 +73,21 @@ TEST_F(RialtoServerCreateDecryptorPrivateTest, getGstWrapperFails)
     EXPECT_CALL(*m_gstWrapperFactoryMock, getGstWrapper()).WillOnce(Return(nullptr));
 
     EXPECT_THROW(gstRialtoDecryptorPrivate =
-                     std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock),
+                     std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock),
+                 std::runtime_error);
+}
+
+/**
+ * Test that GstRialtoDecryptorPrivate throws and execption if getGlibWrapper fails.
+ */
+TEST_F(RialtoServerCreateDecryptorPrivateTest, getGlibWrapperFails)
+{
+    std::unique_ptr<GstRialtoDecryptorPrivate> gstRialtoDecryptorPrivate;
+
+    EXPECT_CALL(*m_gstWrapperFactoryMock, getGstWrapper()).WillOnce(Return(m_gstWrapperMock));
+    EXPECT_CALL(*m_glibWrapperFactoryMock, getGlibWrapper()).WillOnce(Return(nullptr));
+
+    EXPECT_THROW(gstRialtoDecryptorPrivate =
+                     std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock),
                  std::runtime_error);
 }

--- a/tests/unittests/media/server/gstplayer/decryptor/CreateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/decryptor/CreateTest.cpp
@@ -16,11 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "GlibWrapperFactoryMock.h"
+#include "GlibWrapperMock.h"
 #include "GstDecryptorPrivate.h"
 #include "GstWrapperFactoryMock.h"
 #include "GstWrapperMock.h"
-#include "GlibWrapperFactoryMock.h"
-#include "GlibWrapperMock.h"
 #include <gtest/gtest.h>
 
 using namespace firebolt::rialto;
@@ -58,8 +58,9 @@ TEST_F(RialtoServerCreateDecryptorPrivateTest, Create)
     EXPECT_CALL(*m_gstWrapperFactoryMock, getGstWrapper()).WillOnce(Return(m_gstWrapperMock));
     EXPECT_CALL(*m_glibWrapperFactoryMock, getGlibWrapper()).WillOnce(Return(m_glibWrapperMock));
 
-    EXPECT_NO_THROW(gstRialtoDecryptorPrivate =
-                        std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock));
+    EXPECT_NO_THROW(gstRialtoDecryptorPrivate = std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase,
+                                                                                            m_gstWrapperFactoryMock,
+                                                                                            m_glibWrapperFactoryMock));
     EXPECT_NE(gstRialtoDecryptorPrivate, nullptr);
 }
 
@@ -72,8 +73,9 @@ TEST_F(RialtoServerCreateDecryptorPrivateTest, getGstWrapperFails)
 
     EXPECT_CALL(*m_gstWrapperFactoryMock, getGstWrapper()).WillOnce(Return(nullptr));
 
-    EXPECT_THROW(gstRialtoDecryptorPrivate =
-                     std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock),
+    EXPECT_THROW(gstRialtoDecryptorPrivate = std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase,
+                                                                                         m_gstWrapperFactoryMock,
+                                                                                         m_glibWrapperFactoryMock),
                  std::runtime_error);
 }
 
@@ -87,7 +89,8 @@ TEST_F(RialtoServerCreateDecryptorPrivateTest, getGlibWrapperFails)
     EXPECT_CALL(*m_gstWrapperFactoryMock, getGstWrapper()).WillOnce(Return(m_gstWrapperMock));
     EXPECT_CALL(*m_glibWrapperFactoryMock, getGlibWrapper()).WillOnce(Return(nullptr));
 
-    EXPECT_THROW(gstRialtoDecryptorPrivate =
-                     std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock),
+    EXPECT_THROW(gstRialtoDecryptorPrivate = std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase,
+                                                                                         m_gstWrapperFactoryMock,
+                                                                                         m_glibWrapperFactoryMock),
                  std::runtime_error);
 }

--- a/tests/unittests/media/server/gstplayer/decryptor/DecryptTest.cpp
+++ b/tests/unittests/media/server/gstplayer/decryptor/DecryptTest.cpp
@@ -21,6 +21,8 @@
 #include "GstProtectionMetadataHelperMock.h"
 #include "GstWrapperFactoryMock.h"
 #include "GstWrapperMock.h"
+#include "GlibWrapperFactoryMock.h"
+#include "GlibWrapperMock.h"
 #include <gtest/gtest.h>
 
 using namespace firebolt::rialto;
@@ -66,7 +68,9 @@ class RialtoServerDecryptorPrivateDecryptTest : public ::testing::Test
 {
 protected:
     std::shared_ptr<StrictMock<GstWrapperFactoryMock>> m_gstWrapperFactoryMock;
+    std::shared_ptr<StrictMock<GlibWrapperFactoryMock>> m_glibWrapperFactoryMock;
     std::shared_ptr<StrictMock<GstWrapperMock>> m_gstWrapperMock;
+    std::shared_ptr<StrictMock<GlibWrapperMock>> m_glibWrapperMock;
     std::unique_ptr<GstRialtoDecryptorPrivate> m_gstRialtoDecryptorPrivate;
     std::shared_ptr<StrictMock<DecryptionServiceMock>> m_decryptionServiceMock;
     StrictMock<GstProtectionMetadataHelperMock> *m_protectionMetadataWrapperMock;
@@ -104,7 +108,9 @@ protected:
 
     RialtoServerDecryptorPrivateDecryptTest()
         : m_gstWrapperFactoryMock(std::make_shared<StrictMock<GstWrapperFactoryMock>>()),
+          m_glibWrapperFactoryMock(std::make_shared<StrictMock<GlibWrapperFactoryMock>>()),
           m_gstWrapperMock(std::make_shared<StrictMock<GstWrapperMock>>()),
+          m_glibWrapperMock(std::make_shared<StrictMock<GlibWrapperMock>>()),
           m_decryptionServiceMock(std::make_shared<StrictMock<DecryptionServiceMock>>())
     {
         createDecryptorPrivate();
@@ -119,9 +125,10 @@ protected:
     void createDecryptorPrivate()
     {
         EXPECT_CALL(*m_gstWrapperFactoryMock, getGstWrapper()).WillOnce(Return(m_gstWrapperMock));
+        EXPECT_CALL(*m_glibWrapperFactoryMock, getGlibWrapper()).WillOnce(Return(m_glibWrapperMock));
 
         EXPECT_NO_THROW(m_gstRialtoDecryptorPrivate =
-                            std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock));
+                            std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock));
         EXPECT_NE(m_gstRialtoDecryptorPrivate, nullptr);
     }
 

--- a/tests/unittests/media/server/gstplayer/decryptor/DecryptTest.cpp
+++ b/tests/unittests/media/server/gstplayer/decryptor/DecryptTest.cpp
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 #include "DecryptionServiceMock.h"
+#include "GlibWrapperFactoryMock.h"
+#include "GlibWrapperMock.h"
 #include "GstDecryptorPrivate.h"
 #include "GstProtectionMetadataHelperMock.h"
 #include "GstWrapperFactoryMock.h"
 #include "GstWrapperMock.h"
-#include "GlibWrapperFactoryMock.h"
-#include "GlibWrapperMock.h"
 #include <gtest/gtest.h>
 
 using namespace firebolt::rialto;
@@ -130,7 +130,8 @@ protected:
         EXPECT_CALL(*m_glibWrapperFactoryMock, getGlibWrapper()).WillOnce(Return(m_glibWrapperMock));
 
         EXPECT_NO_THROW(m_gstRialtoDecryptorPrivate =
-                            std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock, m_glibWrapperFactoryMock));
+                            std::make_unique<GstRialtoDecryptorPrivate>(&m_decryptorBase, m_gstWrapperFactoryMock,
+                                                                        m_glibWrapperFactoryMock));
         EXPECT_NE(m_gstRialtoDecryptorPrivate, nullptr);
     }
 
@@ -206,13 +207,13 @@ protected:
 
     void expectDecryptWarning()
     {
-            EXPECT_CALL(*m_glibWrapperMock, gErrorNewLiteral(GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT, _))
-                .WillOnce(Return(&m_gError));
-            EXPECT_CALL(*m_gstWrapperMock, gstMessageNewWarning(GST_OBJECT_CAST(&m_decryptorBase), &m_gError, _))
-                .WillOnce(Return(&m_message));
-            EXPECT_CALL(*m_gstWrapperMock, gstElementPostMessage(GST_ELEMENT_CAST(&m_decryptorBase), &m_message))
-                .WillOnce(Return(TRUE));
-            EXPECT_CALL(*m_glibWrapperMock, gErrorFree(&m_gError));
+        EXPECT_CALL(*m_glibWrapperMock, gErrorNewLiteral(GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT, _))
+            .WillOnce(Return(&m_gError));
+        EXPECT_CALL(*m_gstWrapperMock, gstMessageNewWarning(GST_OBJECT_CAST(&m_decryptorBase), &m_gError, _))
+            .WillOnce(Return(&m_message));
+        EXPECT_CALL(*m_gstWrapperMock, gstElementPostMessage(GST_ELEMENT_CAST(&m_decryptorBase), &m_message))
+            .WillOnce(Return(TRUE));
+        EXPECT_CALL(*m_glibWrapperMock, gErrorFree(&m_gError));
     }
 };
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/HandleBusMessageTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/HandleBusMessageTest.cpp
@@ -73,12 +73,9 @@ protected:
             .WillOnce(DoAll(SetArgPointee<1>(&m_err), SetArgPointee<2>(m_debug)));
         EXPECT_CALL(*m_gstWrapper, gstElementGetStaticPad(GST_ELEMENT(&m_decryptorBase), StrEq("src")))
             .WillOnce(Return(&m_srcpad));
-        EXPECT_CALL(*m_gstWrapper, gstPadGetCurrentCaps(&m_srcpad))
-            .WillOnce(Return(&m_caps));
-        EXPECT_CALL(*m_gstWrapper, gstCapsGetStructure(&m_caps, 0))
-            .WillOnce(Return(&m_structure));
-        EXPECT_CALL(*m_gstWrapper, gstStructureGetName(&m_structure))
-            .WillOnce(Return(mimeType));
+        EXPECT_CALL(*m_gstWrapper, gstPadGetCurrentCaps(&m_srcpad)).WillOnce(Return(&m_caps));
+        EXPECT_CALL(*m_gstWrapper, gstCapsGetStructure(&m_caps, 0)).WillOnce(Return(&m_structure));
+        EXPECT_CALL(*m_gstWrapper, gstStructureGetName(&m_structure)).WillOnce(Return(mimeType));
         EXPECT_CALL(*m_glibWrapper, gObjectUnref(&m_structure));
         EXPECT_CALL(*m_glibWrapper, gObjectUnref(&m_caps));
         EXPECT_CALL(*m_glibWrapper, gObjectUnref(&m_srcpad));
@@ -526,9 +523,10 @@ TEST_F(HandleBusMessageTest, shouldHandleWarningMessageForAudioDecryption)
 
     gchar *audioMimeType = "audio/mpeg";
     expectGetMimeType(audioMimeType);
-    EXPECT_CALL(m_gstPlayerClient, notifyPlaybackError(firebolt::rialto::MediaSourceType::AUDIO, firebolt::rialto::PlaybackError::DECRYPTION));
+    EXPECT_CALL(m_gstPlayerClient, notifyPlaybackError(firebolt::rialto::MediaSourceType::AUDIO,
+                                                       firebolt::rialto::PlaybackError::DECRYPTION));
     expectFreeErrorMessage();
-    
+
     firebolt::rialto::server::tasks::generic::HandleBusMessage task{m_context,    m_gstPlayer,   &m_gstPlayerClient,
                                                                     m_gstWrapper, m_glibWrapper, &m_message};
     task.execute();
@@ -546,7 +544,8 @@ TEST_F(HandleBusMessageTest, shouldHandleWarningMessageForVideoDecryption)
 
     gchar *videoMimeType = "video/mp4";
     expectGetMimeType(videoMimeType);
-    EXPECT_CALL(m_gstPlayerClient, notifyPlaybackError(firebolt::rialto::MediaSourceType::VIDEO, firebolt::rialto::PlaybackError::DECRYPTION));
+    EXPECT_CALL(m_gstPlayerClient, notifyPlaybackError(firebolt::rialto::MediaSourceType::VIDEO,
+                                                       firebolt::rialto::PlaybackError::DECRYPTION));
     expectFreeErrorMessage();
 
     firebolt::rialto::server::tasks::generic::HandleBusMessage task{m_context,    m_gstPlayer,   &m_gstPlayerClient,

--- a/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTests.cpp
+++ b/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTests.cpp
@@ -265,6 +265,14 @@ TEST_F(MediaPipelineModuleServiceTests, shouldSendQosEvent)
     sendQosEvent();
 }
 
+TEST_F(MediaPipelineModuleServiceTests, shouldSendPlaybackErrorEvent)
+{
+    mediaPipelineServiceWillCreateSession();
+    sendCreateSessionRequestAndReceiveResponse();
+    mediaClientWillSendPlaybackErrorEvent();
+    sendPlaybackErrorEvent();
+}
+
 TEST_F(MediaPipelineModuleServiceTests, shouldRenderFrame)
 {
     mediaPipelineServiceWillCreateSession();

--- a/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
+++ b/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
@@ -150,7 +150,8 @@ MATCHER_P3(QosEventMatcher, kSourceId, processed, dropped, "")
 
 MATCHER_P2(PlaybackErrorEventMatcher, kExpectedSourceId, kExpectedPlaybackError, "")
 {
-    std::shared_ptr<firebolt::rialto::PlaybackErrorEvent> event = std::dynamic_pointer_cast<firebolt::rialto::PlaybackErrorEvent>(arg);
+    std::shared_ptr<firebolt::rialto::PlaybackErrorEvent> event =
+        std::dynamic_pointer_cast<firebolt::rialto::PlaybackErrorEvent>(arg);
     return ((kExpectedSourceId == event->source_id()) && (kExpectedPlaybackError == event->error()));
 }
 

--- a/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
+++ b/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.cpp
@@ -66,6 +66,7 @@ constexpr firebolt::rialto::QosInfo kQosInfo{5u, 2u};
 constexpr double kRate{1.5};
 constexpr double kVolume{0.7};
 constexpr bool kMute{false};
+constexpr firebolt::rialto::PlaybackError kPlaybackError{firebolt::rialto::PlaybackError::DECRYPTION};
 } // namespace
 
 MATCHER_P(AttachedSourceMatcher, source, "")
@@ -145,6 +146,12 @@ MATCHER_P3(QosEventMatcher, kSourceId, processed, dropped, "")
     std::shared_ptr<firebolt::rialto::QosEvent> event = std::dynamic_pointer_cast<firebolt::rialto::QosEvent>(arg);
     return ((kSourceId == event->source_id()) && (processed == event->qos_info().processed()) &&
             (dropped == event->qos_info().dropped()));
+}
+
+MATCHER_P2(PlaybackErrorEventMatcher, kExpectedSourceId, kExpectedPlaybackError, "")
+{
+    std::shared_ptr<firebolt::rialto::PlaybackErrorEvent> event = std::dynamic_pointer_cast<firebolt::rialto::PlaybackErrorEvent>(arg);
+    return ((kExpectedSourceId == event->source_id()) && (kExpectedPlaybackError == event->error()));
 }
 
 MATCHER_P(PlaybackStateChangeEventMatcher, kPlaybackState, "")
@@ -489,6 +496,11 @@ void MediaPipelineModuleServiceTests::mediaClientWillSendQosEvent()
     EXPECT_CALL(*m_clientMock, sendEvent(QosEventMatcher(kSourceId, kQosInfo.processed, kQosInfo.dropped)));
 }
 
+void MediaPipelineModuleServiceTests::mediaClientWillSendPlaybackErrorEvent()
+{
+    EXPECT_CALL(*m_clientMock, sendEvent(PlaybackErrorEventMatcher(kSourceId, convertPlaybackError(kPlaybackError))));
+}
+
 void MediaPipelineModuleServiceTests::sendClientConnected()
 {
     m_service->clientConnected(m_clientMock);
@@ -820,6 +832,12 @@ void MediaPipelineModuleServiceTests::sendQosEvent()
 {
     ASSERT_TRUE(m_mediaPipelineClient);
     m_mediaPipelineClient->notifyQos(kSourceId, kQosInfo);
+}
+
+void MediaPipelineModuleServiceTests::sendPlaybackErrorEvent()
+{
+    ASSERT_TRUE(m_mediaPipelineClient);
+    m_mediaPipelineClient->notifyPlaybackError(kSourceId, kPlaybackError);
 }
 
 void MediaPipelineModuleServiceTests::expectRequestSuccess()

--- a/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.h
+++ b/tests/unittests/media/server/ipc/mediaPipelineModuleService/MediaPipelineModuleServiceTestsFixture.h
@@ -85,6 +85,7 @@ public:
     void mediaClientWillSendNeedMediaDataEvent(int sessionId);
     void mediaClientWillSendPostionChangeEvent();
     void mediaClientWillSendQosEvent();
+    void mediaClientWillSendPlaybackErrorEvent();
 
     void sendClientConnected();
     void sendClientDisconnected();
@@ -117,6 +118,7 @@ public:
     void sendNeedMediaDataEvent();
     void sendPostionChangeEvent();
     void sendQosEvent();
+    void sendPlaybackErrorEvent();
     void sendRenderFrameRequestAndReceiveResponse();
 
 private:

--- a/tests/unittests/media/server/main/mediaPipeline/CallbackTest.cpp
+++ b/tests/unittests/media/server/main/mediaPipeline/CallbackTest.cpp
@@ -206,6 +206,34 @@ TEST_F(RialtoServerMediaPipelineCallbackTest, notifyQosFailureSourceIdNotFound)
 }
 
 /**
+ * Test a notification of playback error is forwarded to the registered client.
+ */
+TEST_F(RialtoServerMediaPipelineCallbackTest, notifyPlaybackError)
+{
+    auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
+    auto error = firebolt::rialto::PlaybackError::DECRYPTION;
+    int sourceId = attachSource(mediaSourceType, "video/mp4");
+
+    mainThreadWillEnqueueTask();
+    EXPECT_CALL(*m_mediaPipelineClientMock, notifyPlaybackError(sourceId, error));
+
+    m_gstPlayerCallback->notifyPlaybackError(mediaSourceType, error);
+}
+
+/**
+ * Test a notification of playback error fails when sourceid cannot be found.
+ */
+TEST_F(RialtoServerMediaPipelineCallbackTest, notifyPlaybackErrorFailureSourceIdNotFound)
+{
+    auto mediaSourceType = firebolt::rialto::MediaSourceType::VIDEO;
+    auto error = firebolt::rialto::PlaybackError::DECRYPTION;
+
+    mainThreadWillEnqueueTask();
+
+    m_gstPlayerCallback->notifyPlaybackError(mediaSourceType, error);
+}
+
+/**
  * Tests if active request cache is cleared.
  */
 TEST_F(RialtoServerMediaPipelineCallbackTest, clearActiveRequestsCache)

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerClientMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerClientMock.h
@@ -39,6 +39,7 @@ public:
     MOCK_METHOD(void, invalidateActiveRequests, (const MediaSourceType &type), (override));
     MOCK_METHOD(void, notifyQos, (MediaSourceType mediaSourceType, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (MediaSourceType mediaSourceType), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (MediaSourceType mediaSourceType, const PlaybackError& error), (override));
 };
 } // namespace firebolt::rialto::server
 

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerClientMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerClientMock.h
@@ -39,7 +39,7 @@ public:
     MOCK_METHOD(void, invalidateActiveRequests, (const MediaSourceType &type), (override));
     MOCK_METHOD(void, notifyQos, (MediaSourceType mediaSourceType, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (MediaSourceType mediaSourceType), (override));
-    MOCK_METHOD(void, notifyPlaybackError, (MediaSourceType mediaSourceType, const PlaybackError& error), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (MediaSourceType mediaSourceType, const PlaybackError &error), (override));
 };
 } // namespace firebolt::rialto::server
 

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerClientMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerClientMock.h
@@ -39,7 +39,7 @@ public:
     MOCK_METHOD(void, invalidateActiveRequests, (const MediaSourceType &type), (override));
     MOCK_METHOD(void, notifyQos, (MediaSourceType mediaSourceType, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (MediaSourceType mediaSourceType), (override));
-    MOCK_METHOD(void, notifyPlaybackError, (MediaSourceType mediaSourceType, const PlaybackError &error), (override));
+    MOCK_METHOD(void, notifyPlaybackError, (MediaSourceType mediaSourceType, PlaybackError error), (override));
 };
 } // namespace firebolt::rialto::server
 

--- a/wrappers/include/GlibWrapper.h
+++ b/wrappers/include/GlibWrapper.h
@@ -141,7 +141,10 @@ public:
 
     void gValueUnset(GValue *value) const override { return g_value_unset(value); }
 
-    GError* gErrorNewLiteral(GQuark domain, gint code, const gchar* message) const override { return g_error_new_literal(domain, code, message); }
+    GError *gErrorNewLiteral(GQuark domain, gint code, const gchar *message) const override
+    {
+        return g_error_new_literal(domain, code, message);
+    }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/include/GlibWrapper.h
+++ b/wrappers/include/GlibWrapper.h
@@ -140,6 +140,8 @@ public:
     gpointer gValueGetObject(const GValue *value) const override { return g_value_get_object(value); }
 
     void gValueUnset(GValue *value) const override { return g_value_unset(value); }
+
+    GError* gErrorNewLiteral(GQuark domain, gint code, const gchar* message) const override { return g_error_new_literal(domain, code, message); }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -495,6 +495,14 @@ public:
     gboolean gstElementPostMessage(GstElement * element, GstMessage * message) const override { return gst_element_post_message(element, message); }
 
     GstMessage *gstMessageNewWarning(GstObject * src, GError * error, const gchar * debug) const override { return gst_message_new_warning(src, error, debug); }
+
+    virtual void gstMessageParseWarning(GstMessage * message, GError ** gerror, gchar ** debug) const override { gst_message_parse_warning(message, gerror, debug); }
+
+    virtual GstCaps *gstPadGetCurrentCaps(GstPad * pad) const override { return gst_pad_get_current_caps(pad); }
+
+    virtual GstStructure *gstCapsGetStructure(const GstCaps * caps, guint index) const override { return gst_caps_get_structure(caps, index); }
+
+    const gchar *gstStructureGetName(const GstStructure * structure) const override { return gst_structure_get_name(structure); }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -492,17 +492,32 @@ public:
 
     void gstIteratorFree(GstIterator *it) const override { return gst_iterator_free(it); }
 
-    gboolean gstElementPostMessage(GstElement * element, GstMessage * message) const override { return gst_element_post_message(element, message); }
+    gboolean gstElementPostMessage(GstElement *element, GstMessage *message) const override
+    {
+        return gst_element_post_message(element, message);
+    }
 
-    GstMessage *gstMessageNewWarning(GstObject * src, GError * error, const gchar * debug) const override { return gst_message_new_warning(src, error, debug); }
+    GstMessage *gstMessageNewWarning(GstObject *src, GError *error, const gchar *debug) const override
+    {
+        return gst_message_new_warning(src, error, debug);
+    }
 
-    virtual void gstMessageParseWarning(GstMessage * message, GError ** gerror, gchar ** debug) const override { gst_message_parse_warning(message, gerror, debug); }
+    void gstMessageParseWarning(GstMessage *message, GError **gerror, gchar **debug) const override
+    {
+        gst_message_parse_warning(message, gerror, debug);
+    }
 
-    virtual GstCaps *gstPadGetCurrentCaps(GstPad * pad) const override { return gst_pad_get_current_caps(pad); }
+    GstCaps *gstPadGetCurrentCaps(GstPad *pad) const override { return gst_pad_get_current_caps(pad); }
 
-    virtual GstStructure *gstCapsGetStructure(const GstCaps * caps, guint index) const override { return gst_caps_get_structure(caps, index); }
+    GstStructure *gstCapsGetStructure(const GstCaps *caps, guint index) const override
+    {
+        return gst_caps_get_structure(caps, index);
+    }
 
-    const gchar *gstStructureGetName(const GstStructure * structure) const override { return gst_structure_get_name(structure); }
+    const gchar *gstStructureGetName(const GstStructure *structure) const override
+    {
+        return gst_structure_get_name(structure);
+    }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -491,6 +491,10 @@ public:
     }
 
     void gstIteratorFree(GstIterator *it) const override { return gst_iterator_free(it); }
+
+    gboolean gstElementPostMessage(GstElement * element, GstMessage * message) const override { return gst_element_post_message(element, message); }
+
+    GstMessage *gstMessageNewWarning(GstObject * src, GError * error, const gchar * debug) const override { return gst_message_new_warning(src, error, debug); }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGlibWrapper.h
+++ b/wrappers/interface/IGlibWrapper.h
@@ -323,6 +323,15 @@ public:
      * @param[in] value : Value to unset.
      */
     virtual void gValueUnset(GValue *value) const = 0;
+
+    /**
+     * @brief Create a new GError.
+     *
+     * @param[in] domain    : Domain of the error.
+     * @param[in] code      : Error code.
+     * @param[in] message   : Error message.
+     */
+    virtual GError* gErrorNewLiteral(GQuark domain, gint code, const gchar* message) const = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGlibWrapper.h
+++ b/wrappers/interface/IGlibWrapper.h
@@ -331,7 +331,7 @@ public:
      * @param[in] code      : Error code.
      * @param[in] message   : Error message.
      */
-    virtual GError* gErrorNewLiteral(GQuark domain, gint code, const gchar* message) const = 0;
+    virtual GError *gErrorNewLiteral(GQuark domain, gint code, const gchar *message) const = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -1152,7 +1152,7 @@ public:
      *
      * @retval TRUE if the message was posted, FALSE otherwise.
      */
-    virtual gboolean gstElementPostMessage(GstElement * element, GstMessage * message) const = 0;
+    virtual gboolean gstElementPostMessage(GstElement *element, GstMessage *message) const = 0;
 
     /**
      * @brief Create a new warning message.
@@ -1163,7 +1163,7 @@ public:
      *
      * @retval New warning message.
      */
-    virtual GstMessage *gstMessageNewWarning(GstObject * src, GError * error, const gchar * debug) const = 0;
+    virtual GstMessage *gstMessageNewWarning(GstObject *src, GError *error, const gchar *debug) const = 0;
 
     /**
      * @brief Get the GError and error string from the message.
@@ -1172,7 +1172,7 @@ public:
      * @param[out] gerror   : loction to store the error.
      * @param[out] debug    : loction to store the error string.
      */
-    virtual void gstMessageParseWarning(GstMessage * message, GError ** gerror, gchar ** debug) const = 0;
+    virtual void gstMessageParseWarning(GstMessage *message, GError **gerror, gchar **debug) const = 0;
 
     /**
      * @brief Get the capabilities from the pad.
@@ -1181,7 +1181,7 @@ public:
      *
      * @retval the current caps, NULL otherwise.
      */
-    virtual GstCaps *gstPadGetCurrentCaps(GstPad * pad) const = 0;
+    virtual GstCaps *gstPadGetCurrentCaps(GstPad *pad) const = 0;
 
     /**
      * @brief Finds the structure at index in the caps.
@@ -1191,7 +1191,7 @@ public:
      *
      * @retval ptr to a structure.
      */
-    virtual GstStructure *gstCapsGetStructure(const GstCaps * caps, guint index) const = 0;
+    virtual GstStructure *gstCapsGetStructure(const GstCaps *caps, guint index) const = 0;
 
     /**
      * @brief Gets the name of the structure.
@@ -1200,7 +1200,7 @@ public:
      *
      * @retval the name of the structure.
      */
-    virtual const gchar *gstStructureGetName(const GstStructure * structure) const = 0;
+    virtual const gchar *gstStructureGetName(const GstStructure *structure) const = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -1143,6 +1143,27 @@ public:
      * @param[in]  it   : the iterator to free.
      */
     virtual void gstIteratorFree(GstIterator *it) const = 0;
+
+    /**
+     * @brief Post a message on the elements bus.
+     *
+     * @param[in] element   : the element posting the message.
+     * @param[in] message   : message to post.
+     *
+     * @retval TRUE if the message was posted, FALSE otherwise.
+     */
+    virtual gboolean gstElementPostMessage(GstElement * element, GstMessage * message) const = 0;
+
+    /**
+     * @brief Create a new warning message.
+     *
+     * @param[in] src   : the origin of the message.
+     * @param[in] error : GError for this message.
+     * @param[in] debug : error info string.
+     *
+     * @retval New warning message.
+     */
+    virtual GstMessage *gstMessageNewWarning(GstObject * src, GError * error, const gchar * debug) const = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -1164,6 +1164,43 @@ public:
      * @retval New warning message.
      */
     virtual GstMessage *gstMessageNewWarning(GstObject * src, GError * error, const gchar * debug) const = 0;
+
+    /**
+     * @brief Get the GError and error string from the message.
+     *
+     * @param[in]  message  : a message of type WARNING.
+     * @param[out] gerror   : loction to store the error.
+     * @param[out] debug    : loction to store the error string.
+     */
+    virtual void gstMessageParseWarning(GstMessage * message, GError ** gerror, gchar ** debug) const = 0;
+
+    /**
+     * @brief Get the capabilities from the pad.
+     *
+     * @param[in] pad   : pad to get the capabilities.
+     *
+     * @retval the current caps, NULL otherwise.
+     */
+    virtual GstCaps *gstPadGetCurrentCaps(GstPad * pad) const = 0;
+
+    /**
+     * @brief Finds the structure at index in the caps.
+     *
+     * @param[in] caps  : a GstCaps.
+     * @param[in] index : index in the caps to get the structure.
+     *
+     * @retval ptr to a structure.
+     */
+    virtual GstStructure *gstCapsGetStructure(const GstCaps * caps, guint index) const = 0;
+
+    /**
+     * @brief Gets the name of the structure.
+     *
+     * @param[in] structure : a GstStructure.
+     *
+     * @retval the name of the structure.
+     */
+    virtual const gchar *gstStructureGetName(const GstStructure * structure) const = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers


### PR DESCRIPTION
Summary: Send a non-fatal error message through the gst pipeline and propagate the error up to the application in a new PlaybackError API.
Type: Feature
Test Plan: Unittests, Component Tests, Fullstack builds.
Jira: RIALTO-463