### PR TITLE
Fix getSupportedProperties method so that it can reliably determine if immediate-output, etc, is supported

### DIFF
--- a/media/server/gstplayer/source/GstCapabilities.cpp
+++ b/media/server/gstplayer/source/GstCapabilities.cpp
@@ -207,28 +207,102 @@ std::vector<std::string> GstCapabilities::getSupportedProperties(MediaSourceType
     for (GList *iter = factories; iter != nullptr && !propertiesToLookFor.empty(); iter = iter->next)
     {
         GstElementFactory *factory = GST_ELEMENT_FACTORY(iter->data);
-        GType elementType = m_gstWrapper->gstElementFactoryGetElementType(factory);
-        if (elementType == G_TYPE_INVALID)
-            continue;
-        gpointer elementClass = m_glibWrapper->gTypeClassRef(elementType);
-        if (elementClass)
+        gpointer elementClass{nullptr};
+        GstPluginFeature *loadFeature{nullptr};
+        GstElement *elementObj{nullptr};
+
+        RIALTO_SERVER_LOG_DEBUG("Searching the properties of a class");
         {
-            for (auto i = propertiesToLookFor.begin(); i != propertiesToLookFor.end();)
+            // Try to obtain the class without instantiating an object...
+            GType elementType = m_gstWrapper->gstElementFactoryGetElementType(factory);
+            if (elementType == G_TYPE_INVALID)
             {
-                if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_CLASS(elementClass), i->c_str()))
-                {
-                    propertiesFound.push_back(*i);
-                    i = propertiesToLookFor.erase(i);
-                }
-                else
-                    ++i;
+                RIALTO_SERVER_LOG_DEBUG("  Using gstPluginFeatureLoad");
+                loadFeature = m_gstWrapper->gstPluginFeatureLoad(GST_PLUGIN_FEATURE(factory));
+                if (loadFeature)
+                    elementType = m_gstWrapper->gstElementFactoryGetElementType(factory);
             }
 
-            m_glibWrapper->gObjectUnref(elementClass);
+            if (elementType != G_TYPE_INVALID)
+                elementClass = m_glibWrapper->gTypeClassRef(elementType);
         }
+
+        if (!elementClass)
+        {
+            // Create an object because we couldn't get the class
+            RIALTO_SERVER_LOG_DEBUG("  Using gstElementFactoryCreate");
+            elementObj = m_gstWrapper->gstElementFactoryCreate(factory, nullptr);
+        }
+
+        if (elementClass || elementObj)
+        {
+            GParamSpec **props;
+            guint nProps;
+            if (elementObj)
+                props = m_glibWrapper->gObjectClassListProperties(G_OBJECT_GET_CLASS(elementObj), &nProps);
+            else
+                props = m_glibWrapper->gObjectClassListProperties(G_OBJECT_GET_CLASS(elementClass), &nProps);
+
+            if (!props && elementClass && !loadFeature)
+            {
+                RIALTO_SERVER_LOG_DEBUG("  No properties seen, trying gst_plugin_feature_load");
+                m_glibWrapper->gObjectUnref(elementClass);
+                elementClass = nullptr;
+                loadFeature = m_gstWrapper->gstPluginFeatureLoad(GST_PLUGIN_FEATURE(factory));
+                if (loadFeature)
+                {
+                    GType elementType = m_gstWrapper->gstElementFactoryGetElementType(factory);
+
+                    if (elementType != G_TYPE_INVALID)
+                        elementClass = m_glibWrapper->gTypeClassRef(elementType);
+                    if (elementClass)
+                    {
+                        props = m_glibWrapper->gObjectClassListProperties(G_OBJECT_GET_CLASS(elementClass), &nProps);
+                        if (props)
+                        {
+                            RIALTO_SERVER_LOG_DEBUG("  gst_plugin_feature_load worked");
+                        }
+                    }
+                }
+            }
+
+            if (!props && !elementObj)
+            {
+                // Fall back to create an object
+                RIALTO_SERVER_LOG_DEBUG("  No properties seen, creating an object");
+                elementObj = m_gstWrapper->gstElementFactoryCreate(factory, nullptr);
+                if (elementObj)
+                    props = m_glibWrapper->gObjectClassListProperties(G_OBJECT_GET_CLASS(elementObj), &nProps);
+            }
+
+            if (props)
+            {
+                for (guint j = 0; j < nProps && !propertiesToLookFor.empty(); ++j)
+                {
+                    const std::string kPropName{props[j]->name};
+                    for (auto i = propertiesToLookFor.begin(); i != propertiesToLookFor.end();)
+                    {
+                        if (*i == kPropName)
+                        {
+                            RIALTO_SERVER_LOG_DEBUG("  Found property '%s'", kPropName.c_str());
+                            propertiesFound.push_back(*i);
+                            i = propertiesToLookFor.erase(i);
+                        }
+                        else
+                            ++i;
+                    }
+                }
+                m_glibWrapper->gFree(props);
+            }
+        }
+        if (elementObj)
+            m_gstWrapper->gstObjectUnref(elementObj);
+        if (loadFeature)
+            m_gstWrapper->gstObjectUnref(loadFeature);
+        if (elementClass)
+            m_glibWrapper->gObjectUnref(elementClass);
     }
 
