### PR TITLE
Fixed a deadlock issue that could occur when RialtoServer died while RialtoServerManager was waiting for a reply from it

### DIFF
--- a/ipc/client/source/IpcChannelImpl.cpp
+++ b/ipc/client/source/IpcChannelImpl.cpp
@@ -425,7 +425,11 @@ bool ChannelImpl::process()
     }
 
     if ((eventsMask & HaveSocketEvent) && !processSocketEvent())
+    {
+        std::lock_guard<std::mutex> locker(m_lock);
+        termChannel();
         return false;
+    }
 
     if (eventsMask & HaveTimeoutEvent)
         processTimeoutEvent();

--- a/media/server/ipc/source/SessionManagementServer.cpp
+++ b/media/server/ipc/source/SessionManagementServer.cpp
@@ -181,7 +181,7 @@ void SessionManagementServer::start()
             {
                 m_ipcServer->wait(kPollInterval);
             }
-            RIALTO_SERVER_LOG_DEBUG("Session Management Server event loop finished.");
+            RIALTO_SERVER_LOG_MIL("Session Management Server event loop finished.");
         });
 }
 


### PR DESCRIPTION
Summary: Fixed a deadlock issue that could occur when RialtoServer died while RialtoServerManager was waiting for a reply from it
Type: Fix
Test Plan: Unittests, YT conformance tests, Manual Tests
Jira: RIALTO-520