### PR TITLE
Fixes for rialto-597 tests

### DIFF
--- a/tests/common/matchers/MediaPipelineProtoRequestMatchers.h
+++ b/tests/common/matchers/MediaPipelineProtoRequestMatchers.h
@@ -23,9 +23,11 @@
 #include "MediaCommon.h"
 #include "mediapipelinecapabilitiesmodule.pb.h"
 #include "mediapipelinemodule.pb.h"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <memory>
+#include <string>
 #include <vector>
 
 MATCHER_P2(createSessionRequestMatcher, maxWidth, maxHeight, "")
@@ -307,7 +309,9 @@ MATCHER_P2(getSupportedPropertiesRequestMatcher, mediaType, propertyNames, "")
 {
     const ::firebolt::rialto::GetSupportedPropertiesRequest *kRequest =
         dynamic_cast<const ::firebolt::rialto::GetSupportedPropertiesRequest *>(arg);
-    return (kRequest->media_type() == mediaType && kRequest->property_names() == propertyNames);
+    std::vector<std::string> tmp{kRequest->property_names().begin(), kRequest->property_names().end()};
+    return (kRequest->media_type() == static_cast<firebolt::rialto::ProtoMediaSourceType>(mediaType) &&
+            tmp == propertyNames);
 }
 
 MATCHER_P3(flushRequestMatcher, sessionId, sourceId, resetTime, "")

--- a/tests/componenttests/client/mocks/MediaPipelineCapabilitiesModuleMock.h
+++ b/tests/componenttests/client/mocks/MediaPipelineCapabilitiesModuleMock.h
@@ -31,12 +31,20 @@ public:
     MOCK_METHOD(void, getSupportedMimeTypes,
                 (::google::protobuf::RpcController * controller,
                  const ::firebolt::rialto::GetSupportedMimeTypesRequest *request,
-                 ::firebolt::rialto::GetSupportedMimeTypesResponse *response, ::google::protobuf::Closure *done));
+                 ::firebolt::rialto::GetSupportedMimeTypesResponse *response, ::google::protobuf::Closure *done),
+                (override));
 
     MOCK_METHOD(void, isMimeTypeSupported,
                 (::google::protobuf::RpcController * controller,
                  const ::firebolt::rialto::IsMimeTypeSupportedRequest *request,
-                 ::firebolt::rialto::IsMimeTypeSupportedResponse *response, ::google::protobuf::Closure *done));
+                 ::firebolt::rialto::IsMimeTypeSupportedResponse *response, ::google::protobuf::Closure *done),
+                (override));
+
+    MOCK_METHOD(void, getSupportedProperties,
+                (::google::protobuf::RpcController * controller,
+                 const ::firebolt::rialto::GetSupportedPropertiesRequest *request,
+                 ::firebolt::rialto::GetSupportedPropertiesResponse *response, ::google::protobuf::Closure *done),
+                (override));
 
     void defaultReturn(::google::protobuf::RpcController *controller, ::google::protobuf::Closure *done)
     {
@@ -65,6 +73,18 @@ public:
     {
         firebolt::rialto::IsMimeTypeSupportedResponse response;
         response.set_is_supported(value);
+        return response;
+    }
+
+    ::firebolt::rialto::GetSupportedPropertiesResponse getSupportedPropertiesResponse(const std::vector<std::string> &values)
+    {
+        firebolt::rialto::GetSupportedPropertiesResponse response;
+
+        for (const std::string &property : values)
+        {
+            response.add_supported_properties(property);
+        }
+
         return response;
     }
 

--- a/tests/componenttests/client/tests/base/MediaPipelineTestMethods.cpp
+++ b/tests/componenttests/client/tests/base/MediaPipelineTestMethods.cpp
@@ -88,6 +88,7 @@ constexpr bool kResetTime{true};
 constexpr double kPosition{1234};
 constexpr int64_t kDiscontinuityGap{1};
 constexpr bool kIsAudioAac{false};
+const std::vector<std::string> kSupportedProperties{"immediate-output", "testProp2"};
 } // namespace
 
 namespace firebolt::rialto::client::ct
