### PR TITLE
Print official release tag or git hash in rialto logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,21 +97,49 @@ if ( RIALTO_ENABLE_DECRYPT_BUFFER )
     add_compile_definitions( RIALTO_ENABLE_DECRYPT_BUFFER )
 endif()
 
-# Retrieve the commit ID
+# Retrieve the commit ID or release tag
 execute_process(
-    COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
-    RESULT_VARIABLE RESULT 
-    OUTPUT_VARIABLE COMMIT_ID 
+    COMMAND git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-creatordate
+    OUTPUT_VARIABLE TAGS
     OUTPUT_STRIP_TRAILING_WHITESPACE 
 )
 
+string(REGEX MATCH "v[0-9]*.[0-9]*.[0-9]*" LATEST_RELEASE_TAG "${TAGS}")
+
+if(LATEST_RELEASE_TAG STREQUAL "")
+    execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
+        RESULT_VARIABLE RESULT 
+        OUTPUT_VARIABLE COMMIT_ID 
+        OUTPUT_STRIP_TRAILING_WHITESPACE 
+    )
+else()
+    set(COMMIT_ID ${LATEST_RELEASE_TAG})
+endif() 
+
 if(RESULT)
-    message("Failed to get git commit ID: ${RESULT}")
+    message("Failed to get git commit ID or release tag: ${RESULT}")
 endif()
 
 # Preprocesser Variable
 add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
+
+# # Retrieve the commit ID
+# execute_process(
+#     COMMAND git rev-parse HEAD
+#     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
+#     RESULT_VARIABLE RESULT 
+#     OUTPUT_VARIABLE COMMIT_ID 
+#     OUTPUT_STRIP_TRAILING_WHITESPACE 
+# )
+
+# if(RESULT)
+#     message("Failed to get git commit ID: ${RESULT}")
+# endif()
+
+# # Preprocesser Variable
+# add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
 
 # Add our local cmake directory to search for components
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,49 +97,34 @@ if ( RIALTO_ENABLE_DECRYPT_BUFFER )
     add_compile_definitions( RIALTO_ENABLE_DECRYPT_BUFFER )
 endif()
 
+
 # Retrieve the commit ID or release tag
 execute_process(
-    COMMAND git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-creatordate
-    OUTPUT_VARIABLE TAGS
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
+    RESULT_VARIABLE RESULT 
+    OUTPUT_VARIABLE SRCREV 
     OUTPUT_STRIP_TRAILING_WHITESPACE 
 )
 
-string(REGEX MATCH "v[0-9]*.[0-9]*.[0-9]*" LATEST_RELEASE_TAG "${TAGS}")
-
-if(LATEST_RELEASE_TAG STREQUAL "")
+if(RESULT)
+    message("Failed to get git commit ID: ${RESULT}")
+else()
     execute_process(
-        COMMAND git rev-parse HEAD
+        COMMAND git tag --list "v[0-9]*.[0-9]*.[0-9]" --sort=-creatordate --contains ${SRCREV}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
-        RESULT_VARIABLE RESULT 
-        OUTPUT_VARIABLE COMMIT_ID 
+        OUTPUT_VARIABLE TAGS
         OUTPUT_STRIP_TRAILING_WHITESPACE 
     )
-else()
-    set(COMMIT_ID ${LATEST_RELEASE_TAG})
-endif() 
+    string(REPLACE "\n" ", " TAGS "${TAGS}")
 
-if(RESULT)
-    message("Failed to get git commit ID or release tag: ${RESULT}")
+    if(NOT LATEST_RELEASE_TAG STREQUAL "")
+        set(SRCREV ${TAGS})
+    endif() 
 endif()
 
 # Preprocesser Variable
-add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
-
-# # Retrieve the commit ID
-# execute_process(
-#     COMMAND git rev-parse HEAD
-#     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
-#     RESULT_VARIABLE RESULT 
-#     OUTPUT_VARIABLE COMMIT_ID 
-#     OUTPUT_STRIP_TRAILING_WHITESPACE 
-# )
-
-# if(RESULT)
-#     message("Failed to get git commit ID: ${RESULT}")
-# endif()
-
-# # Preprocesser Variable
-# add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
+add_compile_definitions(SRCREV="${SRCREV}")
 
 # Add our local cmake directory to search for components
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,6 @@ if ( RIALTO_ENABLE_DECRYPT_BUFFER )
     add_compile_definitions( RIALTO_ENABLE_DECRYPT_BUFFER )
 endif()
 