-    // Cleanup
     m_gstWrapper->gstPluginFeatureListFree(factories);
     return propertiesFound;
 }

--- a/tests/common/externalLibraryMocks/GlibWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GlibWrapperMock.h
@@ -96,6 +96,7 @@ public:
     MOCK_METHOD(gchar *, gStrdupPrintfStub, (const gchar *format));
 
     MOCK_METHOD(GParamSpec *, gObjectClassFindProperty, (GObjectClass *, const gchar *), (override));
+    MOCK_METHOD(GParamSpec **, gObjectClassListProperties, (GObjectClass * oclass, guint *nProps), (override));
     MOCK_METHOD(gboolean, gStrHasPrefix, (const gchar *, const gchar *), (override));
     MOCK_METHOD(guint *, gSignalListIds, (GType itype, guint *n_ids), (const, override));
     MOCK_METHOD(void, gSignalQuery, (guint signal_id, GSignalQuery *query), (const, override));

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -148,6 +148,7 @@ public:
     MOCK_METHOD(GList *, gstElementFactoryListGetElements, (GstElementFactoryListType type, GstRank minrank), (const));
     MOCK_METHOD(const GList *, gstElementFactoryGetStaticPadTemplates, (GstElementFactory * factory), (const));
     MOCK_METHOD(void, gstPluginFeatureListFree, (GList * list), (const));
+    MOCK_METHOD(GstPluginFeature *, gstPluginFeatureLoad, (GstPluginFeature * feature), (const));
     MOCK_METHOD(GstCaps *, gstCapsNewEmptySimple, (const char *media_type), (const));
     MOCK_METHOD(GstCaps *, gstCapsNewEmpty, (), (const));
     MOCK_METHOD(GstProtectionMeta *, gstBufferAddProtectionMeta, (GstBuffer * buffer, GstStructure *info), (const));

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -41,7 +41,6 @@ public:
     MOCK_METHOD(gboolean, gstElementRegister, (GstPlugin * plugin, const gchar *name, guint rank, GType type),
                 (override));
     MOCK_METHOD(GstElement *, gstElementFactoryMake, (const gchar *factoryname, const gchar *name), (override));
-    MOCK_METHOD(GType, gstElementFactoryGetElementType, (GstElementFactory * factory), (override));
     MOCK_METHOD(gpointer, gstObjectRef, (gpointer object), (override));
     MOCK_METHOD(GstElement *, gstBinGetByName, (GstBin * bin, const gchar *name), (override));
     MOCK_METHOD(GstBus *, gstPipelineGetBus, (GstPipeline * pipeline), (override));
@@ -148,7 +147,6 @@ public:
     MOCK_METHOD(GList *, gstElementFactoryListGetElements, (GstElementFactoryListType type, GstRank minrank), (const));
     MOCK_METHOD(const GList *, gstElementFactoryGetStaticPadTemplates, (GstElementFactory * factory), (const));
     MOCK_METHOD(void, gstPluginFeatureListFree, (GList * list), (const));
-    MOCK_METHOD(GstPluginFeature *, gstPluginFeatureLoad, (GstPluginFeature * feature), (const));
     MOCK_METHOD(GstCaps *, gstCapsNewEmptySimple, (const char *media_type), (const));
     MOCK_METHOD(GstCaps *, gstCapsNewEmpty, (), (const));
     MOCK_METHOD(GstProtectionMeta *, gstBufferAddProtectionMeta, (GstBuffer * buffer, GstStructure *info), (const));

