### PR TITLE
Flush thread events between component tests

### DIFF
--- a/media/client/ipc/include/ControlIpc.h
+++ b/media/client/ipc/include/ControlIpc.h
@@ -71,6 +71,7 @@ public:
 
     bool getSharedMemory(int32_t &fd, uint32_t &size) override;
     bool registerClient() override;
+    void eventThreadFlush() override;
 
 private:
     bool createRpcStubs(const std::shared_ptr<ipc::IChannel> &ipcChannel) override;
@@ -91,7 +92,6 @@ private:
      */
     void onPing(const std::shared_ptr<firebolt::rialto::PingEvent> &event);
 
-private:
     /**
      * @brief Control client for handling messages from server
      */

--- a/media/client/ipc/interface/IControlIpc.h
+++ b/media/client/ipc/interface/IControlIpc.h
@@ -86,6 +86,11 @@ public:
      * @retval true success, false otherwise.
      */
     virtual bool registerClient() = 0;
+
+    /**
+     * @brief Flush any events in the event thread
+     */
+    virtual void eventThreadFlush() = 0;
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/ipc/source/ControlIpc.cpp
+++ b/media/client/ipc/source/ControlIpc.cpp
@@ -88,7 +88,13 @@ ControlIpc::~ControlIpc()
     detachChannel();
 
     // destroy the thread processing async notifications
+    m_eventThread->flush();
     m_eventThread.reset();
+}
+
+void ControlIpc::eventThreadFlush()
+{
+    m_eventThread->flush();
 }
 
 bool ControlIpc::getSharedMemory(int32_t &fd, uint32_t &size)

--- a/media/client/ipc/source/MediaKeysIpc.cpp
+++ b/media/client/ipc/source/MediaKeysIpc.cpp
@@ -173,6 +173,7 @@ MediaKeysIpc::~MediaKeysIpc()
 
     detachChannel();
 
+    m_eventThread->flush();
     m_eventThread.reset();
 }
 

--- a/media/client/ipc/source/MediaPipelineIpc.cpp
+++ b/media/client/ipc/source/MediaPipelineIpc.cpp
@@ -95,6 +95,7 @@ MediaPipelineIpc::~MediaPipelineIpc()
     detachChannel();
 
     // destroy the thread processing async notifications
+    m_eventThread->flush();
     m_eventThread.reset();
 }
 

--- a/media/client/ipc/source/WebAudioPlayerIpc.cpp
+++ b/media/client/ipc/source/WebAudioPlayerIpc.cpp
@@ -91,6 +91,7 @@ WebAudioPlayerIpc::~WebAudioPlayerIpc()
     detachChannel();
 
     // destroy the thread processing async notifications
+    m_eventThread->flush();
     m_eventThread.reset();
 }
 

--- a/media/client/main/include/ClientController.h
+++ b/media/client/main/include/ClientController.h
@@ -80,6 +80,11 @@ private:
      */
     void changeStateAndNotifyClients(ApplicationState state);
 
+    /**
+     * @brief Flush all events
+     */
+    void eventFlush() override;
+
 private:
     /**
      * @brief Mutex protection for class attributes.

--- a/media/client/main/include/IClientController.h
+++ b/media/client/main/include/IClientController.h
@@ -103,6 +103,11 @@ public:
      * @retval true on success, false otherwise.
      */
     virtual bool unregisterClient(std::weak_ptr<IControlClient> client) = 0;
+
+    /**
+     * @brief Flush all events
+     */
+    virtual void eventFlush() = 0;
 };
 
 }; // namespace firebolt::rialto::client

--- a/media/client/main/source/Control.cpp
+++ b/media/client/main/source/Control.cpp
@@ -69,6 +69,10 @@ Control::~Control()
     {
         m_clientController.unregisterClient(client);
     }
+
+    // The following line is for client component tests, it ensures that all events
+    // are processed before moving to the next test
+    m_clientController.eventFlush();
 }
 
 bool Control::registerClient(std::weak_ptr<IControlClient> client, ApplicationState &appState)

