### PR TITLE
Add support for building Rialto on macOS

### DIFF
--- a/.github/workflows/native_rialto_build_macos.yml
+++ b/.github/workflows/native_rialto_build_macos.yml
@@ -43,7 +43,13 @@ jobs:
 
       - name: Build Rialto
         run: |
-          cmake . -B build -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" > output_file.txt 2>&1
+          pkg-config --cflags gstreamer-1.0 > output_file.txt 2>&1
+          ls -l /Library/Frameworks/GStreamer.framework/Versions/1.0/bin >> output_file.txt 2>&1
+          tree /Library/Frameworks/GStreamer.framework/Versions/1.0/bin >> output_file.txt 2>&1
+
+          export PATH=/Library/Frameworks/GStreamer.framework/Versions/1.0/bin:$PATH
+          pkg-config --cflags gstreamer-1.0 >> output_file.txt 2>&1
+          cmake . -B build -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" >> output_file.txt 2>&1
           if [ $? -eq 0 ]
           then
             make -C build >> output_file.txt 2>&1

--- a/.github/workflows/native_rialto_build_macos.yml
+++ b/.github/workflows/native_rialto_build_macos.yml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Build Rialto
         run: |
-          cmake . -B build -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &> output_file.txt
+          cmake . -B build -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" > output_file.txt 2>&1
           if [ $? -eq 0 ]
           then
-            make -C build &>> output_file.txt
+            make -C build >> output_file.txt 2>&1
           else
             exit 1
           fi

--- a/.github/workflows/native_rialto_build_macos.yml
+++ b/.github/workflows/native_rialto_build_macos.yml
@@ -1,0 +1,66 @@
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 Sky UK
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Native Rialto Build on macOS
+
+on:
+  pull_request:
+    branches: [ "master", "rdkcentral:master" ]
+  push:
+    branches: [ "master", "rdkcentral:master" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          brew update
+          brew install cmake
+          brew install protobuf
+          brew install gstreamer gst-plugins-base gst-plugins-bad
+
+      - name: Build Rialto
+        run: |
+          cmake . -B build -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &> output_file.txt
+          if [ $? -eq 0 ]
+          then
+            make -C build &>> output_file.txt
+          else
+            exit 1
+          fi
+
+      - name: Report Build Status Success
+        if: success()
+        run: |
+          echo "Build Succeeded!"
+          exit 0
+
+      - name: Upload Logs on Failure
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Output Logs
+          path: |
+            output_file.txt

--- a/.github/workflows/native_rialto_build_macos.yml
+++ b/.github/workflows/native_rialto_build_macos.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew update
           brew install cmake
           brew install protobuf
           brew install gstreamer gst-plugins-base gst-plugins-bad

--- a/.github/workflows/native_rialto_build_macos.yml
+++ b/.github/workflows/native_rialto_build_macos.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           brew install cmake
           brew install protobuf
+          brew install glib
           brew install gstreamer gst-plugins-base gst-plugins-bad
 
       - name: Build Rialto

--- a/.github/workflows/native_rialto_build_ubuntu.yml
+++ b/.github/workflows/native_rialto_build_ubuntu.yml
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-name: Native Rialto Build
+name: Native Rialto Build on Ubuntu
 
 on:
   pull_request:


### PR DESCRIPTION
Summary: Add support for building Rialto on macOS
Type: Feature
Test Plan: Manual tests
Jira: RIALTO-512