### PR TITLE
Fix for a problem with decryption of first frame in Webkit.

### DIFF
--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -230,11 +230,8 @@ private:
      * @brief Pushes GstSample if playback position has changed or new segment needs to be sent.
      *
      * @param[in] source          : The Gst Source element, that should receive new sample
-     * @param[in] buffer          : The next GstBuffer to push
-     *
-     * @retval True if operation was performed
      */
-    bool pushSampleIfRequired(GstElement *source, GstBuffer *buffer);
+    void pushSampleIfRequired(GstElement *source);
 
 private:
     /**

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -485,15 +485,7 @@ void GstGenericPlayer::attachAudioData()
 
     if (m_context.audioAppSrc)
     {
-        GstBuffer *firstBuffer{nullptr};
-        if (!m_context.audioBuffers.empty())
-        {
-            firstBuffer = m_context.audioBuffers.front();
-        }
-        if (pushSampleIfRequired(m_context.audioAppSrc, firstBuffer) && firstBuffer)
-        {
-            m_context.audioBuffers.pop_front();
-        }
+        pushSampleIfRequired(m_context.audioAppSrc);
         for (GstBuffer *buffer : m_context.audioBuffers)
         {
             m_gstWrapper->gstAppSrcPushBuffer(GST_APP_SRC(m_context.audioAppSrc), buffer);
@@ -533,15 +525,7 @@ void GstGenericPlayer::attachVideoData()
     }
     if (m_context.videoAppSrc)
     {
-        GstBuffer *firstBuffer{nullptr};
-        if (!m_context.videoBuffers.empty())
-        {
-            firstBuffer = m_context.videoBuffers.front();
-        }
-        if (pushSampleIfRequired(m_context.videoAppSrc, firstBuffer) && firstBuffer)
-        {
-            m_context.videoBuffers.pop_front();
-        }
+        pushSampleIfRequired(m_context.videoAppSrc);
         for (GstBuffer *buffer : m_context.videoBuffers)
         {
             m_gstWrapper->gstAppSrcPushBuffer(GST_APP_SRC(m_context.videoAppSrc), buffer);
@@ -663,12 +647,13 @@ bool GstGenericPlayer::setCodecData(GstCaps *caps, const std::shared_ptr<CodecDa
     return false;
 }
 
-bool GstGenericPlayer::pushSampleIfRequired(GstElement *source, GstBuffer *buffer)
+void GstGenericPlayer::pushSampleIfRequired(GstElement *source)
 {
     auto initialPosition = m_context.initialPositions.find(source);
     if (m_context.initialPositions.end() == initialPosition)
     {
-        return false;
+        // Sending initial sample not needed
+        return;
     }
     RIALTO_SERVER_LOG_DEBUG("Pushing new sample...");
     GstSegment *segment{m_gstWrapper->gstSegmentNew()};
@@ -680,22 +665,24 @@ bool GstGenericPlayer::pushSampleIfRequired(GstElement *source, GstBuffer *buffe
         RIALTO_SERVER_LOG_WARN("Segment seek failed.");
         m_gstWrapper->gstSegmentFree(segment);
         m_context.initialPositions.erase(initialPosition);
-        return false;
+        return;
     }
 
     RIALTO_SERVER_LOG_MIL("New segment: [%" GST_TIME_FORMAT ", %" GST_TIME_FORMAT "], rate: %f \n",
                           GST_TIME_ARGS(segment->start), GST_TIME_ARGS(segment->stop), segment->rate);
 
     GstCaps *currentCaps = m_gstWrapper->gstAppSrcGetCaps(GST_APP_SRC(source));
-    GstSample *sample = m_gstWrapper->gstSampleNew(buffer, currentCaps, segment, nullptr);
+    // We can't pass buffer in GstSample, because implementation of gst_app_src_push_sample
+    // uses gst_buffer_copy, which loses RialtoProtectionMeta (that causes problems with EME
+    // for first frame).
+    GstSample *sample = m_gstWrapper->gstSampleNew(nullptr, currentCaps, segment, nullptr);
     m_gstWrapper->gstAppSrcPushSample(GST_APP_SRC(source), sample);
     m_gstWrapper->gstSampleUnref(sample);
     m_gstWrapper->gstCapsUnref(currentCaps);
 
     m_gstWrapper->gstSegmentFree(segment);
     m_context.initialPositions.erase(initialPosition);
-
-    return true;
+    return;
 }
 
 void GstGenericPlayer::scheduleNeedMediaData(GstAppSrc *src)

--- a/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
+++ b/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
@@ -282,10 +282,11 @@ void MediaPipelineTest::willPushAudioSample(const std::unique_ptr<IMediaPipeline
                 gstSegmentDoSeek(&m_segment, kRate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE, GST_SEEK_TYPE_SET, kPosition,
                                  GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE, nullptr))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(&buffer, &m_audioCaps, &m_segment, nullptr)).WillOnce(Return(m_sample));
+    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(nullptr, &m_audioCaps, &m_segment, nullptr)).WillOnce(Return(m_sample));
     EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushSample(&m_audioAppSrc, m_sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSampleUnref(m_sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSegmentFree(&m_segment));
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushBuffer(&m_audioAppSrc, &buffer)).RetiresOnSaturation();
 }
 
 void MediaPipelineTest::willPushVideoSample(const std::unique_ptr<IMediaPipeline::MediaSegment> &segment,
@@ -317,10 +318,11 @@ void MediaPipelineTest::willPushVideoSample(const std::unique_ptr<IMediaPipeline
                 gstSegmentDoSeek(&m_segment, kRate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE, GST_SEEK_TYPE_SET, kPosition,
                                  GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE, nullptr))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(&buffer, &m_videoCaps, &m_segment, nullptr)).WillOnce(Return(m_sample));
+    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(nullptr, &m_videoCaps, &m_segment, nullptr)).WillOnce(Return(m_sample));
     EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushSample(&m_videoAppSrc, m_sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSampleUnref(m_sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSegmentFree(&m_segment));
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushBuffer(&m_videoAppSrc, &buffer)).RetiresOnSaturation();
 }
 
 void MediaPipelineTest::willPause()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -544,39 +544,6 @@ TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioData)
     m_sut->attachAudioData();
 }
 
-TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioSample)
-{
-    constexpr std::int64_t kPosition{124};
-    constexpr double kRate{1.0};
-    GstBuffer buffer{};
-    GstAppSrc audioSrc{};
-    GstSegment segment{};
-    GstSample *sample{nullptr};
-    GstCaps caps{};
-    modifyContext(
-        [&](GenericPlayerContext &context)
-        {
-            context.audioBuffers.emplace_back(&buffer);
-            context.audioNeedData = true;
-            context.playbackRate = kRate;
-            context.streamInfo[firebolt::rialto::MediaSourceType::AUDIO].appSrc = GST_ELEMENT(&audioSrc);
-            context.initialPositions[GST_ELEMENT(&audioSrc)] = kPosition;
-        });
-    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcGetCaps(&audioSrc)).WillOnce(Return(&caps));
-    EXPECT_CALL(*m_gstWrapperMock, gstSegmentNew()).WillOnce(Return(&segment));
-    EXPECT_CALL(*m_gstWrapperMock, gstSegmentInit(&segment, GST_FORMAT_TIME));
-    EXPECT_CALL(*m_gstWrapperMock,
-                gstSegmentDoSeek(&segment, kRate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE, GST_SEEK_TYPE_SET, kPosition,
-                                 GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE, nullptr))
-        .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(&buffer, &caps, &segment, nullptr)).WillOnce(Return(sample));
-    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushSample(&audioSrc, sample));
-    EXPECT_CALL(*m_gstWrapperMock, gstSampleUnref(sample));
-    EXPECT_CALL(*m_gstWrapperMock, gstSegmentFree(&segment));
-    EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&caps));
-    m_sut->attachAudioData();
-}
-
 TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioDataWhenAttachingSampleFails)
 {
     constexpr std::int64_t kPosition{124};
@@ -604,12 +571,11 @@ TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioDataWhenAttachingSampleFail
     m_sut->attachAudioData();
 }
 
-TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioSampleWithAdditionalData)
+TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioSample)
 {
     constexpr std::int64_t kPosition{124};
     constexpr double kRate{1.0};
-    GstBuffer buffer1{};
-    GstBuffer buffer2{};
+    GstBuffer buffer{};
     GstAppSrc audioSrc{};
     GstSegment segment{};
     GstSample *sample{nullptr};
@@ -617,8 +583,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioSampleWithAdditionalData)
     modifyContext(
         [&](GenericPlayerContext &context)
         {
-            context.audioBuffers.emplace_back(&buffer1);
-            context.audioBuffers.emplace_back(&buffer2);
+            context.audioBuffers.emplace_back(&buffer);
             context.audioNeedData = true;
             context.playbackRate = kRate;
             context.streamInfo[firebolt::rialto::MediaSourceType::AUDIO].appSrc = GST_ELEMENT(&audioSrc);
@@ -631,12 +596,12 @@ TEST_F(GstGenericPlayerPrivateTest, shouldAttachAudioSampleWithAdditionalData)
                 gstSegmentDoSeek(&segment, kRate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE, GST_SEEK_TYPE_SET, kPosition,
                                  GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE, nullptr))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(&buffer1, &caps, &segment, nullptr)).WillOnce(Return(sample));
+    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(nullptr, &caps, &segment, nullptr)).WillOnce(Return(sample));
     EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushSample(&audioSrc, sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSampleUnref(sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSegmentFree(&segment));
     EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&caps));
-    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushBuffer(_, &buffer2));
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushBuffer(_, &buffer));
     m_sut->attachAudioData();
 }
 
@@ -702,12 +667,11 @@ TEST_F(GstGenericPlayerPrivateTest, shouldAttachVideoData)
     m_sut->attachVideoData();
 }
 
-TEST_F(GstGenericPlayerPrivateTest, shouldAttachVideoSampleWithAdditionalData)
+TEST_F(GstGenericPlayerPrivateTest, shouldAttachVideoSample)
 {
     constexpr std::int64_t kPosition{124};
     constexpr double kRate{1.0};
-    GstBuffer buffer1{};
-    GstBuffer buffer2{};
+    GstBuffer buffer{};
     GstAppSrc videoSrc{};
     GstSegment segment{};
     GstSample *sample{nullptr};
@@ -715,8 +679,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldAttachVideoSampleWithAdditionalData)
     modifyContext(
         [&](GenericPlayerContext &context)
         {
-            context.videoBuffers.emplace_back(&buffer1);
-            context.videoBuffers.emplace_back(&buffer2);
+            context.videoBuffers.emplace_back(&buffer);
             context.videoNeedData = true;
             context.playbackRate = kRate;
             context.streamInfo[firebolt::rialto::MediaSourceType::VIDEO].appSrc = GST_ELEMENT(&videoSrc);
@@ -729,12 +692,12 @@ TEST_F(GstGenericPlayerPrivateTest, shouldAttachVideoSampleWithAdditionalData)
                 gstSegmentDoSeek(&segment, kRate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE, GST_SEEK_TYPE_SET, kPosition,
                                  GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE, nullptr))
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(&buffer1, &caps, &segment, nullptr)).WillOnce(Return(sample));
+    EXPECT_CALL(*m_gstWrapperMock, gstSampleNew(nullptr, &caps, &segment, nullptr)).WillOnce(Return(sample));
     EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushSample(&videoSrc, sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSampleUnref(sample));
     EXPECT_CALL(*m_gstWrapperMock, gstSegmentFree(&segment));
     EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&caps));
-    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushBuffer(_, &buffer2));
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcPushBuffer(_, &buffer));
     m_sut->attachVideoData();
 }
 


### PR DESCRIPTION
Summary: Fix for a problem with decryption of first frame in Webkit.
Type: Fix
Test Plan: Unittests, Component Tests, YT Conformance Tests
Jira: RIALTO-499