@@ -1951,5 +1952,44 @@ void MediaPipelineTestMethods::shouldCheckIsMimeTypeNotSupported()
 void MediaPipelineTestMethods::isMimeTypeNotSupported()
 {
     EXPECT_EQ(m_mediaPipelineCapabilities->isMimeTypeSupported(kVideoMimeType[0]), false);
+}
+
+void MediaPipelineTestMethods::shouldGetSupportedProperties()
+{
+    EXPECT_CALL(*m_mediaPipelineCapabilitiesModuleMock,
+                getSupportedProperties(_,
+                                       getSupportedPropertiesRequestMatcher(firebolt::rialto::MediaSourceType::VIDEO,
+                                                                            kSupportedProperties),
+                                       _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(
+                            m_mediaPipelineCapabilitiesModuleMock->getSupportedPropertiesResponse(kSupportedProperties)),
+                        WithArgs<0, 3>(Invoke(&(*m_mediaPipelineCapabilitiesModuleMock),
+                                              &MediaPipelineCapabilitiesModuleMock::defaultReturn))));
+}
+
+void MediaPipelineTestMethods::getSupportedProperties()
+{
+    MediaSourceType sourceType = firebolt::rialto::MediaSourceType::VIDEO;
+    EXPECT_EQ(m_mediaPipelineCapabilities->getSupportedProperties(sourceType, kSupportedProperties),
+              kSupportedProperties);
+}
+
+void MediaPipelineTestMethods::shouldGetSupportedPropertiesFailure()
+{
+    EXPECT_CALL(*m_mediaPipelineCapabilitiesModuleMock,
+                getSupportedProperties(_,
+                                       getSupportedPropertiesRequestMatcher(firebolt::rialto::MediaSourceType::VIDEO,
+                                                                            kSupportedProperties),
+                                       _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(
+                            m_mediaPipelineCapabilitiesModuleMock->getSupportedPropertiesResponse(kSupportedProperties)),
+                        WithArgs<0, 3>(Invoke(&(*m_mediaPipelineCapabilitiesModuleMock),
+                                              &MediaPipelineCapabilitiesModuleMock::failureReturn))));
+}
+
+void MediaPipelineTestMethods::getSupportedPropertiesFailure()
+{
+    MediaSourceType sourceType = firebolt::rialto::MediaSourceType::VIDEO;
+    EXPECT_TRUE(m_mediaPipelineCapabilities->getSupportedProperties(sourceType, kSupportedProperties).empty());
 }
 } // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/base/MediaPipelineTestMethods.h
+++ b/tests/componenttests/client/tests/base/MediaPipelineTestMethods.h
@@ -169,6 +169,8 @@ protected:
     void shouldGetSupportedUnknownMimeTypes();
     void shouldCheckIsMimeTypeSupported();
     void shouldCheckIsMimeTypeNotSupported();
+    void shouldGetSupportedProperties();
+    void shouldGetSupportedPropertiesFailure();
 
     // Api methods
     void createMediaPipeline();
@@ -232,6 +234,8 @@ protected:
     void getSupportedVideoMimeTypes();
     void getUnknownMimeTypes();
     void isMimeTypeSupported();
+    void getSupportedProperties();
+    void getSupportedPropertiesFailure();
     void isMimeTypeNotSupported();
     void flush();
     void flushFailure();

--- a/tests/componenttests/client/tests/mse/MediaPipelineCapabilitiesTest.cpp
+++ b/tests/componenttests/client/tests/mse/MediaPipelineCapabilitiesTest.cpp
@@ -36,8 +36,10 @@ public:
  *
  * Sequence Diagrams:
  *  Capabilities - Supported MIME types
- *               -
- * https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-SupportedMIMETypes
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-SupportedMIMETypes
+ *  Capabilities - Get supported properties
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-Getsupportedproperties
+ *
  * Test Setup:
  *  Language: C++
  *  Testing Framework: Google Test
@@ -79,7 +81,17 @@ public:
  *   Expect that isMimeTypeSupported is propagated to server.
  *   Api call returns with failure.
  *
- *  Step 7: Destroy MediaPipelineCapabilities
+ * Step 7: Get supported properties
+ *   getSupportedProperties.
+ *   Expect that getSupportedProperties is propagated to server.
+ *   Api call returns with success
+ *
+ * Step 8: Get supported properties failure
+ *   getSupportedProperties.
+ *   Expect that getSupportedProperties is propagated to server.
+ *   Api call returns with failure and the returned list should be empty
+ *
+ * Step 9: Destroy MediaPipelineCapabilities
  *
  * Test Teardown:
  *  Server is terminated.
@@ -90,7 +102,7 @@ public:
  * Code:
  */
 
-TEST_F(MediaPipelineCapabilitiesTest, checkSupportedMimeTypes)
+TEST_F(MediaPipelineCapabilitiesTest, checkSupportedMimeTypesAndProperties)
 {
     // Step 1: Create a MediaPipelineCabilities object.
     MediaPipelineTestMethods::createMediaPipelineCapabilitiesObject();
@@ -115,7 +127,15 @@ TEST_F(MediaPipelineCapabilitiesTest, checkSupportedMimeTypes)
     MediaPipelineTestMethods::shouldCheckIsMimeTypeNotSupported();
     MediaPipelineTestMethods::isMimeTypeNotSupported();
 
-    // Step 7: Destroy MediaPipelineCapabilities
+    // Step 7: Get supported properties
+    MediaPipelineTestMethods::shouldGetSupportedProperties();
+    MediaPipelineTestMethods::getSupportedProperties();
+
+    // Step 8: Get supported properties - failure
+    MediaPipelineTestMethods::shouldGetSupportedPropertiesFailure();
+    MediaPipelineTestMethods::getSupportedPropertiesFailure();
+
+    // Step 9: Destroy MediaPipelineCapabilities
     MediaPipelineTestMethods::destroyMediaPipelineCapabilitiesObject();
 }
 } // namespace firebolt::rialto::client::ct

