### PR TITLE
Delete objects that could survive between component tests

### DIFF
--- a/scripts/gtest/build_and_run_tests.py
+++ b/scripts/gtest/build_and_run_tests.py
@@ -67,7 +67,8 @@ def getGenericArguments(argParser, suiteInfo):
 # Builds and runs googletests for the given suites
 def buildAndRunGTests(args, f, buildDefines, suitesToRun):
     # Set env variable
-    os.environ["RIALTO_SOCKET_PATH"] = "/tmp/rialto-0"
+    if not "RIALTO_SOCKET_PATH" in os.environ:
+        os.environ["RIALTO_SOCKET_PATH"] = "/tmp/rialto-0"
     # Set env variable to disable journald logging
     os.environ["RIALTO_CONSOLE_LOG"] = "1"
     # Set env variable to enable debug prints

--- a/tests/componenttests/client/tests/control/ApplicationStateChangeTest.cpp
+++ b/tests/componenttests/client/tests/control/ApplicationStateChangeTest.cpp
@@ -74,11 +74,20 @@ class ApplicationStateChangeTest : public ClientComponentTest
  *   Expect that the state change notification is propagated to the client.
  *   Expect that the shared memory region is fetched from the server.
  *
- *  Step 7: Change state to INACTIVE
+ *  Step 7: Destroy web audio player session
+ *   Destroy instance of WebAudioPlayer.
+ *   Expect that the session is destroyed on the server.
+ *
+ *  Step 8: Destroy web audio player session
+ *  Step yy: Destroy media session
+ *   Destroy instance of MediaPipeline.
+ *   Expect that the session is destroyed on the server.
+ *
+ *  Step 9: Change state to INACTIVE
  *   Server notifies the client that the state has changed to INACTIVE.
  *   Expect that the state change notification is propagated to the client.
  *
- *  Step 8: Disconnect the server
+ *  Step 10: Disconnect the server
  *   Server notifies the client that it has disconnected.
  *   Expect that the state is changed to UNKNOWN in the client.
  *
@@ -117,11 +126,19 @@ TEST_F(ApplicationStateChangeTest, lifecycle)
     ControlTestMethods::shouldNotifyApplicationStateRunning();
     ControlTestMethods::sendNotifyApplicationStateRunning();
 
-    // Step 7: Change state to INACTIVE
+    // Step 7: Destroy web audio player session
+    WebAudioPlayerTestMethods::shouldDestroyWebAudioPlayer();
+    WebAudioPlayerTestMethods::destroyWebAudioPlayer();
+
+    // Step 8: Destroy media session
+    MediaPipelineTestMethods::shouldDestroyMediaSession();
+    MediaPipelineTestMethods::destroyMediaPipeline();
+
+    // Step 9: Change state to INACTIVE
     ControlTestMethods::shouldNotifyApplicationStateInactive();
     ControlTestMethods::sendNotifyApplicationStateInactive();
 
-    // Step 8: Disconnect the server
+    // Step 10: Disconnect the server
     ControlTestMethods::shouldNotifyApplicationStateUnknown();
     ClientComponentTest::disconnectServer();
     ClientComponentTest::waitEvent();

--- a/tests/componenttests/client/tests/control/ApplicationStateChangeTest.cpp
+++ b/tests/componenttests/client/tests/control/ApplicationStateChangeTest.cpp
@@ -78,8 +78,7 @@ class ApplicationStateChangeTest : public ClientComponentTest
  *   Destroy instance of WebAudioPlayer.
  *   Expect that the session is destroyed on the server.
  *
- *  Step 8: Destroy web audio player session
- *  Step yy: Destroy media session
+ *  Step 8: Destroy media session
  *   Destroy instance of MediaPipeline.
  *   Expect that the session is destroyed on the server.
  *


### PR DESCRIPTION
Summary: The pull request 306 highlighted an intermittent problem in component tests that allowed the teardown of one test to still be running while the next test starts. This was potentially happening in different threads but for certain it happened within ControlIpc's thread. Making sure that WebAudioPlayer and MediaSession are destroyed earlier in the test prevents this from happening. Also, this change allows the user to set their own value for RIALTO_SOCKET_PATH for python test scripts (allows parallel running on one machine)
Type: Fix
Test Plan: UT/ CT
Jira: NO-JIRA