### PR TITLE
do not send flush event below paused

### DIFF
--- a/media/server/gstplayer/source/tasks/generic/Flush.cpp
+++ b/media/server/gstplayer/source/tasks/generic/Flush.cpp
@@ -86,17 +86,24 @@ void Flush::execute() const
     }
     m_gstPlayerClient->invalidateActiveRequests(m_type);
 
-    // Flush source
-    GstEvent *flushStart = m_gstWrapper->gstEventNewFlushStart();
-    if (!m_gstWrapper->gstElementSendEvent(source, flushStart))
+    if (GST_STATE(m_context.pipeline) >= GST_STATE_PAUSED)
     {
-        RIALTO_SERVER_LOG_WARN("failed to send flush-start event");
-    }
+        // Flush source
+        GstEvent *flushStart = m_gstWrapper->gstEventNewFlushStart();
+        if (!m_gstWrapper->gstElementSendEvent(source, flushStart))
+        {
+            RIALTO_SERVER_LOG_WARN("failed to send flush-start event");
+        }
 
-    GstEvent *flushStop = m_gstWrapper->gstEventNewFlushStop(m_resetTime);
-    if (!m_gstWrapper->gstElementSendEvent(source, flushStop))
+        GstEvent *flushStop = m_gstWrapper->gstEventNewFlushStop(m_resetTime);
+        if (!m_gstWrapper->gstElementSendEvent(source, flushStop))
+        {
+            RIALTO_SERVER_LOG_WARN("failed to send flush-stop event");
+        }
+    }
+    else
     {
-        RIALTO_SERVER_LOG_WARN("failed to send flush-stop event");
+        RIALTO_SERVER_LOG_DEBUG("Skip sending flush event - pipeline below paused");
     }
 
     // Reset Eos info

--- a/tests/componenttests/server/tests/mediaPipeline/FlushTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/FlushTest.cpp
@@ -252,6 +252,7 @@ TEST_F(FlushTest, flushAudioSourceSuccess)
     }
     willNotifyPaused();
     notifyPaused();
+    GST_STATE(&m_pipeline) = GST_STATE_PAUSED;
 
     // Step 8: Flush
     willFlush();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/FlushTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/FlushTest.cpp
@@ -53,6 +53,14 @@ TEST_F(FlushTest, ShouldFlushAudio)
 {
     shouldFlushAudio();
     shouldFlushAudioSrcSuccess();
+    setPipelinePlaying();
+    triggerFlush(firebolt::rialto::MediaSourceType::AUDIO);
+    checkAudioFlushed();
+}
+
+TEST_F(FlushTest, ShouldFlushAudioWithoutSendingEventBelowPaused)
+{
+    shouldFlushAudio();
     triggerFlush(firebolt::rialto::MediaSourceType::AUDIO);
     checkAudioFlushed();
 }
@@ -61,6 +69,7 @@ TEST_F(FlushTest, ShouldFlushAudioEvenIfEventSendingFails)
 {
     shouldFlushAudio();
     shouldFlushAudioSrcFailure();
+    setPipelinePlaying();
     triggerFlush(firebolt::rialto::MediaSourceType::AUDIO);
     checkAudioFlushed();
 }
@@ -69,6 +78,7 @@ TEST_F(FlushTest, ShouldFlushVideo)
 {
     shouldFlushVideo();
     shouldFlushVideoSrcSuccess();
+    setPipelinePlaying();
     triggerFlush(firebolt::rialto::MediaSourceType::VIDEO);
     checkVideoFlushed();
 }


### PR DESCRIPTION
Summary: Do not send flush events when pipeline is below paused state
Type: Fix
Test Plan: UT
Jira: RIALTO-583