--- a/tests/componenttests/client/tests/mse/PipelinePropertyTest.cpp
+++ b/tests/componenttests/client/tests/mse/PipelinePropertyTest.cpp
@@ -45,6 +45,8 @@ public:
  *   on the RialtoServer.
  *
  * Sequence Diagrams:
+ *  Immediate-output property
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-ImmediateOutput
  *
  * Test Setup:
  *  Language: C++

--- a/tests/componenttests/client/tests/mse/QosNotificationTest.cpp
+++ b/tests/componenttests/client/tests/mse/QosNotificationTest.cpp
@@ -51,7 +51,10 @@ public:
  *  Also test the get-stats functionality (which returns the number of rendered and dropped frames)
  *
  * Sequence Diagrams:
- *  Quality of Service - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams
+ *  Quality of Service
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-QualityofService
+ *  Stats
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-Stats
  *
  * Test Setup:
  *  Language: C++

--- a/tests/componenttests/server/tests/mediaPipeline/PipelinePropertyTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/PipelinePropertyTest.cpp
@@ -139,6 +139,8 @@ private:
  *  Test the ability of the Rialto Server to set and get properties of the pipeline
  *
  * Sequence Diagrams:
+ *  Immediate-output property
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-ImmediateOutput
  *
  * Test Setup:
  *  Language: C++
@@ -246,12 +248,14 @@ TEST_F(PipelinePropertyTest, pipelinePropertyGetAndSetSuccess)
 }
 
 /*
- * Component Test: Test falures to Get and set properties of the pipeline
+ * Component Test: Test failures to Get and set properties of the pipeline
  * Test Objective:
  *  Test the ability of the Rialto Server to handle failres while
  *  setting and getting properties of the pipeline
  *
  * Sequence Diagrams:
+ *  Immediate-output property
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-ImmediateOutput
  *
  * Test Setup:
  *  Language: C++

--- a/tests/componenttests/server/tests/mediaPipeline/QosUpdatesTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/QosUpdatesTest.cpp
@@ -165,7 +165,9 @@ private:
  * Sequence Diagrams:
  *  Create, Destroy - https://wiki.rdkcentral.com/pages/viewpage.action?pageId=226375556
  *  Quality of Service
- *   - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams
+ *  Stats
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-Stats
  *
  * Test Setup:
  *  Language: C++
@@ -359,14 +361,14 @@ TEST_F(QosUpdatesTest, QosUpdates)
 }
 
 /*
- * Component Test: Qos Updates Test
+ * Component Test: Test Failures
  * Test Objective:
- *  Test the notifyQos API. After receiving GST_MESSAGE_QOS, RialtoServer should send notifyQos to RialtoClient
+ *  Test a failure to get stats from Rialto Server
  *
  * Sequence Diagrams:
  *  Create, Destroy - https://wiki.rdkcentral.com/pages/viewpage.action?pageId=226375556
- *  Quality of Service
- *   - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams
+ *  Stats
+ *  - https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-Stats
  *
  * Test Setup:
  *  Language: C++
@@ -468,7 +470,7 @@ TEST_F(QosUpdatesTest, QosUpdates)
  *
  * Code:
  */
-TEST_F(QosUpdatesTest, QosUpdatesFailures)
+TEST_F(QosUpdatesTest, StatsFailure)
 {
     // Step 1: Create a new media session
     createSession();

--- a/tests/componenttests/server/tests/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
@@ -316,9 +316,38 @@ TEST_F(MediaPipelineCapabilitiesTest, checkVideoMimeTypes)
         .matchResponse([](const auto &resp) { EXPECT_FALSE(resp.is_supported()); });
 }
 
+/*
+ * Component Test: Check that the API call GetSupportedProperties works
+ * Test Objective:
+ *  Test that the RialtoServer can process a request to get supported pipeline properites
+ *
+ * Sequence Diagrams:
+ *  Capabilities - Get Supported Properties
+ *  https://wiki.rdkcentral.com/display/ASP/Rialto+MSE+Misc+Sequence+Diagrams#RialtoMSEMiscSequenceDiagrams-Getsupportedproperties
+ *
+ * Test Setup:
+ *  Language: C++
+ *  Testing Framework: Google Test
+ *  Components: MediaPipelineCapabilities
+ *
+ * Test Initialize:
+ *  Set Rialto Server to Active
+ *  Connect Rialto Client Stub
+ *
+ * Test Steps:
+ *  Step 1: Get supported properties
+ *
+ * Test Teardown:
+ *  Server is terminated.
+ *
+ * Expected Results:
+ *  Rialto server checks, if mime types are supported.
+ *
+ * Code:
+ */
 TEST_F(MediaPipelineCapabilitiesTest, checkGetSupportedProperties)
 {
-    // Step 1:
+    // Step 1: Get supported properties
     willCallGetSupportedProperties();
     callGetSupportedProperties();
 }


### PR DESCRIPTION
Summary: Added documentation links for the component tests of immediate-output, getSupportedProperties and getStats. Added client component test for getSupportedProperties
Type: Fix
Test Plan: UT, CT  
Jira: NO-JIRA