--- a/media/client/main/source/MediaPipeline.cpp
+++ b/media/client/main/source/MediaPipeline.cpp
@@ -726,10 +726,10 @@ void MediaPipeline::notifyNeedMediaData(int32_t sourceId, size_t frameCount, uin
 void MediaPipeline::notifyApplicationState(ApplicationState state)
 {
     RIALTO_CLIENT_LOG_DEBUG("entry:");
-    std::lock_guard<std::mutex> lock{m_needDataRequestMapMutex};
     m_currentAppState = state;
     if (ApplicationState::RUNNING != state)
     {
+        std::lock_guard<std::mutex> lock{m_needDataRequestMapMutex};
         // If shared memory in use, wait for it to finish before returning
         m_needDataRequestMap.clear();
     }

--- a/tests/componenttests/client/stubs/ServerStub.h
+++ b/tests/componenttests/client/stubs/ServerStub.h
@@ -53,6 +53,7 @@ public:
 
     void clientDisconnected(const std::shared_ptr<::firebolt::rialto::ipc::IClient> &client);
     void clientConnected(const std::shared_ptr<::firebolt::rialto::ipc::IClient> &client);
+    void disconnect();
 
 private:
     std::shared_ptr<::firebolt::rialto::ipc::IServer> m_server;

--- a/tests/componenttests/client/tests/base/ClientComponentTest.cpp
+++ b/tests/componenttests/client/tests/base/ClientComponentTest.cpp
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-#include "ClientComponentTest.h"
 #include <cstring>
 #include <fcntl.h>
 #include <linux/memfd.h>
@@ -29,6 +28,8 @@
 #include <unistd.h>
 #include <utility>
 #include <vector>
+
+#include "ClientComponentTest.h"
 
 #if !defined(SYS_memfd_create)
 #if defined(__NR_memfd_create)
@@ -152,6 +153,7 @@ std::shared_ptr<ServerStub> &ClientComponentTest::getServerStub()
 
 void ClientComponentTest::disconnectServer()
 {
+    m_serverStub->disconnect();
     m_serverStub.reset();
 }
 

--- a/tests/unittests/media/client/ipc/controlIpc/CreateTest.cpp
+++ b/tests/unittests/media/client/ipc/controlIpc/CreateTest.cpp
@@ -91,3 +91,15 @@ TEST_F(RialtoClientControlIpcCreateTest, SubscribeEventFailure)
                      std::make_shared<ControlIpc>(&m_controlClientMock, *m_ipcClientMock, m_eventThreadFactoryMock),
                  std::runtime_error);
 }
+
+/**
+ * Test ControlIpc eventThreadFlush which should call flush on m_eventThread
+ */
+TEST_F(RialtoClientControlIpcCreateTest, EventThreadFlushes)
+{
+    EXPECT_CALL(*m_eventThread, flush()).Times(1);
+
+    createControlIpc();
+    m_controlIpc->eventThreadFlush();
+    destroyControlIpc();
+}

--- a/tests/unittests/media/client/ipc/controlIpc/base/ControlIpcTestBase.cpp
+++ b/tests/unittests/media/client/ipc/controlIpc/base/ControlIpcTestBase.cpp
@@ -49,6 +49,7 @@ void ControlIpcTestBase::createControlIpc()
 {
     expectInitIpc();
     expectSubscribeEvents();
+    EXPECT_CALL(*m_eventThread, flush());
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
 
     EXPECT_NO_THROW(

--- a/tests/unittests/media/client/ipc/controlIpc/base/ControlIpcTestBase.cpp
+++ b/tests/unittests/media/client/ipc/controlIpc/base/ControlIpcTestBase.cpp
@@ -49,7 +49,7 @@ void ControlIpcTestBase::createControlIpc()
 {
     expectInitIpc();
     expectSubscribeEvents();
-    EXPECT_CALL(*m_eventThread, flush());
+    EXPECT_CALL(*m_eventThread, flush()).Times(1).RetiresOnSaturation();
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
 
     EXPECT_NO_THROW(

--- a/tests/unittests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaKeysIpc/CreateTest.cpp
@@ -33,6 +33,7 @@ TEST_F(RialtoClientCreateMediaKeysIpcTest, Create)
     expectSubscribeEvents();
     expectIpcApiCallSuccess();
 
+    EXPECT_CALL(*m_eventThread, flush());
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createMediaKeys"), m_controllerMock.get(),
                                            createMediaKeysRequestMatcher(m_keySystem), _, m_blockingClosureMock.get()))

--- a/tests/unittests/media/client/ipc/mediaKeysIpc/base/MediaKeysIpcTestBase.cpp
+++ b/tests/unittests/media/client/ipc/mediaKeysIpc/base/MediaKeysIpcTestBase.cpp
@@ -37,6 +37,7 @@ void MediaKeysIpcTestBase::createMediaKeysIpc()
     expectSubscribeEvents();
     expectIpcApiCallSuccess();
 
+    EXPECT_CALL(*m_eventThread, flush());
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createMediaKeys"), _, _, _, _))
         .WillOnce(WithArgs<3>(Invoke(this, &MediaKeysIpcTestBase::setCreateMediaKeysResponse)));

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/CallbackTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/CallbackTest.cpp
@@ -30,6 +30,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/CreateTest.cpp
@@ -41,6 +41,7 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateDestroy)
     expectSubscribeEvents();
     expectIpcApiCallSuccess();
 
+    EXPECT_CALL(*m_eventThread, flush());
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createSession"), m_controllerMock.get(),
                                            createSessionRequestMatcher(m_videoReq.maxWidth, m_videoReq.maxHeight), _,
@@ -72,6 +73,7 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateDestroyWithReconnection)
     expectSubscribeEvents();
     expectIpcApiCallSuccess();
 
