### PR TITLE
Fix for glib warning... cannot retrieve class

### DIFF
--- a/media/server/gstplayer/source/GstCapabilities.cpp
+++ b/media/server/gstplayer/source/GstCapabilities.cpp
@@ -208,6 +208,8 @@ std::vector<std::string> GstCapabilities::getSupportedProperties(MediaSourceType
     {
         GstElementFactory *factory = GST_ELEMENT_FACTORY(iter->data);
         GType elementType = m_gstWrapper->gstElementFactoryGetElementType(factory);
+        if (elementType == G_TYPE_INVALID)
+            continue;
         gpointer elementClass = m_glibWrapper->gTypeClassRef(elementType);
         if (elementClass)
         {


### PR DESCRIPTION
Summary: Fix for GstCapabilities::getSupportedProperties glib warning, "cannot retrieve class for invalid (unclassed) type <invalid>"
Type: Fix
Test Plan: UT, CT
Jira: NO-JIRA