--- a/tests/componenttests/server/tests/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
@@ -37,6 +37,7 @@ const char *kPropertyName2 = "test2";
 const char *kPropertyName3 = "prop";
 const GstElementFactoryListType kExpectedFactoryListType{
     GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
+const GstElementFactory *kDummyElementFactory{nullptr};
 }; // namespace
 namespace firebolt::rialto::server::ct
 {
@@ -60,11 +61,13 @@ public:
 
     void willCallGetSupportedProperties()
     {
-        m_listOfFactories = g_list_append(m_listOfFactories, m_dummyElementFactory);
+        m_listOfFactories = g_list_append(m_listOfFactories, const_cast<GstElementFactory *>(kDummyElementFactory));
         EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
             .WillOnce(Return(m_listOfFactories));
         // The next calls should ensure that an object is created and then freed
-        EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(m_dummyElementFactory, nullptr)).WillOnce(Return(&m_object));
+        EXPECT_CALL(*m_gstWrapperMock,
+                    gstElementFactoryCreate(const_cast<GstElementFactory *>(kDummyElementFactory), nullptr))
+            .WillOnce(Return(&m_object));
         EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_object));
 
         EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
@@ -94,9 +97,6 @@ private:
     GParamSpec *m_dummyParamsPtr[kNumPropertiesOnSink];
     std::vector<std::string> m_kParamNames{kPropertyName1, kPropertyName2};
     GstElement m_object;