-
 # Retrieve the commit ID or release tag
 execute_process(
     COMMAND git rev-parse HEAD
@@ -111,17 +110,18 @@ if(RESULT)
     message("Failed to get git commit ID: ${RESULT}")
 else()
     execute_process(
-        COMMAND git tag --list "v[0-9]*.[0-9]*.[0-9]" --sort=-creatordate --contains ${SRCREV}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
+        COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
         OUTPUT_VARIABLE TAGS
         OUTPUT_STRIP_TRAILING_WHITESPACE 
     )
-    string(REPLACE "\n" ", " TAGS "${TAGS}")
-
-    if(NOT LATEST_RELEASE_TAG STREQUAL "")
-        set(SRCREV ${TAGS})
-    endif() 
 endif()
+
+string(REPLACE "\n" ", " TAGS "${TAGS}")
+
+if(NOT TAGS STREQUAL "")
+    set(SRCREV ${TAGS})
+endif() 
 
 # Preprocesser Variable
 add_compile_definitions(SRCREV="${SRCREV}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,9 +127,6 @@ endif()
 add_compile_definitions(SRCREV="${SRCREV}")
 add_compile_definitions(TAGS="${TAGS}")
 
-message("Tags: ${TAGS} ")
-message("Commit: ${SRCREV}")
-
 # Add our local cmake directory to search for components
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if ( RIALTO_ENABLE_DECRYPT_BUFFER )
     add_compile_definitions( RIALTO_ENABLE_DECRYPT_BUFFER )
 endif()
 
-# Retrieve the commit ID or release tag
+# Retrieve the commit ID 
 execute_process(
     COMMAND git rev-parse HEAD
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
@@ -108,23 +108,27 @@ execute_process(
 
 if(RESULT)
     message("Failed to get git commit ID: ${RESULT}")
-else()
-    execute_process(
-        COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
-        OUTPUT_VARIABLE TAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE 
-    )
 endif()
 
+# Retrieve release tag
+execute_process(
+    COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
+    OUTPUT_VARIABLE TAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE 
+)
 string(REPLACE "\n" ", " TAGS "${TAGS}")
 
 if(NOT TAGS STREQUAL "")
-    set(SRCREV ${TAGS})
+    set(TAGS ${TAGS})
 endif() 
 
 # Preprocesser Variable
 add_compile_definitions(SRCREV="${SRCREV}")
+add_compile_definitions(TAGS="${TAGS}")
+
+message("Tags: ${TAGS} ")
+message("Commit: ${SRCREV}")
 
 # Add our local cmake directory to search for components
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/media/client/main/source/ClientController.cpp
+++ b/media/client/main/source/ClientController.cpp
@@ -49,13 +49,13 @@ ClientController::ClientController(const std::shared_ptr<IControlIpcFactory> &Co
 
     if (std::strlen(kSrcRev) > 0)
     {
-        if (kTags[0] == 'v')
+        if (std::strlen(kTags) > 0)
         {
             RIALTO_CLIENT_LOG_MIL("Release Tag(s): %s (Commit ID: %s)", kTags, kSrcRev);
         }
         else
         {
-            RIALTO_CLIENT_LOG_MIL("Release Tag(s): NO TAGS! (Commit ID: %s)", kSrcRev);
+            RIALTO_CLIENT_LOG_MIL("Release Tag(s): No Release Tags! (Commit ID: %s)", kSrcRev);
         }
     }
     else

--- a/media/client/main/source/ClientController.cpp
+++ b/media/client/main/source/ClientController.cpp
@@ -50,7 +50,7 @@ ClientController::ClientController(const std::shared_ptr<IControlIpcFactory> &Co
     {
         if (srcRev[0] == 'v')
         {
-            RIALTO_CLIENT_LOG_MIL("Official Tag(s): %s", srcRev);
+            RIALTO_CLIENT_LOG_MIL("Release Tag(s): %s", srcRev);
         }
         else
         {

--- a/media/client/main/source/ClientController.cpp
+++ b/media/client/main/source/ClientController.cpp
@@ -45,16 +45,17 @@ ClientController::ClientController(const std::shared_ptr<IControlIpcFactory> &Co
     RIALTO_CLIENT_LOG_DEBUG("entry:");
 
     const char kSrcRev[] = SRCREV;
+    const char kTags[] = TAGS;
 
     if (std::strlen(kSrcRev) > 0)
     {
-        if (kSrcRev[0] == 'v')
+        if (kTags[0] == 'v')
         {
-            RIALTO_CLIENT_LOG_MIL("Release Tag(s): %s", kSrcRev);
+            RIALTO_CLIENT_LOG_MIL("Release Tag(s): %s (Commit ID: %s)", kTags, kSrcRev);
         }
         else
         {
-            RIALTO_CLIENT_LOG_MIL("Commit ID: %s", kSrcRev);
+            RIALTO_CLIENT_LOG_MIL("Release Tag(s): NO TAGS! (Commit ID: %s)", kSrcRev);
         }
     }
     else

--- a/media/client/main/source/ClientController.cpp
+++ b/media/client/main/source/ClientController.cpp
@@ -44,17 +44,17 @@ ClientController::ClientController(const std::shared_ptr<IControlIpcFactory> &Co
 {
     RIALTO_CLIENT_LOG_DEBUG("entry:");
 
-    const char srcRev[] = SRCREV;
+    const char kSrcRev[] = SRCREV;
 
-    if (std::strlen(srcRev) > 0)
+    if (std::strlen(kSrcRev) > 0)
     {
-        if (srcRev[0] == 'v')
+        if (kSrcRev[0] == 'v')
         {
-            RIALTO_CLIENT_LOG_MIL("Release Tag(s): %s", srcRev);
+            RIALTO_CLIENT_LOG_MIL("Release Tag(s): %s", kSrcRev);
         }
         else
         {
-            RIALTO_CLIENT_LOG_MIL("Commit ID: %s", srcRev);
+            RIALTO_CLIENT_LOG_MIL("Commit ID: %s", kSrcRev);
         }
     }
     else

--- a/media/client/main/source/ClientController.cpp
+++ b/media/client/main/source/ClientController.cpp
@@ -44,15 +44,22 @@ ClientController::ClientController(const std::shared_ptr<IControlIpcFactory> &Co
 {
     RIALTO_CLIENT_LOG_DEBUG("entry:");
 
-    const char commitID[] = COMMIT_ID;
+    const char srcRev[] = SRCREV;
 
-    if (std::strlen(commitID) > 0)
+    if (std::strlen(srcRev) > 0)
     {
-        RIALTO_CLIENT_LOG_MIL("Commit ID: %s", commitID);
+        if (srcRev[0] == 'v')
+        {
+            RIALTO_CLIENT_LOG_MIL("Official Tag(s): %s", srcRev);
+        }
+        else
+        {
+            RIALTO_CLIENT_LOG_MIL("Commit ID: %s", srcRev);
+        }
     }
     else
     {
-        RIALTO_CLIENT_LOG_WARN("Failed to get git commit ID.");
+        RIALTO_CLIENT_LOG_WARN("Failed to get git commit ID!");
     }
 
     m_controlIpc = ControlIpcFactory->createControlIpc(this);

--- a/media/server/service/source/main.cpp
+++ b/media/server/service/source/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
     {
         if (srcRev[0] == 'v')
         {
-            RIALTO_SERVER_LOG_MIL("Official Tag(s): %s", srcRev);
+            RIALTO_SERVER_LOG_MIL("Release Tag(s): %s", srcRev);
         }
         else
         {

--- a/media/server/service/source/main.cpp
+++ b/media/server/service/source/main.cpp
@@ -27,14 +27,21 @@
 int main(int argc, char *argv[])
 {
     const char commitID[] = COMMIT_ID;
-
+    
     if (std::strlen(commitID) > 0)
     {
-        RIALTO_SERVER_LOG_MIL("Commit ID: %s", commitID);
+        if(commitID[0]=='v' && std::count(commitID, commitID + std::strlen(commitID), '.') == 2)
+        {
+            RIALTO_SERVER_LOG_MIL("Official Tag: %s", commitID);
+        }
+        else
+        {
+            RIALTO_SERVER_LOG_MIL("Commit ID: %s", commitID);
+        }
     }
     else
     {
-        RIALTO_SERVER_LOG_WARN("Failed to get git commit ID.");
+        RIALTO_SERVER_LOG_WARN("Failed to get git commit ID!");
     }
 
     firebolt::rialto::server::gstInitalise(argc, argv);

--- a/media/server/service/source/main.cpp
+++ b/media/server/service/source/main.cpp
@@ -27,16 +27,17 @@
 int main(int argc, char *argv[])
 {
     const char kSrcRev[] = SRCREV;
+    const char kTags[] = TAGS;
 
     if (std::strlen(kSrcRev) > 0)
     {
-        if (kSrcRev[0] == 'v')
+        if (kTags[0] == 'v')
         {
-            RIALTO_SERVER_LOG_MIL("Release Tag(s): %s", kSrcRev);
+            RIALTO_SERVER_LOG_MIL("Release Tag(s): %s (Commit ID: %s)", kTags, kSrcRev);
         }
         else
         {
-            RIALTO_SERVER_LOG_MIL("Commit ID: %s", kSrcRev);
+            RIALTO_SERVER_LOG_MIL("Release Tag(s): NO TAGS! (Commit ID: %s)", kSrcRev);
         }
     }
     else

--- a/media/server/service/source/main.cpp
+++ b/media/server/service/source/main.cpp
@@ -26,17 +26,17 @@
 
 int main(int argc, char *argv[])
 {
-    const char srcRev[] = SRCREV;
+    const char kSrcRev[] = SRCREV;
 
-    if (std::strlen(srcRev) > 0)
+    if (std::strlen(kSrcRev) > 0)
     {
-        if (srcRev[0] == 'v')
+        if (kSrcRev[0] == 'v')
         {
-            RIALTO_SERVER_LOG_MIL("Release Tag(s): %s", srcRev);
+            RIALTO_SERVER_LOG_MIL("Release Tag(s): %s", kSrcRev);
         }
         else
         {
-            RIALTO_SERVER_LOG_MIL("Commit ID: %s", srcRev);
+            RIALTO_SERVER_LOG_MIL("Commit ID: %s", kSrcRev);
         }
     }
     else

--- a/media/server/service/source/main.cpp
+++ b/media/server/service/source/main.cpp
@@ -31,13 +31,13 @@ int main(int argc, char *argv[])
 
     if (std::strlen(kSrcRev) > 0)
     {
-        if (kTags[0] == 'v')
+        if (std::strlen(kTags) > 0)
         {
             RIALTO_SERVER_LOG_MIL("Release Tag(s): %s (Commit ID: %s)", kTags, kSrcRev);
         }
         else
         {
-            RIALTO_SERVER_LOG_MIL("Release Tag(s): NO TAGS! (Commit ID: %s)", kSrcRev);
+            RIALTO_SERVER_LOG_MIL("Release Tag(s): No Release Tags! (Commit ID: %s)", kTags, kSrcRev);
         }
     }
     else

--- a/media/server/service/source/main.cpp
+++ b/media/server/service/source/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            RIALTO_SERVER_LOG_MIL("Release Tag(s): No Release Tags! (Commit ID: %s)", kTags, kSrcRev);
+            RIALTO_SERVER_LOG_MIL("Release Tag(s): No Release Tags! (Commit ID: %s)", kSrcRev);
         }
     }
     else

--- a/media/server/service/source/main.cpp
+++ b/media/server/service/source/main.cpp
@@ -26,17 +26,17 @@
 
 int main(int argc, char *argv[])
 {
-    const char commitID[] = COMMIT_ID;
-    
-    if (std::strlen(commitID) > 0)
+    const char srcRev[] = SRCREV;
+
+    if (std::strlen(srcRev) > 0)
     {
-        if(commitID[0]=='v' && std::count(commitID, commitID + std::strlen(commitID), '.') == 2)
+        if (srcRev[0] == 'v')
         {
-            RIALTO_SERVER_LOG_MIL("Official Tag: %s", commitID);
+            RIALTO_SERVER_LOG_MIL("Official Tag(s): %s", srcRev);
         }
         else
         {
-            RIALTO_SERVER_LOG_MIL("Commit ID: %s", commitID);
+            RIALTO_SERVER_LOG_MIL("Commit ID: %s", srcRev);
         }
     }
     else


### PR DESCRIPTION
Summary: Printing release tag or git hash in rialto logs
Type: Fix
Test Plan: Unit tests and Full Stack
Jira: RIALTO-518