+    EXPECT_CALL(*m_eventThread, flush());
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createSession"), m_controllerMock.get(),
                                            createSessionRequestMatcher(m_videoReq.maxWidth, m_videoReq.maxHeight), _,
@@ -130,6 +132,7 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, FactoryCreatesObject)
 /**
  * Test that a MediaPipelineIpc object not created when the ipc channel has not been created.
  */
+
 TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateNoIpcChannel)
 {
     expectInitIpcButAttachChannelFailure();
@@ -217,6 +220,7 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, CreateSessionFailure)
 TEST_F(RialtoClientCreateMediaPipelineIpcTest, DestroySessionFailure)
 {
     /* create media player */
+    EXPECT_CALL(*m_eventThread, flush());
     createMediaPipelineIpc();
 
     /* destroy media player */
@@ -235,6 +239,7 @@ TEST_F(RialtoClientCreateMediaPipelineIpcTest, DestroySessionFailure)
 TEST_F(RialtoClientCreateMediaPipelineIpcTest, DestructorChannelDisconnected)
 {
     /* create media player */
+    EXPECT_CALL(*m_eventThread, flush());
     createMediaPipelineIpc();
 
     /* destroy media player */

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/DataTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/DataTest.cpp
@@ -47,6 +47,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
 
         initShmInfo();

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/FlushTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/FlushTest.cpp
@@ -27,6 +27,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/GetMuteTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/GetMuteTest.cpp
@@ -27,6 +27,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/GetPositionTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/GetPositionTest.cpp
@@ -27,6 +27,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/GetVolumeTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/GetVolumeTest.cpp
@@ -27,6 +27,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/LoadTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/LoadTest.cpp
@@ -32,6 +32,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/PlayPauseTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/PlayPauseTest.cpp
@@ -27,6 +27,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/RenderFrameTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/RenderFrameTest.cpp
@@ -27,6 +27,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/SetMuteTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/SetMuteTest.cpp
@@ -29,6 +29,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/SetPlaybackRateTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/SetPlaybackRateTest.cpp
@@ -29,6 +29,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/SetPositionTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/SetPositionTest.cpp
@@ -29,6 +29,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/SetSourcePositionTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/SetSourcePositionTest.cpp
@@ -30,6 +30,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/SetVideoWindowTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/SetVideoWindowTest.cpp
@@ -32,6 +32,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/SetVolumeTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/SetVolumeTest.cpp
@@ -29,6 +29,7 @@ protected:
     {
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/mediaPipelineIpc/SourceTest.cpp
+++ b/tests/unittests/media/client/ipc/mediaPipelineIpc/SourceTest.cpp
@@ -44,6 +44,7 @@ protected:
 
         MediaPipelineIpcTestBase::SetUp();
 
+        EXPECT_CALL(*m_eventThread, flush());
         createMediaPipelineIpc();
     }
 

--- a/tests/unittests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
+++ b/tests/unittests/media/client/ipc/webAudioPlayerIpc/CreateTest.cpp
@@ -42,6 +42,7 @@ TEST_F(RialtoClientCreateWebAudioPlayerIpcTest, CreateDestroy)
     expectSubscribeEvents();
     expectIpcApiCallSuccess();
 
+    EXPECT_CALL(*m_eventThread, flush());
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createWebAudioPlayer"), m_controllerMock.get(),
                                            createWebAudioPlayerRequestMatcher(m_audioMimeType, m_priority, m_config), _,

--- a/tests/unittests/media/client/ipc/webAudioPlayerIpc/base/WebAudioPlayerIpcTestBase.cpp
+++ b/tests/unittests/media/client/ipc/webAudioPlayerIpc/base/WebAudioPlayerIpcTestBase.cpp
@@ -45,6 +45,7 @@ void WebAudioPlayerIpcTestBase::createWebAudioPlayerIpc()
     expectSubscribeEvents();
     expectIpcApiCallSuccess();
 
+    EXPECT_CALL(*m_eventThread, flush());
     EXPECT_CALL(*m_eventThreadFactoryMock, createEventThread(_)).WillOnce(Return(ByMove(std::move(m_eventThread))));
     EXPECT_CALL(*m_channelMock, CallMethod(methodMatcher("createWebAudioPlayer"), _, _, _, _))
         .WillOnce(WithArgs<3>(Invoke(this, &WebAudioPlayerIpcTestBase::setCreateWebAudioPlayerResponse)));

--- a/tests/unittests/media/client/main/clientController/CreateTest.cpp
+++ b/tests/unittests/media/client/main/clientController/CreateTest.cpp
@@ -71,3 +71,21 @@ TEST_F(ClientControllerCreateTest, CreateControlIpcFailure)
     EXPECT_THROW(controller = std::make_unique<ClientController>(m_controlIpcFactoryMock), std::runtime_error);
     EXPECT_EQ(controller, nullptr);
 }
+
+TEST_F(ClientControllerCreateTest, testThatEventFlushWorks)
+{
+    std::unique_ptr<IClientController> controller;
+
+    // Create
+    EXPECT_CALL(*m_controlIpcFactoryMock, createControlIpc(_)).WillOnce(Return(m_controlIpcMock));
+
+    EXPECT_NO_THROW(controller = std::make_unique<ClientController>(m_controlIpcFactoryMock));
+
+    // Call eventFlush which should call eventThreadFlush on m_controlIpc
+    EXPECT_CALL(*m_controlIpcMock, eventThreadFlush());
+    controller->eventFlush();
+
+    // Destroy
+    EXPECT_CALL(*m_controlIpcMock, eventThreadFlush());
+    controller.reset();
+}

--- a/tests/unittests/media/client/main/clientController/CreateTest.cpp
+++ b/tests/unittests/media/client/main/clientController/CreateTest.cpp
@@ -58,6 +58,7 @@ TEST_F(ClientControllerCreateTest, CreateDestroy)
     EXPECT_NO_THROW(controller = std::make_unique<ClientController>(m_controlIpcFactoryMock));
 
     // Destroy
+    EXPECT_CALL(*m_controlIpcMock, eventThreadFlush());
     controller.reset();
 }
 