-    char m_suppliesAddressOfDummyElementFactory{0};
-    GstElementFactory *m_dummyElementFactory{
-        reinterpret_cast<GstElementFactory *>(&m_suppliesAddressOfDummyElementFactory)};
 };
 
 /*

--- a/tests/componenttests/server/tests/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipelineCapabilities/MediaPipelineCapabilitiesTest.cpp
@@ -37,7 +37,6 @@ const char *kPropertyName2 = "test2";
 const char *kPropertyName3 = "prop";
 const GstElementFactoryListType kExpectedFactoryListType{
     GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
-const GstElementFactory *kDummyElementFactory{nullptr};
 }; // namespace
 namespace firebolt::rialto::server::ct
 {
@@ -56,18 +55,17 @@ public:
         for (int i = 0; i < kNumPropertiesOnSink; ++i)
             m_dummyParamsPtr[i] = &m_dummyParams[i];
         memset(&m_object, 0x00, sizeof(m_object));
+        m_elementFactory = gst_element_factory_find("fakesrc");
     }
-    ~MediaPipelineCapabilitiesTest() override = default;
+    ~MediaPipelineCapabilitiesTest() { gst_object_unref(m_elementFactory); }
 
     void willCallGetSupportedProperties()
     {
-        m_listOfFactories = g_list_append(m_listOfFactories, const_cast<GstElementFactory *>(kDummyElementFactory));
+        m_listOfFactories = g_list_append(m_listOfFactories, m_elementFactory);
         EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
             .WillOnce(Return(m_listOfFactories));
         // The next calls should ensure that an object is created and then freed
-        EXPECT_CALL(*m_gstWrapperMock,
-                    gstElementFactoryCreate(const_cast<GstElementFactory *>(kDummyElementFactory), nullptr))
-            .WillOnce(Return(&m_object));
+        EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(m_elementFactory, nullptr)).WillOnce(Return(&m_object));
         EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_object));
 
         EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
@@ -97,6 +95,7 @@ private:
     GParamSpec *m_dummyParamsPtr[kNumPropertiesOnSink];
     std::vector<std::string> m_kParamNames{kPropertyName1, kPropertyName2};
     GstElement m_object;
+    GstElementFactory *m_elementFactory;
 };
 
 /*

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
@@ -43,8 +43,8 @@ namespace
 {
 const GstElementFactoryListType kExpectedFactoryListType{
     GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
-
-};
+const GstElementFactory *kDummyElementFactory{nullptr};
+}; // namespace
 template <typename T> class GListWrapper
 {
 public:
@@ -151,13 +151,15 @@ public:
     {
         createSutWithNoDecoderAndNoSink();
 
-        m_listOfFactories = g_list_append(m_listOfFactories, m_dummyElementFactory);
+        m_listOfFactories = g_list_append(m_listOfFactories, const_cast<GstElementFactory *>(kDummyElementFactory));
         EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
             .WillOnce(Return(m_listOfFactories));
         EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(m_listOfFactories)).Times(1);
 
         // The next calls should ensure that an object is created and then freed
-        EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(m_dummyElementFactory, nullptr)).WillOnce(Return(&m_object));
+        EXPECT_CALL(*m_gstWrapperMock,
+                    gstElementFactoryCreate(const_cast<GstElementFactory *>(kDummyElementFactory), nullptr))
+            .WillOnce(Return(&m_object));
         EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_object));
     }
 
@@ -208,9 +210,6 @@ public:
     // variables used to test getSupportedProperties
     GstElement m_object;
     GList *m_listOfFactories{nullptr};
-    char m_suppliesAddressOfDummyElementFactory{0};
-    GstElementFactory *m_dummyElementFactory{
-        reinterpret_cast<GstElementFactory *>(&m_suppliesAddressOfDummyElementFactory)};
 };
 
 /**

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
@@ -335,6 +335,8 @@ TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported)
     std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
     // this time we should find all the properties...
     EXPECT_EQ(supportedProperties, kParamNames);
+
+    gst_plugin_feature_list_free(listOfFactories);
 }
 
 TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_usePluginFeatureLoad)
@@ -380,6 +382,8 @@ TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_usePlu
     std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
     // this time we should find all the properties...
     EXPECT_EQ(supportedProperties, kParamNames);
+
+    gst_plugin_feature_list_free(listOfFactories);
 }
 
 TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_useObjectCreation)
@@ -423,6 +427,8 @@ TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_useObj
     std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
     // this time we should find all the properties...
     EXPECT_EQ(supportedProperties, kParamNames);
+
+    gst_plugin_feature_list_free(listOfFactories);
 }
 
 TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_usePluginFeatureLoadAfterNoProperties)
@@ -467,6 +473,8 @@ TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_usePlu
     std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
     // this time we should find all the properties...
     EXPECT_EQ(supportedProperties, kParamNames);
+
+    gst_plugin_feature_list_free(listOfFactories);
 }
 
 TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_useObjectCreationAfterNoProperties)
@@ -518,6 +526,8 @@ TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_useObj
     std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
     // this time we should find all the properties...
     EXPECT_EQ(supportedProperties, kParamNames);
+
+    gst_plugin_feature_list_free(listOfFactories);
 }
 
 TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithNoPropertiesSupported)

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
@@ -32,7 +32,9 @@ using namespace firebolt::rialto::server;
 using namespace firebolt::rialto::wrappers;
 
 using ::testing::_;
+using ::testing::DoAll;
 using ::testing::Return;
+using ::testing::SetArgPointee;
 using ::testing::StrEq;
 using ::testing::StrictMock;
 using ::testing::UnorderedElementsAre;
@@ -127,6 +129,17 @@ public:
         return decoderPadTemplate;
     }
 
+    void createSutWithNoDecoderAndNoSink()
+    {
+        EXPECT_CALL(*m_gstWrapperMock,
+                    gstElementFactoryListGetElements(GST_ELEMENT_FACTORY_TYPE_DECODER, GST_RANK_MARGINAL))
+            .WillOnce(Return(nullptr));
+        EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(GST_ELEMENT_FACTORY_TYPE_SINK, GST_RANK_MARGINAL))
+            .WillOnce(Return(nullptr));
+
+        m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock, m_glibWrapperMock);
+    }
+
     std::shared_ptr<StrictMock<GstWrapperMock>> m_gstWrapperMock{std::make_shared<StrictMock<GstWrapperMock>>()};
     std::shared_ptr<StrictMock<GstWrapperFactoryMock>> m_gstWrapperFactoryMock{
         std::make_shared<StrictMock<GstWrapperFactoryMock>>()};
@@ -193,13 +206,7 @@ TEST_F(GstCapabilitiesTest, FactoryCreatesObject)
 
 TEST_F(GstCapabilitiesTest, CreateGstCapabilities_NoDecoderAndNoSink)
 {
-    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(GST_ELEMENT_FACTORY_TYPE_DECODER, GST_RANK_MARGINAL))
-        .WillOnce(Return(nullptr));
-    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(GST_ELEMENT_FACTORY_TYPE_SINK, GST_RANK_MARGINAL))
-        .WillOnce(Return(nullptr));
-
-    m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock, m_glibWrapperMock);
-
+    createSutWithNoDecoderAndNoSink();
     EXPECT_TRUE(m_sut->getSupportedMimeTypes(MediaSourceType::AUDIO).empty());
 
     EXPECT_FALSE(m_sut->isMimeTypeSupported("audio/x-raw"));
@@ -290,41 +297,264 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OnlyOneDecoderWithTwoSinkPadsA
     EXPECT_TRUE(m_sut->isMimeTypeSupported("audio/mp4"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("audio/beep-boop3"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("video/h264"));
+}
 
-    // The following EXPECTs are for the call to getSupportedProperties()
+TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported)
+{
+    createSutWithNoDecoderAndNoSink();
+
     const GstElementFactoryListType kExpectedFactoryListType{
         GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
     GList *listOfFactories{nullptr};
     GstElementFactory *dummyFactory{nullptr};
     const GType kDummyType{3};
     GObjectClass dummyClass;
-    GParamSpec dummyParam;
-    std::vector<std::string> kParamNames{"test-name-123", "test2"};
     memset(&dummyClass, 0x00, sizeof(dummyClass));
+
     listOfFactories = g_list_append(listOfFactories, dummyFactory);
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
         .WillOnce(Return(listOfFactories));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryGetElementType(dummyFactory)).WillOnce(Return(kDummyType));
     EXPECT_CALL(*m_glibWrapperMock, gTypeClassRef(kDummyType)).WillOnce(Return(&dummyClass));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(&dummyClass, _))
-        .Times(kParamNames.size())
-        .WillRepeatedly(Return(&dummyParam));
     EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&dummyClass));
-    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(listOfFactories)).Times(1);
-    std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
-    EXPECT_EQ(supportedProperties, kParamNames);
 
-    // call getSupportedProperties() once again, this time gstreamer will not find the properties...
+    // Params suppoted by the sink...
+    const int kNumParamsSupportedByServer{2};
+    GParamSpec dummySinkParams[kNumParamsSupportedByServer];
+    dummySinkParams[0].name = "test-name-123";
+    dummySinkParams[1].name = "test2";
+    GParamSpec *dummySinkParamsPtr[] = {&dummySinkParams[0], &dummySinkParams[1]};
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(kNumParamsSupportedByServer), Return(dummySinkParamsPtr)));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(dummySinkParamsPtr)).Times(1);
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(listOfFactories)).Times(1);
+
+    // Params that the caller is asking about...
+    std::vector<std::string> kParamNames{"test-name-123", "test2"};
+    std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
+    // this time we should find all the properties...
+    EXPECT_EQ(supportedProperties, kParamNames);
+}
+
+TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_usePluginFeatureLoad)
+{
+    createSutWithNoDecoderAndNoSink();
+
+    const GstElementFactoryListType kExpectedFactoryListType{
+        GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
+    GList *listOfFactories{nullptr};
+    GstElementFactory *dummyFactory{nullptr};
+    const GType kDummyType{3};
+    GObjectClass dummyClass;
+    memset(&dummyClass, 0x00, sizeof(dummyClass));
+
+    listOfFactories = g_list_append(listOfFactories, dummyFactory);
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
+        .WillOnce(Return(listOfFactories));
+
+    // The next calls will ensure that gstPluginFeatureLoad is used
+    char tmpFeatureAddress{1};
+    GstPluginFeature *feature{reinterpret_cast<GstPluginFeature *>(tmpFeatureAddress)};
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureLoad(_)).WillOnce(Return(feature));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(feature));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryGetElementType(dummyFactory))
+        .WillOnce(Return(G_TYPE_INVALID))
+        .WillOnce(Return(kDummyType));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeClassRef(kDummyType)).WillOnce(Return(&dummyClass));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&dummyClass));
+
+    // Params suppoted by the sink...
+    const int kNumParamsSupportedByServer{1};
+    GParamSpec dummySinkParams[kNumParamsSupportedByServer];
+    dummySinkParams[0].name = "test-name-123";
+    GParamSpec *dummySinkParamsPtr[] = {&dummySinkParams[0], &dummySinkParams[1]};
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(kNumParamsSupportedByServer), Return(dummySinkParamsPtr)));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(dummySinkParamsPtr)).Times(1);
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(listOfFactories)).Times(1);
+
+    // Params that the caller is asking about...
+    std::vector<std::string> kParamNames{"test-name-123"};
+    std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
+    // this time we should find all the properties...
+    EXPECT_EQ(supportedProperties, kParamNames);
+}
+
+TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_useObjectCreation)
+{
+    createSutWithNoDecoderAndNoSink();
+
+    const GstElementFactoryListType kExpectedFactoryListType{
+        GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
+    GList *listOfFactories{nullptr};
+    GstElementFactory *dummyFactory{nullptr};
+    GObjectClass dummyClass;
+    memset(&dummyClass, 0x00, sizeof(dummyClass));
+
+    listOfFactories = g_list_append(listOfFactories, dummyFactory);
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
+        .WillOnce(Return(listOfFactories));
+
+    // The next calls should ensure that gstPluginFeatureLoad fails
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureLoad(_)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryGetElementType(dummyFactory)).WillOnce(Return(G_TYPE_INVALID));
+
+    // The next calls should ensure that an object is created
+    GstElement object;
+    memset(&object, 0x00, sizeof(object));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(dummyFactory, nullptr)).WillOnce(Return(&object));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&object));
+
+    // Params suppoted by the sink...
+    const int kNumParamsSupportedByServer{1};
+    GParamSpec dummySinkParams[kNumParamsSupportedByServer];
+    dummySinkParams[0].name = "test-name-123";
+    GParamSpec *dummySinkParamsPtr[] = {&dummySinkParams[0], &dummySinkParams[1]};
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(kNumParamsSupportedByServer), Return(dummySinkParamsPtr)));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(dummySinkParamsPtr)).Times(1);
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(listOfFactories)).Times(1);
+
+    // Params that the caller is asking about...
+    std::vector<std::string> kParamNames{"test-name-123"};
+    std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
+    // this time we should find all the properties...
+    EXPECT_EQ(supportedProperties, kParamNames);
+}
+
+TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_usePluginFeatureLoadAfterNoProperties)
+{
+    createSutWithNoDecoderAndNoSink();
+
+    const GstElementFactoryListType kExpectedFactoryListType{
+        GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
+    GList *listOfFactories{nullptr};
+    GstElementFactory *dummyFactory{nullptr};
+    const GType kDummyType{3};
+    GObjectClass dummyClass;
+    memset(&dummyClass, 0x00, sizeof(dummyClass));
+
+    listOfFactories = g_list_append(listOfFactories, dummyFactory);
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
+        .WillOnce(Return(listOfFactories));
+
+    // The next calls will ensure that gstPluginFeatureLoad is used AFTER a class was seen with no properties
+    char tmpFeatureAddress{1};
+    GstPluginFeature *feature{reinterpret_cast<GstPluginFeature *>(tmpFeatureAddress)};
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureLoad(_)).WillOnce(Return(feature));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(feature));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryGetElementType(dummyFactory)).WillRepeatedly(Return(kDummyType));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeClassRef(kDummyType)).WillRepeatedly(Return(&dummyClass));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&dummyClass)).Times(2);
+
+    // Params suppoted by the sink...
+    const int kNumParamsSupportedByServer{1};
+    GParamSpec dummySinkParams[kNumParamsSupportedByServer];
+    dummySinkParams[0].name = "test-name-123";
+    GParamSpec *dummySinkParamsPtr[] = {&dummySinkParams[0], &dummySinkParams[1]};
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(0), Return(nullptr)))
+        .WillOnce(DoAll(SetArgPointee<1>(kNumParamsSupportedByServer), Return(dummySinkParamsPtr)));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(dummySinkParamsPtr)).Times(1);
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(listOfFactories)).Times(1);
+
+    // Params that the caller is asking about...
+    std::vector<std::string> kParamNames{"test-name-123"};
+    std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
+    // this time we should find all the properties...
+    EXPECT_EQ(supportedProperties, kParamNames);
+}
+
+TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithPropertiesSupported_useObjectCreationAfterNoProperties)
+{
+    createSutWithNoDecoderAndNoSink();
+
+    const GstElementFactoryListType kExpectedFactoryListType{
+        GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
+    GList *listOfFactories{nullptr};
+    GstElementFactory *dummyFactory{nullptr};
+    const GType kDummyType{3};
+    GObjectClass dummyClass;
+    memset(&dummyClass, 0x00, sizeof(dummyClass));
+
+    listOfFactories = g_list_append(listOfFactories, dummyFactory);
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
+        .WillOnce(Return(listOfFactories));
+
+    // The next calls will ensure that gstPluginFeatureLoad is used AFTER a class was seen with no properties
+    char tmpFeatureAddress{1};
+    GstPluginFeature *feature{reinterpret_cast<GstPluginFeature *>(tmpFeatureAddress)};
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureLoad(_)).WillOnce(Return(feature));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(feature));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryGetElementType(dummyFactory)).WillRepeatedly(Return(kDummyType));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeClassRef(kDummyType)).WillRepeatedly(Return(&dummyClass));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&dummyClass)).Times(2);
+
+    // The next calls should ensure that an object is created
+    GstElement object;
+    memset(&object, 0x00, sizeof(object));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryCreate(dummyFactory, nullptr)).WillOnce(Return(&object));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&object));
+
+    // Params suppoted by the sink...
+    const int kNumParamsSupportedByServer{1};
+    GParamSpec dummySinkParams[kNumParamsSupportedByServer];
+    dummySinkParams[0].name = "test-name-123";
+    GParamSpec *dummySinkParamsPtr[] = {&dummySinkParams[0], &dummySinkParams[1]};
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(0), Return(nullptr)))
+        .WillOnce(DoAll(SetArgPointee<1>(0), Return(nullptr)))
+        .WillOnce(DoAll(SetArgPointee<1>(kNumParamsSupportedByServer), Return(dummySinkParamsPtr)));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(dummySinkParamsPtr)).Times(1);
+    EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(listOfFactories)).Times(1);
+
+    // Params that the caller is asking about...
+    std::vector<std::string> kParamNames{"test-name-123"};
+    std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
+    // this time we should find all the properties...
+    EXPECT_EQ(supportedProperties, kParamNames);
+}
+
+TEST_F(GstCapabilitiesTest, getSupportedPropertiesWithNoPropertiesSupported)
+{
+    createSutWithNoDecoderAndNoSink();
+
+    const GstElementFactoryListType kExpectedFactoryListType{
+        GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO};
+    GList *listOfFactories{nullptr};
+    GstElementFactory *dummyFactory{nullptr};
+    const GType kDummyType{3};
+    GObjectClass dummyClass;
+    memset(&dummyClass, 0x00, sizeof(dummyClass));
+
+    listOfFactories = g_list_append(listOfFactories, dummyFactory);
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListGetElements(kExpectedFactoryListType, GST_RANK_NONE))
         .WillOnce(Return(listOfFactories));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryGetElementType(dummyFactory)).WillOnce(Return(kDummyType));
     EXPECT_CALL(*m_glibWrapperMock, gTypeClassRef(kDummyType)).WillOnce(Return(&dummyClass));
-    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(&dummyClass, _))
-        .Times(kParamNames.size())
-        .WillRepeatedly(Return(nullptr));
     EXPECT_CALL(*m_glibWrapperMock, gObjectUnref(&dummyClass));
+
+    // Params suppoted by the sink...
+    const int kNumParamsSupportedByServer{2};
+    GParamSpec dummySinkParams[kNumParamsSupportedByServer];
+    dummySinkParams[0].name = "test3";
+    dummySinkParams[1].name = "test4";
+    GParamSpec *dummySinkParamsPtr[] = {&dummySinkParams[0], &dummySinkParams[1]};
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassListProperties(_, _))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(kNumParamsSupportedByServer), Return(dummySinkParamsPtr)));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(dummySinkParamsPtr)).Times(1);
     EXPECT_CALL(*m_gstWrapperMock, gstPluginFeatureListFree(listOfFactories)).Times(1);
-    supportedProperties = m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames);
+
+    // Params that the caller is asking about...
+    std::vector<std::string> kParamNames{"test-name-123", "test2"};
+    std::vector<std::string> supportedProperties{m_sut->getSupportedProperties(MediaSourceType::VIDEO, kParamNames)};
+    // this time we will not find the properties...
     EXPECT_TRUE(supportedProperties.empty());
 
     gst_plugin_feature_list_free(listOfFactories);

--- a/wrappers/include/GlibWrapper.h
+++ b/wrappers/include/GlibWrapper.h
@@ -72,6 +72,8 @@ public:
 
     GParamSpec *gObjectClassFindProperty(GObjectClass *oclass, const gchar *property_name) override;
 
+    GParamSpec **gObjectClassListProperties(GObjectClass *oclass, guint *nProps) override;
+
     gpointer gTypeClassRef(GType type) override { return g_type_class_ref(type); }
 
     GType gTypeFromName(const gchar *name) override { return g_type_from_name(name); }

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -97,11 +97,6 @@ public:
         return gst_element_factory_make(factoryname, name);
     }
 
-    GType gstElementFactoryGetElementType(GstElementFactory *factory)
-    {
-        return gst_element_factory_get_element_type(factory);
-    }
-
     GstElement *gstBinGetByName(GstBin *bin, const gchar *name) override { return gst_bin_get_by_name(bin, name); }
 
     gpointer gstObjectRef(gpointer object) override { return gst_object_ref(object); }
@@ -364,11 +359,6 @@ public:
     }
 
     void gstPluginFeatureListFree(GList *list) const override { gst_plugin_feature_list_free(list); }
-
-    GstPluginFeature *gstPluginFeatureLoad(GstPluginFeature *feature) const override
-    {
-        return gst_plugin_feature_load(feature);
-    }
 
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -365,6 +365,11 @@ public:
 
     void gstPluginFeatureListFree(GList *list) const override { gst_plugin_feature_list_free(list); }
 
+    GstPluginFeature *gstPluginFeatureLoad(GstPluginFeature *feature) const override
+    {
+        return gst_plugin_feature_load(feature);
+    }
+
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {
         /* there's no valist equivalent of gst_caps_new_simple */

