### PR TITLE
Fix intermittent issues with server component test with valgrind

### DIFF
--- a/tests/componenttests/server/common/ExpectMessage.h
+++ b/tests/componenttests/server/common/ExpectMessage.h
@@ -84,7 +84,7 @@ private:
     std::shared_ptr<::firebolt::rialto::ipc::IChannel> m_channel{nullptr};
     std::shared_ptr<MessageType> m_message{nullptr};
     std::function<bool(const MessageType &)> m_filter{[](const MessageType &) { return true; }};
-    std::chrono::milliseconds m_timeout{200};
+    std::chrono::milliseconds m_timeout{400};
 };
 } // namespace firebolt::rialto::server::ct
 

--- a/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
+++ b/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
@@ -300,7 +300,7 @@ void MediaPipelineTest::willRemoveAudioSource()
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, StrEq("video"))).WillOnce(Return(&m_videoFlag));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, StrEq("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, StrEq("flags")));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, StrEq("flags"))).WillOnce(Invoke(this, &MediaPipelineTest::workerFinished));
 }
 
 void MediaPipelineTest::willStop()
@@ -609,6 +609,10 @@ void MediaPipelineTest::removeSource(int sourceId)
 {
     auto removeSourceReq{createRemoveSourceRequest(m_sessionId, sourceId)};
     ConfigureAction<RemoveSource>(m_clientStub).send(removeSourceReq).expectSuccess();
+
+    // Sources other than audio do not do anything for RemoveSource 
+    if (m_audioSourceId == sourceId)
+        waitWorker();
 }
 
 void MediaPipelineTest::stop()

--- a/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
+++ b/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
@@ -300,7 +300,8 @@ void MediaPipelineTest::willRemoveAudioSource()
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, StrEq("video"))).WillOnce(Return(&m_videoFlag));
     EXPECT_CALL(*m_glibWrapperMock, gFlagsGetValueByNick(&m_flagsClass, StrEq("native-video")))
         .WillOnce(Return(&m_nativeVideoFlag));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, StrEq("flags"))).WillOnce(Invoke(this, &MediaPipelineTest::workerFinished));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&m_pipeline, StrEq("flags")))
+        .WillOnce(Invoke(this, &MediaPipelineTest::workerFinished));
 }
 
 void MediaPipelineTest::willStop()
@@ -610,7 +611,7 @@ void MediaPipelineTest::removeSource(int sourceId)
     auto removeSourceReq{createRemoveSourceRequest(m_sessionId, sourceId)};
     ConfigureAction<RemoveSource>(m_clientStub).send(removeSourceReq).expectSuccess();
 
-    // Sources other than audio do not do anything for RemoveSource 
+    // Sources other than audio do not do anything for RemoveSource
     if (m_audioSourceId == sourceId)
         waitWorker();
 }


### PR DESCRIPTION
Summary: Increase event timeout and synchronising removing audio source in component tests.
Type: Fix
Test Plan: Valgrind server component tests.
Jira: NO-JIRA