--- a/tests/unittests/media/client/main/clientController/MemoryManagementTest.cpp
+++ b/tests/unittests/media/client/main/clientController/MemoryManagementTest.cpp
@@ -62,6 +62,7 @@ protected:
 
     ~ClientControllerMemoryManagementTest()
     {
+        EXPECT_CALL(*m_controlIpcMock, eventThreadFlush());
         m_sut.reset();
 
         m_controlIpcMock.reset();

--- a/tests/unittests/media/client/main/control/ControlTest.cpp
+++ b/tests/unittests/media/client/main/control/ControlTest.cpp
@@ -70,5 +70,6 @@ TEST_F(RialtoClientControlTest, CreateDestroy)
     EXPECT_NO_THROW(control = std::make_unique<Control>(*m_clientControllerMock));
 
     // Destroy
+    EXPECT_CALL(*m_clientControllerMock, eventFlush());
     control.reset();
 }

--- a/tests/unittests/media/client/mocks/ipc/ControlIpcMock.h
+++ b/tests/unittests/media/client/mocks/ipc/ControlIpcMock.h
@@ -33,6 +33,7 @@ public:
 
     MOCK_METHOD(bool, getSharedMemory, (int32_t & fd, uint32_t &size), (override));
     MOCK_METHOD(bool, registerClient, (), (override));
+    MOCK_METHOD(void, eventThreadFlush, (), (override));
 };
 } // namespace firebolt::rialto::client
 

--- a/tests/unittests/media/client/mocks/main/ClientControllerMock.h
+++ b/tests/unittests/media/client/mocks/main/ClientControllerMock.h
@@ -35,6 +35,7 @@ public:
     MOCK_METHOD(std::shared_ptr<ISharedMemoryHandle>, getSharedMemoryHandle, (), (override));
     MOCK_METHOD(bool, registerClient, (std::weak_ptr<IControlClient> client, ApplicationState &appState), (override));
     MOCK_METHOD(bool, unregisterClient, (std::weak_ptr<IControlClient> client), (override));
+    MOCK_METHOD(void, eventFlush, (), (override));
 };
 } // namespace firebolt::rialto::client
 


### PR DESCRIPTION
Summary: The pull request 306 highlighted an intermittent problem in component tests that allowed the teardown of one test to still be running while the next test starts. This was potentially happening in different threads but for certain it happened within ControlIpc's thread. Extra flush calls in this PR will wait for all threads to finish before teardown is allowed to complete. This wasn't a problem before 306 because the events concerned didn't hold a lock on the WebAudioPlayer/ MediaPipeline clients which allowed them to start destructing while they were still potentially being used (therefore destruction used to happen earlier). Now the destruction is correctly delayed until the final thread drops its shared_ptr (and the next test now also delayed until immediately after this happens).    
Type: Fix  
Test Plan: UT/ CT  
Jira: NO-JIRA