--- a/wrappers/interface/IGlibWrapper.h
+++ b/wrappers/interface/IGlibWrapper.h
@@ -94,6 +94,16 @@ public:
     virtual GParamSpec *gObjectClassFindProperty(GObjectClass *oclass, const gchar *property_name) = 0;
 
     /**
+     * @brief returns all the GParamSpec for the properties of a class.
+     *
+     * @param[in] oclass        : a GObjectClass
+     * @param[out] nProps : the number of properties returned
+     *
+     * @retval an array of GParamSpec for the oclass
+     */
+    virtual GParamSpec **gObjectClassListProperties(GObjectClass *oclass, guint *nProps) = 0;
+
+    /**
      * @brief Increments the reference count of the class. Creates the class if it does not exist.
      *
      * @param[in] type  : Type of class to increment.

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -869,6 +869,15 @@ public:
     virtual void gstPluginFeatureListFree(GList *list) const = 0;
 
     /**
+     * @brief Loads the plugin containing feature if it's not already loaded
+     *
+     * @param[in] feature : the feature to load
+     *
+     * @retval a reference to the loaded feature, or NULL on error
+     */
+    virtual GstPluginFeature *gstPluginFeatureLoad(GstPluginFeature *feature) const = 0;
+
+    /**
      * @brief Creates a new GstCaps with one GstStructure.
      *
      * @param[in] media_type : the media type of the structure

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -141,15 +141,6 @@ public:
     virtual GstElement *gstElementFactoryMake(const gchar *factoryname, const gchar *name) = 0;
 
     /**
-     * @brief Get the element type returned by the requested factory.
-     *
-     * @param[in] factory   : Factory
-     *
-     * @retval GType that the factory produces
-     */
-    virtual GType gstElementFactoryGetElementType(GstElementFactory *factory) = 0;
-
-    /**
      * @brief Increment reference count on object.
      *
      * @param[in] object   : Object to increment.
@@ -867,15 +858,6 @@ public:
      * @param[in] list : list of GstPluginFeature
      */
     virtual void gstPluginFeatureListFree(GList *list) const = 0;
-
-    /**
-     * @brief Loads the plugin containing feature if it's not already loaded
-     *
-     * @param[in] feature : the feature to load
-     *
-     * @retval a reference to the loaded feature, or NULL on error
-     */
-    virtual GstPluginFeature *gstPluginFeatureLoad(GstPluginFeature *feature) const = 0;
 
     /**
      * @brief Creates a new GstCaps with one GstStructure.

--- a/wrappers/source/GlibWrapper.cpp
+++ b/wrappers/source/GlibWrapper.cpp
@@ -59,6 +59,11 @@ GParamSpec *GlibWrapper::gObjectClassFindProperty(GObjectClass *oclass, const gc
     return g_object_class_find_property(oclass, property_name);
 }
 
+GParamSpec **GlibWrapper::gObjectClassListProperties(GObjectClass *oclass, guint *nProps)
+{
+    return g_object_class_list_properties(oclass, nProps);
+}
+
 gchar *GlibWrapper::gStrdupPrintf(const gchar *format, ...)
 {
     gchar *str = NULL;


### PR DESCRIPTION
Summary: fix_getSupportedProperties so that it is robust. For speed, initially, it tries to get properties from the class info only. If this fails, and it often does fail immediately after rialtoserver start-up, then it uses gst_plugin_feature_load and tries again. If this fails then it instantiates an object in order to get its properties (this is what gst-inspect does)
Type: Fix  
Test Plan: UT, CT, native_build
Jira: RIALTO-597