### PR TITLE
Cache and set pending audio low latency properties

### DIFF
--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -136,6 +136,31 @@ struct GenericPlayerContext
     std::optional<bool> pendingImmediateOutputForVideo{};
 
     /**
+     * @brief Pending low latency
+     */
+    std::optional<bool> pendingLowLatency{};
+
+    /**
+     * @brief Pending sync
+     */
+    std::optional<bool> pendingSync{};
+
+    /**
+     * @brief Pending sync off
+     */
+    std::optional<bool> pendingSyncOff{};
+
+    /**
+     * @brief Pending stream sync mode
+     */
+    std::optional<int32_t> pendingStreamSyncMode{};
+
+    /**
+     * @brief Pending render frame
+     */
+    bool pendingRenderFrame{false};
+
+    /**
      * @brief Last audio sample timestamps
      * TODO(LLDEV-31012) Needed to detect audio stream underflow
      */

--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -180,6 +180,16 @@ struct GenericPlayerContext
      * Attribute can be used only in worker thread
      */
     std::map<GstElement *, std::vector<SegmentData>> initialPositions;
+
+    /**
+     * @brief Set if low latency is queued on the pipeline.
+     */
+    std::optional<bool> lowLatency{std::nullopt};
+
+    /**
+     * @brief Set if sync is queued on the pipeline.
+     */
+    std::optional<bool> sync{std::nullopt};
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -210,16 +210,6 @@ struct GenericPlayerContext
      * Attribute can be used only in worker thread
      */
     std::map<GstElement *, std::vector<SegmentData>> initialPositions;
-
-    /**
-     * @brief Set if low latency is queued on the pipeline.
-     */
-    std::optional<bool> lowLatency{std::nullopt};
-
-    /**
-     * @brief Set if sync is queued on the pipeline.
-     */
-    std::optional<bool> sync{std::nullopt};
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -138,6 +138,10 @@ private:
     void scheduleVideoUnderflow() override;
     void scheduleAllSourcesAttached() override;
     bool setVideoSinkRectangle() override;
+    bool setLowLatency() override;
+    bool setSync() override;
+    bool setSyncOff() override;
+    bool setStreamSyncMode() override;
     void notifyNeedMediaData(const MediaSourceType mediaSource) override;
     GstBuffer *createBuffer(const IMediaPipeline::MediaSegment &mediaSegment) const override;
     void attachData(const firebolt::rialto::MediaSourceType mediaType) override;

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -245,6 +245,13 @@ private:
      */
     bool setCodecData(GstCaps *caps, const std::shared_ptr<CodecData> &codecData) const;
 
+    /**
+     * @brief Gets the element from the pipeline that has type.
+     *
+     * @retval The element or nullptr if not found.
+     */
+    GstElement *getElementFromPipeline(GstElementFactoryListType type) const;
+
 private:
     /**
      * @brief The player context.

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -144,6 +144,7 @@ private:
     bool setSync() override;
     bool setSyncOff() override;
     bool setStreamSyncMode() override;
+    bool setRenderFrame() override;
     void notifyNeedMediaData(const MediaSourceType mediaSource) override;
     GstBuffer *createBuffer(const IMediaPipeline::MediaSegment &mediaSegment) const override;
     void attachData(const firebolt::rialto::MediaSourceType mediaType) override;

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -130,7 +130,6 @@ public:
     void flush(const MediaSourceType &mediaSourceType, bool resetTime) override;
     void setSourcePosition(const MediaSourceType &mediaSourceType, int64_t position, bool resetTime) override;
     void processAudioGap(int64_t position, uint32_t duration, int64_t discontinuityGap, bool audioAac) override;
-    GstElement *getSink(const MediaSourceType &mediaSourceType) const override;
 
 private:
     void scheduleNeedMediaData(GstAppSrc *src) override;
@@ -166,11 +165,8 @@ private:
     void addAutoAudioSinkChild(GObject *object) override;
     void removeAutoVideoSinkChild(GObject *object) override;
     void removeAutoAudioSinkChild(GObject *object) override;
-    GstElement *getSinkChildIfAutoVideoSink(GstElement *sink) const override;
-    GstElement *getSinkChildIfAutoAudioSink(GstElement *sink) const override;
     void setPlaybinFlags(bool enableAudio = true) override;
     void pushSampleIfRequired(GstElement *source, const std::string &typeStr) override;
-    GstElement *getDecoder(const MediaSourceType &mediaSourceType) override;
 
 private:
     /**
@@ -252,11 +248,42 @@ private:
     bool setCodecData(GstCaps *caps, const std::shared_ptr<CodecData> &codecData) const;
 
     /**
-     * @brief Gets the element from the pipeline that has type.
+     * @brief Gets the video sink element child sink if present.
+     *        Only gets children for GstAutoVideoSink's.
      *
-     * @retval The element or nullptr if not found.
+     * @param[in] sink    : Sink element to check.
+     *
+     * @retval Underlying child video sink or 'sink' if there are no children.
      */
-    GstElement *getElementFromPipeline(GstElementFactoryListType type) const;
+    GstElement *getSinkChildIfAutoVideoSink(GstElement *sink) const;
+
+    /**
+     * @brief Gets the audio sink element child sink if present.
+     *        Only gets children for GstAutoAudioSink's.
+     *
+     * @param[in] sink    : Sink element to check.
+     *
+     * @retval Underlying child audio sink or 'sink' if there are no children.
+     */
+    GstElement *getSinkChildIfAutoAudioSink(GstElement *sink) const;
+
+    /**
+     * @brief Gets the sink element for source type.
+     *
+     * @param[in] mediaSourceType : the source type to obtain the sink for
+     *
+     * @retval The sink, NULL if not found. Please call getObjectUnref() if it's non-null
+     */
+    GstElement *getSink(const MediaSourceType &mediaSourceType) const;
+
+    /**
+     * @brief Gets the decoder element for source type.
+     *
+     * @param[in] mediaSourceType : the source type to obtain the decoder for
+     *
+     * @retval The decoder, NULL if not found
+     */
+    GstElement *getDecoder(const MediaSourceType &mediaSourceType);
 
 private:
     /**

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -167,6 +167,7 @@ private:
     void removeAutoAudioSinkChild(GObject *object) override;
     void setPlaybinFlags(bool enableAudio = true) override;
     void pushSampleIfRequired(GstElement *source, const std::string &typeStr) override;
+    GstElement *getSink(const MediaSourceType &mediaSourceType) const override;
 
 private:
     /**
@@ -266,15 +267,6 @@ private:
      * @retval Underlying child audio sink or 'sink' if there are no children.
      */
     GstElement *getSinkChildIfAutoAudioSink(GstElement *sink) const;
-
-    /**
-     * @brief Gets the sink element for source type.
-     *
-     * @param[in] mediaSourceType : the source type to obtain the sink for
-     *
-     * @retval The sink, NULL if not found. Please call getObjectUnref() if it's non-null
-     */
-    GstElement *getSink(const MediaSourceType &mediaSourceType) const;
 
     /**
      * @brief Gets the decoder element for source type.

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -109,7 +109,7 @@ public:
     virtual bool setStreamSyncMode() = 0;
 
     /**
-     * @brief Renders the frame. Called by the worker thread.
+     * @brief Sets frame rendering. Called by the worker thread.
      *
      * @retval true on success.
      */
@@ -221,44 +221,6 @@ public:
      * @param[in] object    : Element removed from the autoaudiosink.
      */
     virtual void removeAutoAudioSinkChild(GObject *object) = 0;
-
-    /**
-     * @brief Gets the video sink element child sink if present.
-     *        Only gets children for GstAutoVideoSink's.
-     *
-     * @param[in] sink    : Sink element to check.
-     *
-     * @retval Underlying child video sink or 'sink' if there are no children.
-     */
-    virtual GstElement *getSinkChildIfAutoVideoSink(GstElement *sink) const = 0;
-
-    /**
-     * @brief Gets the audio sink element child sink if present.
-     *        Only gets children for GstAutoAudioSink's.
-     *
-     * @param[in] sink    : Sink element to check.
-     *
-     * @retval Underlying child audio sink or 'sink' if there are no children.
-     */
-    virtual GstElement *getSinkChildIfAutoAudioSink(GstElement *sink) const = 0;
-
-    /**
-     * @brief Gets the sink element for source type.
-     *
-     * @param[in] mediaSourceType : the source type to obtain the sink for
-     *
-     * @retval The sink, NULL if not found. Please call getObjectUnref() if it's non-null
-     */
-    virtual GstElement *getSink(const MediaSourceType &mediaSourceType) const = 0;
-
-    /**
-     * @brief Gets the decoder element for source type.
-     *
-     * @param[in] mediaSourceType : the source type to obtain the decoder for
-     *
-     * @retval The decoder, NULL if not found
-     */
-    virtual GstElement *getDecoder(const MediaSourceType &mediaSourceType) = 0;
 
     /**
      * @brief Sets the audio and video flags on the pipeline based on the input.

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -223,6 +223,15 @@ public:
     virtual void removeAutoAudioSinkChild(GObject *object) = 0;
 
     /**
+     * @brief Gets the sink element for source type.
+     *
+     * @param[in] mediaSourceType : the source type to obtain the sink for
+     *
+     * @retval The sink, NULL if not found. Please call getObjectUnref() if it's non-null
+     */
+    virtual GstElement *getSink(const MediaSourceType &mediaSourceType) const = 0;
+
+    /**
      * @brief Sets the audio and video flags on the pipeline based on the input.
      *
      * @param[in] enableAudio : Whether to enable audio flags.

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -109,6 +109,13 @@ public:
     virtual bool setStreamSyncMode() = 0;
 
     /**
+     * @brief Renders the frame. Called by the worker thread.
+     *
+     * @retval true on success.
+     */
+    virtual bool setRenderFrame() = 0;
+
+    /**
      * @brief Sends NeedMediaData notification. Called by the worker thread.
      */
     virtual void notifyNeedMediaData(const MediaSourceType mediaSource) = 0;

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -73,6 +73,34 @@ public:
     virtual bool setVideoSinkRectangle() = 0;
 
     /**
+     * @brief Sets the low latency property. Called by the worker thread.
+     *
+     * @retval true on success.
+     */
+    virtual bool setLowLatency() = 0;
+
+    /**
+     * @brief Sets the sync property. Called by the worker thread.
+     *
+     * @retval true on success.
+     */
+    virtual bool setSync() = 0;
+
+    /**
+     * @brief Sets the sync off property. Called by the worker thread.
+     *
+     * @retval true on success.
+     */
+    virtual bool setSyncOff() = 0;
+
+    /**
+     * @brief Sets the stream sync mode property. Called by the worker thread.
+     *
+     * @retval true on success.
+     */
+    virtual bool setStreamSyncMode() = 0;
+
+    /**
      * @brief Sends NeedMediaData notification. Called by the worker thread.
      */
     virtual void notifyNeedMediaData(const MediaSourceType mediaSource) = 0;

--- a/media/server/gstplayer/include/Utils.h
+++ b/media/server/gstplayer/include/Utils.h
@@ -29,6 +29,7 @@ namespace firebolt::rialto::server
 {
 bool isVideoDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
+bool isAudioSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 std::string getUnderflowSignalName(const firebolt::rialto::wrappers::IGlibWrapper &glibWrapper, GstElement *element);
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/Utils.h
+++ b/media/server/gstplayer/include/Utils.h
@@ -29,6 +29,7 @@ namespace firebolt::rialto::server
 {
 bool isVideoDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
+bool isVideoSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isAudioSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 std::string getUnderflowSignalName(const firebolt::rialto::wrappers::IGlibWrapper &glibWrapper, GstElement *element);
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
@@ -299,13 +299,14 @@ public:
     /**
      * @brief Creates a SetLowLatency task.
      *
-     * @param[in] context             : The GstGenericPlayer context
+     * @param[in] context       : The GstGenericPlayer context
      * @param[in] player        : The GstGenericPlayer instance
      * @param[in] lowLatency    : The low latency value to set
      *
      * @retval the new SetLowLatency task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool lowLatency) const = 0;
+    virtual std::unique_ptr<IPlayerTask> createSetLowLatency(GenericPlayerContext &context,
+                                                             IGstGenericPlayerPrivate &player, bool lowLatency) const = 0;
 
     /**
      * @brief Creates a SetSync task.
@@ -316,7 +317,8 @@ public:
      *
      * @retval the new SetSync task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const = 0;
+    virtual std::unique_ptr<IPlayerTask> createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
+                                                       bool sync) const = 0;
 
     /**
      * @brief Creates a SetSyncOff task.
@@ -327,7 +329,8 @@ public:
      *
      * @retval the new SetSyncOff task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool syncOff) const = 0;
+    virtual std::unique_ptr<IPlayerTask> createSetSyncOff(GenericPlayerContext &context,
+                                                          IGstGenericPlayerPrivate &player, bool syncOff) const = 0;
 
     /**
      * @brief Creates a SetStreamSyncMode task.
@@ -338,7 +341,8 @@ public:
      *
      * @retval the new SetStreamSyncMode task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
+    virtual std::unique_ptr<IPlayerTask> createSetStreamSyncMode(GenericPlayerContext &context,
+                                                                 IGstGenericPlayerPrivate &player,
                                                                  int32_t streamSyncMode) const = 0;
 
     /**
@@ -386,10 +390,10 @@ public:
                                                                    const GstCaps *caps) const = 0;
 
     /**
-     * @brief Creates an RenderFrame task.
+     * @brief Creates a RenderFrame task.
      *
      * @param[in] context       : The GstGenericPlayer context
-     * @param[in] player           : The GstPlayer instance
+     * @param[in] player        : The GstPlayer instance
      *
      * @retval the new RenderFrame task instance.
      */

--- a/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
@@ -310,7 +310,7 @@ public:
     /**
      * @brief Creates a SetSync task.
      *
-     * @param[in] context             : The GstGenericPlayer context
+     * @param[in] context       : The GstGenericPlayer context
      * @param[in] player        : The GstGenericPlayer instance
      * @param[in] sync          : The sync value to set
      *
@@ -321,22 +321,24 @@ public:
     /**
      * @brief Creates a SetSyncOff task.
      *
+     * @param[in] context       : The GstGenericPlayer context
      * @param[in] player        : The GstGenericPlayer instance
      * @param[in] syncOff       : The syncOff value to set
      *
      * @retval the new SetSyncOff task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetSyncOff(IGstGenericPlayerPrivate &player, bool syncOff) const = 0;
+    virtual std::unique_ptr<IPlayerTask> createSetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool syncOff) const = 0;
 
     /**
      * @brief Creates a SetStreamSyncMode task.
      *
+     * @param[in] context           : The GstGenericPlayer context
      * @param[in] player            : The GstGenericPlayer instance
      * @param[in] streamSyncMode    : The streamSyncMode value to set
      *
      * @retval the new SetStreamSyncMode task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetStreamSyncMode(IGstGenericPlayerPrivate &player,
+    virtual std::unique_ptr<IPlayerTask> createSetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                                  int32_t streamSyncMode) const = 0;
 
     /**
@@ -383,6 +385,14 @@ public:
     virtual std::unique_ptr<IPlayerTask> createUpdatePlaybackGroup(GenericPlayerContext &context, GstElement *typefind,
                                                                    const GstCaps *caps) const = 0;
 
+    /**
+     * @brief Creates an RenderFrame task.
+     *
+     * @param[in] context       : The GstGenericPlayer context
+     * @param[in] player           : The GstPlayer instance
+     *
+     * @retval the new RenderFrame task instance.
+     */
     virtual std::unique_ptr<IPlayerTask> createRenderFrame(GenericPlayerContext &context,
                                                            IGstGenericPlayerPrivate &player) const = 0;
 

--- a/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
@@ -299,22 +299,24 @@ public:
     /**
      * @brief Creates a SetLowLatency task.
      *
+     * @param[in] context             : The GstGenericPlayer context
      * @param[in] player        : The GstGenericPlayer instance
      * @param[in] lowLatency    : The low latency value to set
      *
      * @retval the new SetLowLatency task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetLowLatency(IGstGenericPlayerPrivate &player, bool lowLatency) const = 0;
+    virtual std::unique_ptr<IPlayerTask> createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool lowLatency) const = 0;
 
     /**
      * @brief Creates a SetSync task.
      *
+     * @param[in] context             : The GstGenericPlayer context
      * @param[in] player        : The GstGenericPlayer instance
      * @param[in] sync          : The sync value to set
      *
      * @retval the new SetSync task instance.
      */
-    virtual std::unique_ptr<IPlayerTask> createSetSync(IGstGenericPlayerPrivate &player, bool sync) const = 0;
+    virtual std::unique_ptr<IPlayerTask> createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const = 0;
 
     /**
      * @brief Creates a SetSyncOff task.

--- a/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
@@ -84,8 +84,8 @@ public:
                                                               const std::string &textTrackIdentifier) const override;
     std::unique_ptr<IPlayerTask> createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool lowLatency) const override;
     std::unique_ptr<IPlayerTask> createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const override;
-    std::unique_ptr<IPlayerTask> createSetSyncOff(IGstGenericPlayerPrivate &player, bool syncOff) const override;
-    std::unique_ptr<IPlayerTask> createSetStreamSyncMode(IGstGenericPlayerPrivate &player,
+    std::unique_ptr<IPlayerTask> createSetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool syncOff) const override;
+    std::unique_ptr<IPlayerTask> createSetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                          int32_t streamSyncMode) const override;
     std::unique_ptr<IPlayerTask> createShutdown(IGstGenericPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createStop(GenericPlayerContext &context,

--- a/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
@@ -82,9 +82,12 @@ public:
                                                bool mute) const override;
     std::unique_ptr<IPlayerTask> createSetTextTrackIdentifier(GenericPlayerContext &context,
                                                               const std::string &textTrackIdentifier) const override;
-    std::unique_ptr<IPlayerTask> createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool lowLatency) const override;
-    std::unique_ptr<IPlayerTask> createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const override;
-    std::unique_ptr<IPlayerTask> createSetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool syncOff) const override;
+    std::unique_ptr<IPlayerTask> createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
+                                                     bool lowLatency) const override;
+    std::unique_ptr<IPlayerTask> createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
+                                               bool sync) const override;
+    std::unique_ptr<IPlayerTask> createSetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
+                                                  bool syncOff) const override;
     std::unique_ptr<IPlayerTask> createSetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                          int32_t streamSyncMode) const override;
     std::unique_ptr<IPlayerTask> createShutdown(IGstGenericPlayerPrivate &player) const override;

--- a/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
@@ -82,8 +82,8 @@ public:
                                                bool mute) const override;
     std::unique_ptr<IPlayerTask> createSetTextTrackIdentifier(GenericPlayerContext &context,
                                                               const std::string &textTrackIdentifier) const override;
-    std::unique_ptr<IPlayerTask> createSetLowLatency(IGstGenericPlayerPrivate &player, bool lowLatency) const override;
-    std::unique_ptr<IPlayerTask> createSetSync(IGstGenericPlayerPrivate &player, bool sync) const override;
+    std::unique_ptr<IPlayerTask> createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool lowLatency) const override;
+    std::unique_ptr<IPlayerTask> createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const override;
     std::unique_ptr<IPlayerTask> createSetSyncOff(IGstGenericPlayerPrivate &player, bool syncOff) const override;
     std::unique_ptr<IPlayerTask> createSetStreamSyncMode(IGstGenericPlayerPrivate &player,
                                                          int32_t streamSyncMode) const override;

--- a/media/server/gstplayer/include/tasks/generic/RenderFrame.h
+++ b/media/server/gstplayer/include/tasks/generic/RenderFrame.h
@@ -21,27 +21,20 @@
 #define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_RENDER_FRAME_H_
 
 #include "GenericPlayerContext.h"
-#include "IGlibWrapper.h"
 #include "IGstGenericPlayerPrivate.h"
-#include "IGstWrapper.h"
 #include "IPlayerTask.h"
-#include <cstdint>
-#include <memory>
 
 namespace firebolt::rialto::server::tasks::generic
 {
 class RenderFrame : public IPlayerTask
 {
 public:
-    RenderFrame(GenericPlayerContext &context, std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> gstWrapper,
-                std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> glibWrapper, IGstGenericPlayerPrivate &player);
-    ~RenderFrame() override = default;
+    RenderFrame(GenericPlayerContext &context, IGstGenericPlayerPrivate &player);
+    ~RenderFrame() override;
     void execute() const override;
 
 private:
     GenericPlayerContext &m_context;
-    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
-    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
     IGstGenericPlayerPrivate &m_player;
 };
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/include/tasks/generic/SetLowLatency.h
+++ b/media/server/gstplayer/include/tasks/generic/SetLowLatency.h
@@ -21,29 +21,21 @@
 #define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_LOW_LATENCY_H_
 
 #include "GenericPlayerContext.h"
-#include "IGlibWrapper.h"
 #include "IGstGenericPlayerPrivate.h"
-#include "IGstWrapper.h"
 #include "IPlayerTask.h"
-
-#include <memory>
 
 namespace firebolt::rialto::server::tasks::generic
 {
 class SetLowLatency : public IPlayerTask
 {
 public:
-    explicit SetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
-                           const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
-                           const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper, bool lowLatency);
+    SetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool lowLatency);
     ~SetLowLatency() override;
     void execute() const override;
 
 private:
     GenericPlayerContext &m_context;
     IGstGenericPlayerPrivate &m_player;
-    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
-    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
     bool m_lowLatency;
 };
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/include/tasks/generic/SetLowLatency.h
+++ b/media/server/gstplayer/include/tasks/generic/SetLowLatency.h
@@ -20,6 +20,7 @@
 #ifndef FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_LOW_LATENCY_H_
 #define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_LOW_LATENCY_H_
 
+#include "GenericPlayerContext.h"
 #include "IGlibWrapper.h"
 #include "IGstGenericPlayerPrivate.h"
 #include "IGstWrapper.h"
@@ -32,13 +33,14 @@ namespace firebolt::rialto::server::tasks::generic
 class SetLowLatency : public IPlayerTask
 {
 public:
-    explicit SetLowLatency(IGstGenericPlayerPrivate &player,
+    explicit SetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                            const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                            const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper, bool lowLatency);
     ~SetLowLatency() override;
     void execute() const override;
 
 private:
+    GenericPlayerContext &m_context;
     IGstGenericPlayerPrivate &m_player;
     std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
     std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;

--- a/media/server/gstplayer/include/tasks/generic/SetStreamSyncMode.h
+++ b/media/server/gstplayer/include/tasks/generic/SetStreamSyncMode.h
@@ -29,8 +29,7 @@ namespace firebolt::rialto::server::tasks::generic
 class SetStreamSyncMode : public IPlayerTask
 {
 public:
-    SetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
-                               int32_t streamSyncMode);
+    SetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, int32_t streamSyncMode);
     ~SetStreamSyncMode() override;
     void execute() const override;
 

--- a/media/server/gstplayer/include/tasks/generic/SetStreamSyncMode.h
+++ b/media/server/gstplayer/include/tasks/generic/SetStreamSyncMode.h
@@ -20,29 +20,23 @@
 #ifndef FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_STREAM_SYNC_MODE_H_
 #define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_STREAM_SYNC_MODE_H_
 
-#include "IGlibWrapper.h"
+#include "GenericPlayerContext.h"
 #include "IGstGenericPlayerPrivate.h"
-#include "IGstWrapper.h"
 #include "IPlayerTask.h"
-
-#include <memory>
 
 namespace firebolt::rialto::server::tasks::generic
 {
 class SetStreamSyncMode : public IPlayerTask
 {
 public:
-    explicit SetStreamSyncMode(IGstGenericPlayerPrivate &player,
-                               const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
-                               const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
+    SetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                int32_t streamSyncMode);
     ~SetStreamSyncMode() override;
     void execute() const override;
 
 private:
+    GenericPlayerContext &m_context;
     IGstGenericPlayerPrivate &m_player;
-    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
-    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
     int32_t m_streamSyncMode;
 };
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/include/tasks/generic/SetSync.h
+++ b/media/server/gstplayer/include/tasks/generic/SetSync.h
@@ -20,6 +20,7 @@
 #ifndef FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_SYNC_H_
 #define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_SYNC_H_
 
+#include "GenericPlayerContext.h"
 #include "IGlibWrapper.h"
 #include "IGstGenericPlayerPrivate.h"
 #include "IGstWrapper.h"
@@ -32,13 +33,14 @@ namespace firebolt::rialto::server::tasks::generic
 class SetSync : public IPlayerTask
 {
 public:
-    explicit SetSync(IGstGenericPlayerPrivate &player,
+    explicit SetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                      const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                      const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper, bool sync);
     ~SetSync() override;
     void execute() const override;
 
 private:
+    GenericPlayerContext &m_context;
     IGstGenericPlayerPrivate &m_player;
     std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
     std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;

--- a/media/server/gstplayer/include/tasks/generic/SetSync.h
+++ b/media/server/gstplayer/include/tasks/generic/SetSync.h
@@ -21,9 +21,7 @@
 #define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_SYNC_H_
 
 #include "GenericPlayerContext.h"
-#include "IGlibWrapper.h"
 #include "IGstGenericPlayerPrivate.h"
-#include "IGstWrapper.h"
 #include "IPlayerTask.h"
 
 #include <memory>
@@ -33,17 +31,13 @@ namespace firebolt::rialto::server::tasks::generic
 class SetSync : public IPlayerTask
 {
 public:
-    explicit SetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
-                     const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
-                     const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper, bool sync);
+    SetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync);
     ~SetSync() override;
     void execute() const override;
 
 private:
     GenericPlayerContext &m_context;
     IGstGenericPlayerPrivate &m_player;
-    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
-    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
     bool m_sync;
 };
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/include/tasks/generic/SetSyncOff.h
+++ b/media/server/gstplayer/include/tasks/generic/SetSyncOff.h
@@ -20,28 +20,22 @@
 #ifndef FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_SYNC_OFF_H_
 #define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SET_SYNC_OFF_H_
 
-#include "IGlibWrapper.h"
+#include "GenericPlayerContext.h"
 #include "IGstGenericPlayerPrivate.h"
-#include "IGstWrapper.h"
 #include "IPlayerTask.h"
-
-#include <memory>
 
 namespace firebolt::rialto::server::tasks::generic
 {
 class SetSyncOff : public IPlayerTask
 {
 public:
-    explicit SetSyncOff(IGstGenericPlayerPrivate &player,
-                        const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
-                        const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper, bool syncOff);
+    SetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool syncOff);
     ~SetSyncOff() override;
     void execute() const override;
 
 private:
+    GenericPlayerContext &m_context;
     IGstGenericPlayerPrivate &m_player;
-    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
-    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
     bool m_syncOff;
 };
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -1017,6 +1017,136 @@ bool GstGenericPlayer::setWesterossinkSecondaryVideo()
     return result;
 }
 
+bool GstGenericPlayer::setLowLatency()
+{
+    bool result{false};
+    if (m_context.pendingLowLatency.has_value())
+    {
+        GstElement *sink{getSink(MediaSourceType::AUDIO)};
+        if (sink)
+        {
+            bool lowLatency{m_context.pendingLowLatency.value()};
+            RIALTO_SERVER_LOG_DEBUG("Set low-latency to %s", lowLatency ? "TRUE" : "FALSE");
+
+            GstElement *actualSink = getSinkChildIfAutoAudioSink(sink);
+            if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(actualSink), "low-latency"))
+            {
+                gboolean lowLatencyGboolean{lowLatency ? TRUE : FALSE};
+                m_glibWrapper->gObjectSet(actualSink, "low-latency", m_lowLatency, nullptr);
+                result = true;
+            }
+            else
+            {
+                RIALTO_SERVER_LOG_ERROR("Failed to set low-latency property on sink '%s'", GST_ELEMENT_NAME(actualSink));
+            }
+            m_context.pendingLowLatency.reset();
+            m_gstWrapper->gstObjectUnref(sink);
+        }
+        else
+        {
+            RIALTO_SERVER_LOG_DEBUG("Pending low-latency, sink is NULL");
+        }
+    }
+    return result;
+}
+
+bool GstGenericPlayer::setSync()
+{
+    bool result{false};
+    if (m_context.pendingSync.has_value())
+    {
+        GstElement *sink{getSink(MediaSourceType::AUDIO)};
+        if (sink)
+        {
+            bool sync{m_context.pendingSync.value()};
+            RIALTO_SERVER_LOG_DEBUG("Set sync to %s", sync ? "TRUE" : "FALSE");
+
+            GstElement *actualSink = getSinkChildIfAutoAudioSink(sink);
+            if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(actualSink), "sync"))
+            {
+                gboolean syncGboolean{sync ? TRUE : FALSE};
+                m_glibWrapper->gObjectSet(actualSink, "sync", m_sync, nullptr);
+                result = true;
+            }
+            else
+            {
+                RIALTO_SERVER_LOG_ERROR("Failed to set sync property on sink '%s'", GST_ELEMENT_NAME(actualSink));
+            }
+            m_context.pendingSync.reset();
+            m_gstWrapper->gstObjectUnref(sink);
+        }
+        else
+        {
+            RIALTO_SERVER_LOG_DEBUG("Pending sync, sink is NULL");
+        }
+    }
+    return result;
+}
+
+bool GstGenericPlayer::setSyncOff()
+{
+    bool result{false};
+    if (m_context.pendingSyncOff.has_value())
+    {
+        GstElement *decoder = getDecoder(MediaSourceType::AUDIO);
+        if (decoder)
+        {
+            bool syncOff{m_context.pendingSyncOff.value()};
+            RIALTO_SERVER_LOG_DEBUG("Set sync-off to %s", syncOff ? "TRUE" : "FALSE");
+
+            if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(decoder), "sync-off"))
+            {
+                gboolean syncOffGboolean{decoder ? TRUE : FALSE};
+                m_glibWrapper->gObjectSet(decoder, "sync-off", syncOff, nullptr);
+                result = true;
+            }
+            else
+            {
+                RIALTO_SERVER_LOG_ERROR("Failed to set sync-off property on decoder '%s'", GST_ELEMENT_NAME(decoder));
+            }
+            m_context.pendingSyncOff.reset();
+            m_gstWrapper->gstObjectUnref(decoder);
+        }
+        else
+        {
+            RIALTO_SERVER_LOG_DEBUG("Pending sync-off, decoder is NULL");
+        }
+    }
+    return result;
+}
+
+bool GstGenericPlayer::setStreamSyncMode()
+{
+    bool result{false};
+    if (m_context.pendingStreamSyncMode.has_value())
+    {
+        GstElement *decoder = getDecoder(MediaSourceType::AUDIO);
+        if (decoder)
+        {
+            bool streamSyncMode{m_context.pendingStreamSyncMode.value()};
+            RIALTO_SERVER_LOG_DEBUG("Set stream-sync-mode to %s", streamSyncMode ? "TRUE" : "FALSE");
+
+            if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(decoder), "stream-sync-mode"))
+            {
+                gboolean streamSyncModeGboolean{decoder ? TRUE : FALSE};
+                m_glibWrapper->gObjectSet(decoder, "stream-sync-mode", streamSyncMode, nullptr);
+                result = true;
+            }
+            else
+            {
+                RIALTO_SERVER_LOG_ERROR("Failed to set stream-sync-mode property on decoder '%s'", GST_ELEMENT_NAME(decoder));
+            }
+            m_context.pendingStreamSyncMode.reset();
+            m_gstWrapper->gstObjectUnref(decoder);
+        }
+        else
+        {
+            RIALTO_SERVER_LOG_DEBUG("Pending stream-sync-mode, decoder is NULL");
+        }
+    }
+    return result;
+}
+
 bool GstGenericPlayer::setErmContext()
 {
     bool result = false;

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -442,7 +442,7 @@ GstElement *GstGenericPlayer::getDecoder(const MediaSourceType &mediaSourceType)
     return getElementFromPipeline(type);
 }
 
-GstElement *GstGenericPlayer::getElementFromPipeline(GstElementFactoryListType type) 
+GstElement *GstGenericPlayer::getElementFromPipeline(GstElementFactoryListType type) const
 {
     GstIterator *it = m_gstWrapper->gstBinIterateElements(GST_BIN(m_context.pipeline));
     GValue item = G_VALUE_INIT;

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -1127,7 +1127,8 @@ bool GstGenericPlayer::setStreamSyncMode()
             }
             else
             {
-                RIALTO_SERVER_LOG_ERROR("Failed to set stream-sync-mode property on decoder '%s'", GST_ELEMENT_NAME(decoder));
+                RIALTO_SERVER_LOG_ERROR("Failed to set stream-sync-mode property on decoder '%s'",
+                                        GST_ELEMENT_NAME(decoder));
             }
             m_context.pendingStreamSyncMode.reset();
             m_gstWrapper->gstObjectUnref(decoder);
@@ -1154,8 +1155,8 @@ bool GstGenericPlayer::setRenderFrame()
                 RIALTO_SERVER_LOG_INFO("Rendering preroll");
 
                 m_glibWrapper->gObjectSet(sink, kStepOnPrerollPropertyName.c_str(), 1, nullptr);
-                m_gstWrapper->gstElementSendEvent(sink,
-                                                m_gstWrapper->gstEventNewStep(GST_FORMAT_BUFFERS, 1, 1.0, true, false));
+                m_gstWrapper->gstElementSendEvent(sink, m_gstWrapper->gstEventNewStep(GST_FORMAT_BUFFERS, 1, 1.0, true,
+                                                                                      false));
                 m_glibWrapper->gObjectSet(sink, kStepOnPrerollPropertyName.c_str(), 0, nullptr);
                 result = true;
             }
@@ -1417,10 +1418,10 @@ bool GstGenericPlayer::getSync(bool &sync)
         }
         m_gstWrapper->gstObjectUnref(sink);
     }
-    else if (m_context.sync.has_value())
+    else if (m_context.pendingSync.has_value())
     {
         RIALTO_SERVER_LOG_DEBUG("Returning queued value");
-        sync = m_context.sync.value();
+        sync = m_context.pendingSync.value();
         returnValue = true;
     }
     else
@@ -1457,6 +1458,12 @@ bool GstGenericPlayer::getStreamSyncMode(int32_t &streamSyncMode)
     if (decoder && m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(decoder), "stream-sync-mode"))
     {
         m_glibWrapper->gObjectGet(decoder, "stream-sync-mode", &streamSyncMode, nullptr);
+        returnValue = true;
+    }
+    else if (m_context.pendingStreamSyncMode.has_value())
+    {
+        RIALTO_SERVER_LOG_DEBUG("Returning queued value");
+        streamSyncMode = m_context.pendingStreamSyncMode.value();
         returnValue = true;
     }
     else

--- a/media/server/gstplayer/source/Utils.cpp
+++ b/media/server/gstplayer/source/Utils.cpp
@@ -57,6 +57,20 @@ bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, G
     return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
 }
 
+bool isVideoSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
+{
+    if (!element)
+    {
+        return false;
+    }
+    GstElementFactory *factory{gstWrapper.gstElementGetFactory(element)};
+    if (!factory)
+    {
+        return false;
+    }
+    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
+}
+
 bool isAudioSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
 {
     if (!element)

--- a/media/server/gstplayer/source/Utils.cpp
+++ b/media/server/gstplayer/source/Utils.cpp
@@ -40,7 +40,8 @@ bool isVideoDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, G
     {
         return false;
     }
-    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
+    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER |
+                                                               GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
 }
 
 bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
@@ -54,7 +55,8 @@ bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, G
     {
         return false;
     }
-    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
+    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER |
+                                                               GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
 }
 
 bool isVideoSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
@@ -68,7 +70,8 @@ bool isVideoSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstE
     {
         return false;
     }
-    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
+    return gstWrapper.gstElementFactoryListIsType(factory,
+                                                  GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
 }
 
 bool isAudioSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
@@ -82,7 +85,8 @@ bool isAudioSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstE
     {
         return false;
     }
-    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
+    return gstWrapper.gstElementFactoryListIsType(factory,
+                                                  GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
 }
 
 std::string getUnderflowSignalName(const firebolt::rialto::wrappers::IGlibWrapper &glibWrapper, GstElement *element)

--- a/media/server/gstplayer/source/Utils.cpp
+++ b/media/server/gstplayer/source/Utils.cpp
@@ -40,8 +40,7 @@ bool isVideoDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, G
     {
         return false;
     }
-    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER) &&
-           gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
+    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
 }
 
 bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
@@ -55,8 +54,21 @@ bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, G
     {
         return false;
     }
-    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER) &&
-           gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
+    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
+}
+
+bool isAudioSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
+{
+    if (!element)
+    {
+        return false;
+    }
+    GstElementFactory *factory{gstWrapper.gstElementGetFactory(element)};
+    if (!factory)
+    {
+        return false;
+    }
+    return gstWrapper.gstElementFactoryListIsType(factory, GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
 }
 
 std::string getUnderflowSignalName(const firebolt::rialto::wrappers::IGlibWrapper &glibWrapper, GstElement *element)

--- a/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
@@ -211,15 +211,15 @@ GenericPlayerTaskFactory::createSetTextTrackIdentifier(GenericPlayerContext &con
     return std::make_unique<tasks::generic::SetTextTrackIdentifier>(context, m_glibWrapper, textTrackIdentifier);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetLowLatency(IGstGenericPlayerPrivate &player,
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                                            bool lowLatency) const
 {
-    return std::make_unique<tasks::generic::SetLowLatency>(player, m_gstWrapper, m_glibWrapper, lowLatency);
+    return std::make_unique<tasks::generic::SetLowLatency>(context, player, m_gstWrapper, m_glibWrapper, lowLatency);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSync(IGstGenericPlayerPrivate &player, bool sync) const
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const
 {
-    return std::make_unique<tasks::generic::SetSync>(player, m_gstWrapper, m_glibWrapper, sync);
+    return std::make_unique<tasks::generic::SetSync>(context, player, m_gstWrapper, m_glibWrapper, sync);
 }
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSyncOff(IGstGenericPlayerPrivate &player, bool syncOff) const

--- a/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
@@ -214,23 +214,23 @@ GenericPlayerTaskFactory::createSetTextTrackIdentifier(GenericPlayerContext &con
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                                            bool lowLatency) const
 {
-    return std::make_unique<tasks::generic::SetLowLatency>(context, player, m_gstWrapper, m_glibWrapper, lowLatency);
+    return std::make_unique<tasks::generic::SetLowLatency>(context, player, lowLatency);
 }
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const
 {
-    return std::make_unique<tasks::generic::SetSync>(context, player, m_gstWrapper, m_glibWrapper, sync);
+    return std::make_unique<tasks::generic::SetSync>(context, player, sync);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSyncOff(IGstGenericPlayerPrivate &player, bool syncOff) const
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool syncOff) const
 {
-    return std::make_unique<tasks::generic::SetSyncOff>(player, m_gstWrapper, m_glibWrapper, syncOff);
+    return std::make_unique<tasks::generic::SetSyncOff>(context, player, syncOff);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetStreamSyncMode(IGstGenericPlayerPrivate &player,
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                                                int32_t streamSyncMode) const
 {
-    return std::make_unique<tasks::generic::SetStreamSyncMode>(player, m_gstWrapper, m_glibWrapper, streamSyncMode);
+    return std::make_unique<tasks::generic::SetStreamSyncMode>(context, player, streamSyncMode);
 }
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createShutdown(IGstGenericPlayerPrivate &player) const
@@ -262,7 +262,7 @@ std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createUpdatePlaybackGroup
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createRenderFrame(GenericPlayerContext &context,
                                                                          IGstGenericPlayerPrivate &player) const
 {
-    return std::make_unique<tasks::generic::RenderFrame>(context, m_gstWrapper, m_glibWrapper, player);
+    return std::make_unique<tasks::generic::RenderFrame>(context, player);
 }
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createPing(std::unique_ptr<IHeartbeatHandler> &&heartbeatHandler) const

--- a/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
@@ -211,23 +211,28 @@ GenericPlayerTaskFactory::createSetTextTrackIdentifier(GenericPlayerContext &con
     return std::make_unique<tasks::generic::SetTextTrackIdentifier>(context, m_glibWrapper, textTrackIdentifier);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetLowLatency(GenericPlayerContext &context,
+                                                                           IGstGenericPlayerPrivate &player,
                                                                            bool lowLatency) const
 {
     return std::make_unique<tasks::generic::SetLowLatency>(context, player, lowLatency);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool sync) const
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSync(GenericPlayerContext &context,
+                                                                     IGstGenericPlayerPrivate &player, bool sync) const
 {
     return std::make_unique<tasks::generic::SetSync>(context, player, sync);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSyncOff(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool syncOff) const
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetSyncOff(GenericPlayerContext &context,
+                                                                        IGstGenericPlayerPrivate &player,
+                                                                        bool syncOff) const
 {
     return std::make_unique<tasks::generic::SetSyncOff>(context, player, syncOff);
 }
 
-std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createSetStreamSyncMode(GenericPlayerContext &context,
+                                                                               IGstGenericPlayerPrivate &player,
                                                                                int32_t streamSyncMode) const
 {
     return std::make_unique<tasks::generic::SetStreamSyncMode>(context, player, streamSyncMode);

--- a/media/server/gstplayer/source/tasks/generic/RenderFrame.cpp
+++ b/media/server/gstplayer/source/tasks/generic/RenderFrame.cpp
@@ -22,8 +22,7 @@
 
 namespace firebolt::rialto::server::tasks::generic
 {
-RenderFrame::RenderFrame(GenericPlayerContext &context,
-                         IGstGenericPlayerPrivate &player)
+RenderFrame::RenderFrame(GenericPlayerContext &context, IGstGenericPlayerPrivate &player)
     : m_context{context}, m_player{player}
 {
     RIALTO_SERVER_LOG_DEBUG("Constructing RenderFrame");

--- a/media/server/gstplayer/source/tasks/generic/SetLowLatency.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetLowLatency.cpp
@@ -22,8 +22,7 @@
 
 namespace firebolt::rialto::server::tasks::generic
 {
-SetLowLatency::SetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
-                             bool lowLatency)
+SetLowLatency::SetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player, bool lowLatency)
     : m_context(context), m_player(player), m_lowLatency{lowLatency}
 {
     RIALTO_SERVER_LOG_DEBUG("Constructing SetLowLatency");

--- a/media/server/gstplayer/source/tasks/generic/SetLowLatency.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetLowLatency.cpp
@@ -23,11 +23,11 @@
 
 namespace firebolt::rialto::server::tasks::generic
 {
-SetLowLatency::SetLowLatency(IGstGenericPlayerPrivate &player,
+SetLowLatency::SetLowLatency(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                              const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                              const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
                              bool lowLatency)
-    : m_player(player), m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}, m_lowLatency{lowLatency}
+    : m_context(context), m_player(player), m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}, m_lowLatency{lowLatency}
 {
     RIALTO_SERVER_LOG_DEBUG("Constructing SetLowLatency");
 }
@@ -57,7 +57,8 @@ void SetLowLatency::execute() const
     }
     else
     {
-        RIALTO_SERVER_LOG_ERROR("Failed to set low-latency property, sink is NULL");
+        RIALTO_SERVER_LOG_DEBUG("No sink attahced to the pipeline, queueing low latency");
+        m_context.lowLatency = m_lowLatency;
     }
 }
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/generic/SetSync.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetSync.cpp
@@ -23,10 +23,10 @@
 
 namespace firebolt::rialto::server::tasks::generic
 {
-SetSync::SetSync(IGstGenericPlayerPrivate &player,
+SetSync::SetSync(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                  const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                  const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper, bool sync)
-    : m_player(player), m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}, m_sync{sync}
+    : m_context(context), m_player(player), m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}, m_sync{sync}
 {
     RIALTO_SERVER_LOG_DEBUG("Constructing SetSync");
 }
@@ -57,6 +57,7 @@ void SetSync::execute() const
     else
     {
         RIALTO_SERVER_LOG_ERROR("Failed to set sync property, sink is NULL");
+        m_context.sync = m_sync;
     }
 }
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/generic/SetSync.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetSync.cpp
@@ -38,7 +38,7 @@ void SetSync::execute() const
     m_context.pendingSync = m_sync;
     if (m_context.pipeline)
     {
-        m_player.setLowLatency();
+        m_player.setSync();
     }
 }
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
@@ -241,6 +241,34 @@ void SetupElement::execute() const
                                           &m_player);
         }
     }
+    else if (isAudioSink(*m_gstWrapper, m_element))
+    {
+        GstElement *actualSink = m_player.getSinkChildIfAutoAudioSink(m_element);
+        if (m_context.lowLatency.has_value())
+        {
+            if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(actualSink), "low-latency"))
+            {
+                m_glibWrapper->gObjectSet(actualSink, "low-latency", m_context.lowLatency.value(), nullptr);
+            }
+            else
+            {
+                RIALTO_SERVER_LOG_WARN("Failed to set low-latency property on sink '%s'", GST_ELEMENT_NAME(actualSink));
+            }
+            m_context.lowLatency.reset();
+        }
+        if (m_context.sync.has_value())
+        {
+            if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(actualSink), "sync"))
+            {
+                m_glibWrapper->gObjectSet(actualSink, "sync", m_context.sync.value(), nullptr);
+            }
+            else
+            {
+                RIALTO_SERVER_LOG_WARN("Failed to set sync property on sink '%s'", GST_ELEMENT_NAME(actualSink));
+            }
+            m_context.sync.reset();
+        }
+    }
 
     m_gstWrapper->gstObjectUnref(m_element);
 }

--- a/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
@@ -218,10 +218,13 @@ void SetupElement::execute() const
         {
             m_player.setVideoSinkRectangle();
         }
-
         if (m_context.pendingImmediateOutputForVideo.has_value())
         {
             m_player.setImmediateOutput();
+        }
+        if (m_context.pendingRenderFrame)
+        {
+            m_player.setRenderFrame();
         }
     }
     else if (isVideoDecoder(*m_gstWrapper, m_element))

--- a/tests/common/externalLibraryMocks/GlibWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GlibWrapperMock.h
@@ -55,7 +55,7 @@ public:
                 gboolean val = va_arg(args, gboolean);
                 gObjectSetBoolStub(object, kProperty, val);
             }
-            else if (g_strcmp0(kProperty, "stream-sync-mode") == 0)
+            else if (g_strcmp0(kProperty, "stream-sync-mode") == 0 || g_strcmp0(kProperty, "frame-step-on-preroll") == 0)
             {
                 gint val = va_arg(args, gint);
                 gObjectSetIntStub(object, kProperty, val);

--- a/tests/componenttests/server/tests/mediaPipeline/RenderFrameTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/RenderFrameTest.cpp
@@ -61,9 +61,11 @@ public:
         EXPECT_CALL(*m_glibWrapperMock,
                     gObjectClassFindProperty(G_OBJECT_GET_CLASS(m_videoSink), StrEq("frame-step-on-preroll")))
             .WillOnce(Return(&m_paramSpec));
-        EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(_, StrEq("frame-step-on-preroll"))).Times(2);
+
+        EXPECT_CALL(*m_glibWrapperMock, gObjectSetIntStub(_, StrEq("frame-step-on-preroll"), 1)).Times(1);
         EXPECT_CALL(*m_gstWrapperMock, gstEventNewStep(GST_FORMAT_BUFFERS, 1, 1.0, true, false))
             .WillOnce(Return(&m_newStepEvent));
+        EXPECT_CALL(*m_glibWrapperMock, gObjectSetIntStub(_, StrEq("frame-step-on-preroll"), 0)).Times(1);
         EXPECT_CALL(*m_gstWrapperMock, gstElementSendEvent(_, &m_newStepEvent));
         EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(GST_OBJECT(m_videoSink)));
     }

--- a/tests/componenttests/server/tests/mediaPipeline/UnderflowTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/UnderflowTest.cpp
@@ -84,11 +84,13 @@ public:
     {
         EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(m_audioDecoder)).WillOnce(Return(m_audioDecoder));
         EXPECT_CALL(*m_gstWrapperMock,
-                    gstElementFactoryListIsType(m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-            .WillOnce(Return(FALSE))
+                    gstElementFactoryListIsType(m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER |
+                                                                      GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+            .WillRepeatedly(Return(FALSE))
             .RetiresOnSaturation();
         EXPECT_CALL(*m_gstWrapperMock,
-                    gstElementFactoryListIsType(m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+                    gstElementFactoryListIsType(m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER |
+                                                                      GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
             .WillOnce(Return(TRUE))
             .RetiresOnSaturation();
         EXPECT_CALL(*m_glibWrapperMock, gObjectType(m_audioDecoder)).WillRepeatedly(Return(G_TYPE_PARAM));
@@ -109,8 +111,9 @@ public:
     {
         EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(m_videoDecoder)).WillOnce(Return(m_videoDecoder));
         EXPECT_CALL(*m_gstWrapperMock,
-                    gstElementFactoryListIsType(m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-            .WillOnce(Return(TRUE))
+                    gstElementFactoryListIsType(m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER |
+                                                                      GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+            .WillRepeatedly(Return(TRUE))
             .RetiresOnSaturation();
         EXPECT_CALL(*m_glibWrapperMock, gObjectType(m_videoDecoder)).WillRepeatedly(Return(G_TYPE_PARAM));
         EXPECT_CALL(*m_glibWrapperMock, gSignalConnect(_, StrEq("buffer-underflow-callback"), _, _))

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -264,13 +264,13 @@ TEST_F(GstGenericPlayerPrivateTest, shouldScheduleVideoUnderflowWithUnderflowDis
 
 TEST_F(GstGenericPlayerPrivateTest, shouldNotSetVideoRectangleWhenVideoSinkIsNull)
 {
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kVideoSinkStr), _));
     EXPECT_FALSE(m_sut->setVideoSinkRectangle());
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldNotSetVideoRectangleWhenVideoSinkDoesNotHaveRectangleProperty)
 {
-    expectGetSink(m_kVideoSinkStr, m_realElement);
+    expectGetSink(kVideoSinkStr, m_realElement);
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("rectangle"))).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement));
     EXPECT_FALSE(m_sut->setVideoSinkRectangle());
@@ -278,7 +278,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldNotSetVideoRectangleWhenVideoSinkDoesN
 
 TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangle)
 {
-    expectGetSink(m_kVideoSinkStr, m_realElement);
+    expectGetSink(kVideoSinkStr, m_realElement);
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("rectangle"))).WillOnce(Return(&m_rectangleSpec));
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(m_realElement, StrEq("rectangle")));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement));
@@ -288,7 +288,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangle)
 TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangleAutoVideoSink)
 {
     GstElement *autoVideoSinkChild = setAutoVideoSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kVideoSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -308,7 +308,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangleAutoVideoSink)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetImmediateOutputIfSinkIsNull)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingImmediateOutputForVideo = true; });
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kVideoSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -322,7 +322,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetImmediateOutputIfPropertyDoes
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingImmediateOutputForVideo = true; });
 
-    expectGetSink(m_kVideoSinkStr, m_realElement);
+    expectGetSink(kVideoSinkStr, m_realElement);
 
     expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kImmediateOutputStr);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -333,7 +333,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetImmediateOutput)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingImmediateOutputForVideo = true; });
 
-    expectGetSink(m_kVideoSinkStr, m_realElement);
+    expectGetSink(kVideoSinkStr, m_realElement);
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kImmediateOutputStr, true);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -343,7 +343,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetImmediateOutput)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetLowLatencyIfSinkIsNull)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -356,8 +356,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetLowLatencyIfSinkIsNull)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetLowLatencyIfPropertyDoesntExist)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
-    
-    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectGetSink(kAudioSinkStr, m_realElement);
 
     expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kLowLatencyStr);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -367,8 +367,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetLowLatencyIfPropertyDoesntExi
 TEST_F(GstGenericPlayerPrivateTest, shouldSetLowLatency)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
-    
-    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectGetSink(kAudioSinkStr, m_realElement);
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kLowLatencyStr, true);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -378,7 +378,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetLowLatency)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncIfSinkIsNull)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingSync = true; });
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -391,8 +391,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncIfSinkIsNull)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncIfPropertyDoesntExist)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingSync = true; });
-    
-    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectGetSink(kAudioSinkStr, m_realElement);
 
     expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncStr);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -402,8 +402,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncIfPropertyDoesntExist)
 TEST_F(GstGenericPlayerPrivateTest, shouldSetSync)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingSync = true; });
-    
-    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectGetSink(kAudioSinkStr, m_realElement);
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncStr, true);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -420,7 +420,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncOffIfDecoderIsNull)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncOffIfPropertyDoesntExist)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingSyncOff = true; });
-    
+
     expectGetDecoder(m_realElement);
 
     expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncOffStr);
@@ -431,7 +431,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncOffIfPropertyDoesntExist)
 TEST_F(GstGenericPlayerPrivateTest, shouldSetSyncOff)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingSyncOff = true; });
-    
+
     expectGetDecoder(m_realElement);
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncOffStr, true);
@@ -449,7 +449,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetStreamSyncModeIfDecoderIsNull
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetStreamSyncModeIfPropertyDoesntExist)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingStreamSyncMode = 1; });
-    
+
     expectGetDecoder(m_realElement);
 
     expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kStreamSyncModeStr);
@@ -460,7 +460,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetStreamSyncModeIfPropertyDoesn
 TEST_F(GstGenericPlayerPrivateTest, shouldSetStreamSyncMode)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingStreamSyncMode = 1; });
-    
+
     expectGetDecoder(m_realElement);
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kStreamSyncModeStr, 1);
@@ -471,7 +471,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetStreamSyncMode)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetRenderFrameIfSinkIsNull)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingRenderFrame = true; });
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kVideoSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -484,8 +484,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetRenderFrameIfSinkIsNull)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetRenderFrameIfPropertyDoesntExist)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingRenderFrame = true; });
-    
-    expectGetSink(m_kVideoSinkStr, m_realElement);
+
+    expectGetSink(kVideoSinkStr, m_realElement);
 
     expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kFrameStepOnPrerollStr);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -495,88 +495,16 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetRenderFrameIfPropertyDoesntEx
 TEST_F(GstGenericPlayerPrivateTest, shouldSetRenderFrame)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingRenderFrame = true; });
-    
-    expectGetSink(m_kVideoSinkStr, m_realElement);
+
+    expectGetSink(kVideoSinkStr, m_realElement);
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kFrameStepOnPrerollStr, 1);
-    
-    EXPECT_CALL(*m_gstWrapperMock, gstEventNewStep(GST_FORMAT_BUFFERS, 1, 1.0, true, false))
-        .WillOnce(Return(&m_event));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstEventNewStep(GST_FORMAT_BUFFERS, 1, 1.0, true, false)).WillOnce(Return(&m_event));
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetIntStub(_, StrEq(kFrameStepOnPrerollStr.c_str()), 0)).Times(1);
     EXPECT_CALL(*m_gstWrapperMock, gstElementSendEvent(m_realElement, &m_event));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
     EXPECT_TRUE(m_sut->setRenderFrame());
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldGetSink)
-{
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
-        .WillOnce(Invoke(
-            [&](gpointer object, const gchar *first_property_name, void *element)
-            {
-                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
-                *elementPtr = m_realElement;
-            }));
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return("testsink")); // Return any string except GstAutoVideoSink
-
-    EXPECT_EQ(m_realElement, m_sut->getSink(MediaSourceType::VIDEO));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldFailToGetSinkForUnknownMediaSourceType)
-{
-    EXPECT_EQ(nullptr, m_sut->getSink(MediaSourceType::UNKNOWN));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldFailToGetSinkIfStubNull)
-{
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _)).Times(1);
-
-    EXPECT_EQ(nullptr, m_sut->getSink(MediaSourceType::AUDIO));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldGetSinkChildAutoVideoSink)
-{
-    GstElement *autoVideoSinkChild = setAutoVideoSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return(kAutoVideoSinkTypeName.c_str()));
-    EXPECT_EQ(autoVideoSinkChild, m_sut->getSinkChildIfAutoVideoSink(m_realElement));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldGetSinkChildAutoAudioSink)
-{
-    GstElement *autoAudioSinkChild = setAutoAudioSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return(kAutoAudioSinkTypeName.c_str()));
-    EXPECT_EQ(autoAudioSinkChild, m_sut->getSinkChildIfAutoAudioSink(m_realElement));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldNotGetVideoSinkChildGenericSink)
-{
-    setAutoVideoSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(m_kElementTypeName.c_str()));
-    EXPECT_EQ(m_realElement, m_sut->getSinkChildIfAutoVideoSink(m_realElement));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldNotGetAudioSinkChildGenericSink)
-{
-    setAutoAudioSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(m_kElementTypeName.c_str()));
-    EXPECT_EQ(m_realElement, m_sut->getSinkChildIfAutoAudioSink(m_realElement));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldNotGetSinkChildAutoVideoSink)
-{
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return(kAutoVideoSinkTypeName.c_str()));
-    EXPECT_EQ(m_realElement, m_sut->getSinkChildIfAutoVideoSink(m_realElement));
-}
-
-TEST_F(GstGenericPlayerPrivateTest, shouldNotGetSinkChildAutoAudioSink)
-{
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return(kAutoAudioSinkTypeName.c_str()));
-    EXPECT_EQ(m_realElement, m_sut->getSinkChildIfAutoAudioSink(m_realElement));
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldNotifyNeedAudioData)

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -296,7 +296,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangleAutoVideoSink)
                 *elementPtr = m_realElement;
             }));
     EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return(kAutoAudioSinkTypeName.c_str()));
+        .WillOnce(Return(kAutoVideoSinkTypeName.c_str()));
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("rectangle"))).WillOnce(Return(&m_rectangleSpec));
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(autoVideoSinkChild, StrEq("rectangle")));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(GST_OBJECT(autoVideoSinkChild))).WillOnce(Return(autoVideoSinkChild));
@@ -379,8 +379,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetLowLatencyAutoAudioSink)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
 
-    GstElement *autoVideoSinkChild = setAutoAudioSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kVideoSinkStr), _))
+    GstElement *autoAudioSinkChild = setAutoAudioSinkChild();
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -388,10 +388,12 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetLowLatencyAutoAudioSink)
                 *elementPtr = m_realElement;
             }));
     EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return(kAutoVideoSinkTypeName.c_str()));
+        .WillOnce(Return(kAutoAudioSinkTypeName.c_str()));
 
-    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, autoVideoSinkChild, kLowLatencyStr, true);
-    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(autoVideoSinkChild)).Times(1);
+    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, autoAudioSinkChild, kLowLatencyStr, true);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(GST_OBJECT(autoAudioSinkChild))).WillOnce(Return(autoAudioSinkChild));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(autoAudioSinkChild));
     EXPECT_TRUE(m_sut->setLowLatency());
 }
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -67,9 +67,13 @@ const std::shared_ptr<firebolt::rialto::CodecData> kCodecDataWithString{std::mak
                                 firebolt::rialto::CodecDataType::STRING})};
 const std::string kAutoVideoSinkTypeName{"GstAutoVideoSink"};
 const std::string kAutoAudioSinkTypeName{"GstAutoAudioSink"};
-const std::string kElementTypeName{"GenericSink"};
 constexpr bool kResetTime{true};
 const std::string kImmediateOutputStr{"immediate-output"};
+const std::string kLowLatencyStr{"low-latency"};
+const std::string kSyncStr{"sync"};
+const std::string kSyncOffStr{"sync-off"};
+const std::string kStreamSyncModeStr{"stream-sync-mode"};
+const std::string kFrameStepOnPrerollStr{"frame-step-on-preroll"};
 } // namespace
 
 bool operator==(const GstRialtoProtectionData &lhs, const GstRialtoProtectionData &rhs)
@@ -88,6 +92,7 @@ protected:
     GstElement *m_realElement;
     GstElement m_element{};
     GParamSpec m_rectangleSpec{};
+    GstEvent m_event{};
 
     GstGenericPlayerPrivateTest()
     {
@@ -259,20 +264,13 @@ TEST_F(GstGenericPlayerPrivateTest, shouldScheduleVideoUnderflowWithUnderflowDis
 
 TEST_F(GstGenericPlayerPrivateTest, shouldNotSetVideoRectangleWhenVideoSinkIsNull)
 {
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _));
     EXPECT_FALSE(m_sut->setVideoSinkRectangle());
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldNotSetVideoRectangleWhenVideoSinkDoesNotHaveRectangleProperty)
 {
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _))
-        .WillOnce(Invoke(
-            [&](gpointer object, const gchar *first_property_name, void *element)
-            {
-                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
-                *elementPtr = m_realElement;
-            }));
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(kElementTypeName.c_str()));
+    expectGetSink(m_kVideoSinkStr, m_realElement);
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("rectangle"))).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement));
     EXPECT_FALSE(m_sut->setVideoSinkRectangle());
@@ -280,14 +278,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldNotSetVideoRectangleWhenVideoSinkDoesN
 
 TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangle)
 {
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _))
-        .WillOnce(Invoke(
-            [&](gpointer object, const gchar *first_property_name, void *element)
-            {
-                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
-                *elementPtr = m_realElement;
-            }));
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(kElementTypeName.c_str()));
+    expectGetSink(m_kVideoSinkStr, m_realElement);
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("rectangle"))).WillOnce(Return(&m_rectangleSpec));
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(m_realElement, StrEq("rectangle")));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement));
@@ -297,7 +288,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangle)
 TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangleAutoVideoSink)
 {
     GstElement *autoVideoSinkChild = setAutoVideoSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -317,7 +308,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangleAutoVideoSink)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetImmediateOutputIfSinkIsNull)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingImmediateOutputForVideo = true; });
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -330,15 +321,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetImmediateOutputIfSinkIsNull)
 TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetImmediateOutputIfPropertyDoesntExist)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingImmediateOutputForVideo = true; });
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _))
-        .WillOnce(Invoke(
-            [&](gpointer object, const gchar *first_property_name, void *element)
-            {
-                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
-                *elementPtr = m_realElement;
-            }));
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return("testsink")); // Return any string except GstAutoVideoSink
+
+    expectGetSink(m_kVideoSinkStr, m_realElement);
 
     expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kImmediateOutputStr);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
@@ -348,24 +332,185 @@ TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetImmediateOutputIfPropertyDoes
 TEST_F(GstGenericPlayerPrivateTest, shouldSetImmediateOutput)
 {
     modifyContext([&](GenericPlayerContext &context) { context.pendingImmediateOutputForVideo = true; });
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _))
-        .WillOnce(Invoke(
-            [&](gpointer object, const gchar *first_property_name, void *element)
-            {
-                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
-                *elementPtr = m_realElement;
-            }));
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return("testsink")); // Return any string except GstAutoVideoSink
+
+    expectGetSink(m_kVideoSinkStr, m_realElement);
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kImmediateOutputStr, true);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
     EXPECT_TRUE(m_sut->setImmediateOutput());
 }
 
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetLowLatencyIfSinkIsNull)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+        .WillOnce(Invoke(
+            [&](gpointer object, const gchar *first_property_name, void *element)
+            {
+                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
+                *elementPtr = nullptr;
+            }));
+    EXPECT_FALSE(m_sut->setLowLatency());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetLowLatencyIfPropertyDoesntExist)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
+    
+    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kLowLatencyStr);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_FALSE(m_sut->setLowLatency());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldSetLowLatency)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
+    
+    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kLowLatencyStr, true);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_TRUE(m_sut->setLowLatency());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncIfSinkIsNull)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingSync = true; });
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+        .WillOnce(Invoke(
+            [&](gpointer object, const gchar *first_property_name, void *element)
+            {
+                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
+                *elementPtr = nullptr;
+            }));
+    EXPECT_FALSE(m_sut->setSync());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncIfPropertyDoesntExist)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingSync = true; });
+    
+    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncStr);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_FALSE(m_sut->setSync());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldSetSync)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingSync = true; });
+    
+    expectGetSink(m_kAudioSinkStr, m_realElement);
+
+    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncStr, true);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_TRUE(m_sut->setSync());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncOffIfDecoderIsNull)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingSyncOff = true; });
+    expectNoDecoder();
+    EXPECT_FALSE(m_sut->setSyncOff());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetSyncOffIfPropertyDoesntExist)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingSyncOff = true; });
+    
+    expectGetDecoder(m_realElement);
+
+    expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncOffStr);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_FALSE(m_sut->setSyncOff());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldSetSyncOff)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingSyncOff = true; });
+    
+    expectGetDecoder(m_realElement);
+
+    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kSyncOffStr, true);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_TRUE(m_sut->setSyncOff());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetStreamSyncModeIfDecoderIsNull)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingStreamSyncMode = 1; });
+    expectNoDecoder();
+    EXPECT_FALSE(m_sut->setStreamSyncMode());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetStreamSyncModeIfPropertyDoesntExist)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingStreamSyncMode = 1; });
+    
+    expectGetDecoder(m_realElement);
+
+    expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kStreamSyncModeStr);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_FALSE(m_sut->setStreamSyncMode());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldSetStreamSyncMode)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingStreamSyncMode = 1; });
+    
+    expectGetDecoder(m_realElement);
+
+    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kStreamSyncModeStr, 1);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_TRUE(m_sut->setStreamSyncMode());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetRenderFrameIfSinkIsNull)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingRenderFrame = true; });
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
+        .WillOnce(Invoke(
+            [&](gpointer object, const gchar *first_property_name, void *element)
+            {
+                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
+                *elementPtr = nullptr;
+            }));
+    EXPECT_FALSE(m_sut->setRenderFrame());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldFailToSetRenderFrameIfPropertyDoesntExist)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingRenderFrame = true; });
+    
+    expectGetSink(m_kVideoSinkStr, m_realElement);
+
+    expectPropertyDoesntExist(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kFrameStepOnPrerollStr);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_FALSE(m_sut->setRenderFrame());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldSetRenderFrame)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingRenderFrame = true; });
+    
+    expectGetSink(m_kVideoSinkStr, m_realElement);
+
+    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kFrameStepOnPrerollStr, 1);
+    
+    EXPECT_CALL(*m_gstWrapperMock, gstEventNewStep(GST_FORMAT_BUFFERS, 1, 1.0, true, false))
+        .WillOnce(Return(&m_event));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectSetIntStub(_, StrEq(kFrameStepOnPrerollStr.c_str()), 0)).Times(1);
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSendEvent(m_realElement, &m_event));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_TRUE(m_sut->setRenderFrame());
+}
+
 TEST_F(GstGenericPlayerPrivateTest, shouldGetSink)
 {
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("video-sink"), _))
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kVideoSinkStr), _))
         .WillOnce(Invoke(
             [&](gpointer object, const gchar *first_property_name, void *element)
             {
@@ -409,14 +554,14 @@ TEST_F(GstGenericPlayerPrivateTest, shouldGetSinkChildAutoAudioSink)
 TEST_F(GstGenericPlayerPrivateTest, shouldNotGetVideoSinkChildGenericSink)
 {
     setAutoVideoSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(m_kElementTypeName.c_str()));
     EXPECT_EQ(m_realElement, m_sut->getSinkChildIfAutoVideoSink(m_realElement));
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldNotGetAudioSinkChildGenericSink)
 {
     setAutoAudioSinkChild();
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement))).WillOnce(Return(m_kElementTypeName.c_str()));
     EXPECT_EQ(m_realElement, m_sut->getSinkChildIfAutoAudioSink(m_realElement));
 }
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -296,7 +296,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetVideoRectangleAutoVideoSink)
                 *elementPtr = m_realElement;
             }));
     EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
-        .WillOnce(Return(kAutoVideoSinkTypeName.c_str()));
+        .WillOnce(Return(kAutoAudioSinkTypeName.c_str()));
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("rectangle"))).WillOnce(Return(&m_rectangleSpec));
     EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(autoVideoSinkChild, StrEq("rectangle")));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(GST_OBJECT(autoVideoSinkChild))).WillOnce(Return(autoVideoSinkChild));
@@ -372,6 +372,26 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSetLowLatency)
 
     expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, m_realElement, kLowLatencyStr, true);
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_realElement)).Times(1);
+    EXPECT_TRUE(m_sut->setLowLatency());
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldSetLowLatencyAutoAudioSink)
+{
+    modifyContext([&](GenericPlayerContext &context) { context.pendingLowLatency = true; });
+
+    GstElement *autoVideoSinkChild = setAutoAudioSinkChild();
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kVideoSinkStr), _))
+        .WillOnce(Invoke(
+            [&](gpointer object, const gchar *first_property_name, void *element)
+            {
+                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
+                *elementPtr = m_realElement;
+            }));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_realElement)))
+        .WillOnce(Return(kAutoVideoSinkTypeName.c_str()));
+
+    expectSetProperty(m_glibWrapperMock, m_gstWrapperMock, autoVideoSinkChild, kLowLatencyStr, true);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(autoVideoSinkChild)).Times(1);
     EXPECT_TRUE(m_sut->setLowLatency());
 }
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -710,7 +710,7 @@ TEST_F(GstGenericPlayerTest, shouldSetSyncOff)
     constexpr bool kSyncOff{true};
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
-    EXPECT_CALL(m_taskFactoryMock, createSetSyncOff(_, kSyncOff)).WillOnce(Return(ByMove(std::move(task))));
+    EXPECT_CALL(m_taskFactoryMock, createSetSyncOff(_, _, kSyncOff)).WillOnce(Return(ByMove(std::move(task))));
 
     m_sut->setSyncOff(kSyncOff);
 }
@@ -720,7 +720,7 @@ TEST_F(GstGenericPlayerTest, shouldSetStreamSyncMode)
     constexpr int32_t kStreamSyncMode{1};
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
-    EXPECT_CALL(m_taskFactoryMock, createSetStreamSyncMode(_, kStreamSyncMode)).WillOnce(Return(ByMove(std::move(task))));
+    EXPECT_CALL(m_taskFactoryMock, createSetStreamSyncMode(_, _, kStreamSyncMode)).WillOnce(Return(ByMove(std::move(task))));
 
     m_sut->setStreamSyncMode(kStreamSyncMode);
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -39,11 +39,11 @@ class GstGenericPlayerTest : public GstGenericPlayerTestCommon
 protected:
     std::unique_ptr<IGstGenericPlayer> m_sut;
     VideoRequirements m_videoReq = {kMinPrimaryVideoWidth, kMinPrimaryVideoHeight};
+    GstElement *m_pipeline;
     GstIterator m_it{};
     char m_dummy{0};
     GstElementFactory *m_factory = reinterpret_cast<GstElementFactory *>(&m_dummy);
     GstElement *m_element;
-    GstElement *m_pipeline;
     GParamSpec m_prop{};
 
     GstGenericPlayerTest()
@@ -332,7 +332,7 @@ TEST_F(GstGenericPlayerTest, shouldGetImmediateOutputInPlayingState)
     const bool kTestImmediateOutputValue{true};
     const std::string kPropertyStr{"immediate-output"};
 
-    expectGetSink(m_kVideoSinkStr, m_element);
+    expectGetSink(kVideoSinkStr, m_element);
     willGetElementProperty(kPropertyStr, kTestImmediateOutputValue);
 
     bool immediateOutputState;
@@ -346,7 +346,7 @@ TEST_F(GstGenericPlayerTest, shouldGetImmediateOutputInPlayingStateForAudio)
     const bool kTestImmediateOutputValue{true};
     const std::string kPropertyStr{"immediate-output"};
 
-    expectGetSink(m_kAudioSinkStr, m_element);
+    expectGetSink(kAudioSinkStr, m_element);
     willGetElementProperty(kPropertyStr, kTestImmediateOutputValue);
 
     bool immediateOutputState;
@@ -367,7 +367,7 @@ TEST_F(GstGenericPlayerTest, shouldFailToGetImmediateOutputInPlayingStateIfStubN
     setPipelineState(GST_STATE_PLAYING);
 
     // Fail to get sink which should cause the getImmediateOutput() call to return false
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kAudioSinkStr), _)).Times(1);
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _)).Times(1);
 
     bool immediateOutputState;
     EXPECT_FALSE(m_sut->getImmediateOutput(MediaSourceType::AUDIO, immediateOutputState));
@@ -377,7 +377,7 @@ TEST_F(GstGenericPlayerTest, shouldFailToGetImmediateOutputInPlayingStateIfPrope
 {
     setPipelineState(GST_STATE_PLAYING);
 
-    expectGetSink(m_kVideoSinkStr, m_element);
+    expectGetSink(kVideoSinkStr, m_element);
 
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("immediate-output"))).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_element)).Times(1);
@@ -394,7 +394,7 @@ TEST_F(GstGenericPlayerTest, shouldGetStatsInPlayingState)
     uint64_t returnedDroppedFrames{};
     setPipelineState(GST_STATE_PLAYING);
 
-    expectGetSink(m_kVideoSinkStr, m_element);
+    expectGetSink(kVideoSinkStr, m_element);
 
     GstStructure testStructure;
     EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("stats"), _))
@@ -431,7 +431,7 @@ TEST_F(GstGenericPlayerTest, shouldFailToGetStatsInPlayingStateIfStubNull)
     setPipelineState(GST_STATE_PLAYING);
 
     // Fail to get sink which should cause the getStats() call to return false
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kAudioSinkStr), _)).Times(1);
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _)).Times(1);
 
     uint64_t returnedRenderedFrames;
     uint64_t returnedDroppedFrames;
@@ -442,7 +442,7 @@ TEST_F(GstGenericPlayerTest, shouldFailToGetStatsInPlayingStateIfStructureNull)
 {
     setPipelineState(GST_STATE_PLAYING);
 
-    expectGetSink(m_kAudioSinkStr, m_element);
+    expectGetSink(kAudioSinkStr, m_element);
 
     // Fail to get GstStructure which should cause the getStats() call to return false
     EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("stats"), _)).Times(1);
@@ -457,7 +457,7 @@ TEST_F(GstGenericPlayerTest, shouldFailToGetStatsInPlayingStateIfStructIncomplet
 {
     setPipelineState(GST_STATE_PLAYING);
 
-    expectGetSink(m_kVideoSinkStr, m_element);
+    expectGetSink(kVideoSinkStr, m_element);
 
     GstStructure testStructure;
     EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("stats"), _))
@@ -644,7 +644,7 @@ TEST_F(GstGenericPlayerTest, shouldGetSync)
     const bool kSyncValue{true};
     const std::string kPropertyStr{"sync"};
 
-    expectGetSink(m_kAudioSinkStr, m_element);
+    expectGetSink(kAudioSinkStr, m_element);
     willGetElementProperty(kPropertyStr, kSyncValue);
 
     bool sync;
@@ -654,7 +654,7 @@ TEST_F(GstGenericPlayerTest, shouldGetSync)
 
 TEST_F(GstGenericPlayerTest, shouldFailToGetSyncIfStubNull)
 {
-    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(m_kAudioSinkStr), _)).Times(1);
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _)).Times(1);
 
     bool sync;
     EXPECT_FALSE(m_sut->getSync(sync));
@@ -662,7 +662,7 @@ TEST_F(GstGenericPlayerTest, shouldFailToGetSyncIfStubNull)
 
 TEST_F(GstGenericPlayerTest, shouldFailToGetSyncIfPropertyDoesntExist)
 {
-    expectGetSink(m_kAudioSinkStr, m_element);
+    expectGetSink(kAudioSinkStr, m_element);
 
     EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("sync"))).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_element)).Times(1);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -658,7 +658,7 @@ TEST_F(GstGenericPlayerTest, shouldSetLowLatency)
     constexpr bool kLowLatency{true};
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
-    EXPECT_CALL(m_taskFactoryMock, createSetLowLatency(_, kLowLatency)).WillOnce(Return(ByMove(std::move(task))));
+    EXPECT_CALL(m_taskFactoryMock, createSetLowLatency(_, _, kLowLatency)).WillOnce(Return(ByMove(std::move(task))));
 
     m_sut->setLowLatency(kLowLatency);
 }
@@ -668,7 +668,7 @@ TEST_F(GstGenericPlayerTest, shouldSetSync)
     constexpr bool kSync{true};
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
-    EXPECT_CALL(m_taskFactoryMock, createSetSync(_, kSync)).WillOnce(Return(ByMove(std::move(task))));
+    EXPECT_CALL(m_taskFactoryMock, createSetSync(_, _, kSync)).WillOnce(Return(ByMove(std::move(task))));
 
     m_sut->setSync(kSync);
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -652,6 +652,18 @@ TEST_F(GstGenericPlayerTest, shouldGetSync)
     EXPECT_EQ(sync, kSyncValue);
 }
 
+TEST_F(GstGenericPlayerTest, shouldGetPendingSyncIfNoSinkAvailable)
+{
+    const bool kSyncValue{true};
+
+    getContext([&](GenericPlayerContext &m_context) { m_context.pendingSync = kSyncValue; });
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _)).Times(1);
+
+    bool sync;
+    EXPECT_TRUE(m_sut->getSync(sync));
+    EXPECT_EQ(sync, kSyncValue);
+}
+
 TEST_F(GstGenericPlayerTest, shouldFailToGetSyncIfStubNull)
 {
     EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(kAudioSinkStr), _)).Times(1);
@@ -698,6 +710,18 @@ TEST_F(GstGenericPlayerTest, shouldGetStreamSyncMode)
 
     expectGetDecoder(m_element);
     willGetElementProperty(kPropertyStr, kStreamSyncModeValue);
+
+    int32_t streamSyncMode;
+    EXPECT_TRUE(m_sut->getStreamSyncMode(streamSyncMode));
+    EXPECT_EQ(streamSyncMode, kStreamSyncModeValue);
+}
+
+TEST_F(GstGenericPlayerTest, shouldGetPendingStreamSyncModeIfNoSinkAvailable)
+{
+    constexpr int32_t kStreamSyncModeValue{1};
+
+    getContext([&](GenericPlayerContext &m_context) { m_context.pendingStreamSyncMode = kStreamSyncModeValue; });
+    expectNoDecoder();
 
     int32_t streamSyncMode;
     EXPECT_TRUE(m_sut->getStreamSyncMode(streamSyncMode));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -495,6 +495,66 @@ void GenericTasksTestsBase::shouldSetupVideoElementWithPendingImmediateOutput()
     expectSetupVideoElement();
 }
 
+void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingLowLatency()
+{
+    testContext->m_context.pendingLowLatency = true;
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
+
+    // This is the extra EXPECT caused by setting pendingLowLatency...
+    EXPECT_CALL(testContext->m_gstPlayer, setLowLatency());
+    expectSetupAudioElement();
+}
+
+void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingSync()
+{
+    testContext->m_context.pendingSync = true;
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
+
+    // This is the extra EXPECT caused by setting pendingSync...
+    EXPECT_CALL(testContext->m_gstPlayer, setSync());
+    expectSetupAudioElement();
+}
+
+void GenericTasksTestsBase::shouldSetupAudioDecoderElementWithPendingSyncOff()
+{
+    testContext->m_context.pendingSyncOff = true;
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
+
+    // This is the extra EXPECT caused by setting pendingSyncOff...
+    EXPECT_CALL(testContext->m_gstPlayer, setSyncOff());
+    expectSetupAudioElement();
+}
+
+void GenericTasksTestsBase::shouldSetupAudioDecoderElementWithPendingStreamSyncMode()
+{
+    testContext->m_context.pendingStreamSyncMode = true;
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
+
+    // This is the extra EXPECT caused by setting pendingStreamSyncMode...
+    EXPECT_CALL(testContext->m_gstPlayer, setStreamSyncMode());
+    expectSetupAudioElement();
+}
+
 void GenericTasksTestsBase::shouldSetupVideoElementAmlhalasink()
 {
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -2882,7 +2882,7 @@ void GenericTasksTestsBase::shouldSetLowLatency()
 
 void GenericTasksTestsBase::triggerSetLowLatency()
 {
-    firebolt::rialto::server::tasks::generic::SetLowLatency task{testContext->m_gstPlayer, testContext->m_gstWrapper,
+    firebolt::rialto::server::tasks::generic::SetLowLatency task{testContext->m_context, testContext->m_gstPlayer, testContext->m_gstWrapper,
                                                                  testContext->m_glibWrapper, true};
     task.execute();
 }
@@ -2912,7 +2912,7 @@ void GenericTasksTestsBase::shouldSetSync()
 
 void GenericTasksTestsBase::triggerSetSync()
 {
-    firebolt::rialto::server::tasks::generic::SetSync task{testContext->m_gstPlayer, testContext->m_gstWrapper,
+    firebolt::rialto::server::tasks::generic::SetSync task{testContext->m_context, testContext->m_gstPlayer, testContext->m_gstWrapper,
                                                            testContext->m_glibWrapper, true};
     task.execute();
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -2470,8 +2470,7 @@ void GenericTasksTestsBase::shouldRenderFrame()
 
 void GenericTasksTestsBase::triggerRenderFrame()
 {
-    firebolt::rialto::server::tasks::generic::RenderFrame task{testContext->m_context, testContext->m_gstWrapper,
-                                                               testContext->m_glibWrapper, testContext->m_gstPlayer};
+    firebolt::rialto::server::tasks::generic::RenderFrame task{testContext->m_context, testContext->m_gstPlayer};
     task.execute();
 }
 
@@ -2853,8 +2852,7 @@ void GenericTasksTestsBase::shouldSetLowLatency()
 
 void GenericTasksTestsBase::triggerSetLowLatency()
 {
-    firebolt::rialto::server::tasks::generic::SetLowLatency task{testContext->m_context, testContext->m_gstPlayer, testContext->m_gstWrapper,
-                                                                 testContext->m_glibWrapper, true};
+    firebolt::rialto::server::tasks::generic::SetLowLatency task{testContext->m_context, testContext->m_gstPlayer, true};
     task.execute();
 }
 
@@ -2880,8 +2878,7 @@ void GenericTasksTestsBase::shouldSetSync()
 
 void GenericTasksTestsBase::triggerSetSync()
 {
-    firebolt::rialto::server::tasks::generic::SetSync task{testContext->m_context, testContext->m_gstPlayer, testContext->m_gstWrapper,
-                                                           testContext->m_glibWrapper, true};
+    firebolt::rialto::server::tasks::generic::SetSync task{testContext->m_context, testContext->m_gstPlayer, true};
     task.execute();
 }
 
@@ -2908,8 +2905,7 @@ void GenericTasksTestsBase::shouldSetSyncOff()
 
 void GenericTasksTestsBase::triggerSetSyncOff()
 {
-    firebolt::rialto::server::tasks::generic::SetSyncOff task{testContext->m_gstPlayer, testContext->m_gstWrapper,
-                                                              testContext->m_glibWrapper, true};
+    firebolt::rialto::server::tasks::generic::SetSyncOff task{testContext->m_context, testContext->m_gstPlayer, true};
     task.execute();
 }
 
@@ -2936,8 +2932,7 @@ void GenericTasksTestsBase::shouldSetStreamSyncMode()
 
 void GenericTasksTestsBase::triggerSetStreamSyncMode()
 {
-    firebolt::rialto::server::tasks::generic::SetStreamSyncMode task{testContext->m_gstPlayer, testContext->m_gstWrapper,
-                                                                     testContext->m_glibWrapper, true};
+    firebolt::rialto::server::tasks::generic::SetStreamSyncMode task{testContext->m_context, testContext->m_gstPlayer, true};
     task.execute();
 }
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -381,14 +381,26 @@ void GenericTasksTestsBase::setContextSetupSourceFinished()
     testContext->m_context.setupSourceFinished = true;
 }
 
-void GenericTasksTestsBase::expectSetupVideoElement()
+void GenericTasksTestsBase::expectSetupVideoSinkElement()
 {
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
     EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER))
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
         .WillOnce(Return(TRUE));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(_));
+}
+
+void GenericTasksTestsBase::expectSetupVideoDecoderElement()
+{
+    EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
     EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
         .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectType(testContext->m_element)).WillRepeatedly(Return(G_TYPE_PARAM));
     EXPECT_CALL(*testContext->m_glibWrapper, gSignalListIds(_, _))
@@ -411,23 +423,46 @@ void GenericTasksTestsBase::expectSetupVideoElement()
     EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(_));
 }
 
-void GenericTasksTestsBase::expectSetupAudioElement()
+void GenericTasksTestsBase::expectSetupAudioSinkElement()
 {
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-        .WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
     EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER))
-        .WillRepeatedly(Return(TRUE));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
         .WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(_));
+}
+
+void GenericTasksTestsBase::expectSetupAudioDecoderElement()
+{
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
         .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectType(testContext->m_element)).WillRepeatedly(Return(G_TYPE_PARAM));
     EXPECT_CALL(*testContext->m_glibWrapper, gSignalListIds(_, _))
@@ -450,17 +485,22 @@ void GenericTasksTestsBase::expectSetupAudioElement()
     EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(_));
 }
 
-void GenericTasksTestsBase::shouldSetupVideoElementOnly()
+void GenericTasksTestsBase::shouldSetupVideoSinkElementOnly()
 {
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-        .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
-    expectSetupVideoElement();
+    expectSetupVideoSinkElement();
+}
+
+void GenericTasksTestsBase::shouldSetupVideoDecoderElementOnly()
+{
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
+    expectSetupVideoDecoderElement();
 }
 
 void GenericTasksTestsBase::shouldSetupVideoElementWithPendingGeometry()
@@ -468,15 +508,11 @@ void GenericTasksTestsBase::shouldSetupVideoElementWithPendingGeometry()
     testContext->m_context.pendingGeometry = kRectangle;
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-        .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     // This is the extra EXPECT caused by setting pendingGeometry...
     EXPECT_CALL(testContext->m_gstPlayer, setVideoSinkRectangle());
-    expectSetupVideoElement();
+    expectSetupVideoSinkElement();
 }
 
 void GenericTasksTestsBase::shouldSetupVideoElementWithPendingImmediateOutput()
@@ -484,15 +520,11 @@ void GenericTasksTestsBase::shouldSetupVideoElementWithPendingImmediateOutput()
     testContext->m_context.pendingImmediateOutputForVideo = true;
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-        .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     // This is the extra EXPECT caused by setting pendingImmediateOutputForVideo...
     EXPECT_CALL(testContext->m_gstPlayer, setImmediateOutput());
-    expectSetupVideoElement();
+    expectSetupVideoSinkElement();
 }
 
 void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingLowLatency()
@@ -500,14 +532,10 @@ void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingLowLatency()
     testContext->m_context.pendingLowLatency = true;
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
-        .WillOnce(Return(TRUE));
 
     // This is the extra EXPECT caused by setting pendingLowLatency...
     EXPECT_CALL(testContext->m_gstPlayer, setLowLatency());
-    expectSetupAudioElement();
+    expectSetupAudioSinkElement();
 }
 
 void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingSync()
@@ -515,14 +543,10 @@ void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingSync()
     testContext->m_context.pendingSync = true;
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
-        .WillOnce(Return(TRUE));
 
     // This is the extra EXPECT caused by setting pendingSync...
     EXPECT_CALL(testContext->m_gstPlayer, setSync());
-    expectSetupAudioElement();
+    expectSetupAudioSinkElement();
 }
 
 void GenericTasksTestsBase::shouldSetupAudioDecoderElementWithPendingSyncOff()
@@ -530,14 +554,10 @@ void GenericTasksTestsBase::shouldSetupAudioDecoderElementWithPendingSyncOff()
     testContext->m_context.pendingSyncOff = true;
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
-        .WillOnce(Return(TRUE));
 
     // This is the extra EXPECT caused by setting pendingSyncOff...
     EXPECT_CALL(testContext->m_gstPlayer, setSyncOff());
-    expectSetupAudioElement();
+    expectSetupAudioDecoderElement();
 }
 
 void GenericTasksTestsBase::shouldSetupAudioDecoderElementWithPendingStreamSyncMode()
@@ -545,52 +565,55 @@ void GenericTasksTestsBase::shouldSetupAudioDecoderElementWithPendingStreamSyncM
     testContext->m_context.pendingStreamSyncMode = true;
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
-        .WillOnce(Return(TRUE));
 
     // This is the extra EXPECT caused by setting pendingStreamSyncMode...
     EXPECT_CALL(testContext->m_gstPlayer, setStreamSyncMode());
-    expectSetupAudioElement();
+    expectSetupAudioDecoderElement();
+}
+
+void GenericTasksTestsBase::shouldSetupVideoSinkElementWithPendingRenderFrame()
+{
+    testContext->m_context.pendingRenderFrame = true;
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
+
+    // This is the extra EXPECT caused by setting pendingRenderFrame...
+    EXPECT_CALL(testContext->m_gstPlayer, setRenderFrame());
+    expectSetupVideoSinkElement();
 }
 
 void GenericTasksTestsBase::shouldSetupVideoElementAmlhalasink()
 {
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-        .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("wait-video")));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("a-wait-timeout")));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("disable-xrun")));
-    expectSetupVideoElement();
+    expectSetupVideoSinkElement();
 }
 
 void GenericTasksTestsBase::shouldSetupAudioElementBrcmAudioSink()
 {
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-        .WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("async")));
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
     EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER))
-        .WillRepeatedly(Return(TRUE));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
         .WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
         .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectType(testContext->m_element)).WillRepeatedly(Return(G_TYPE_PARAM));
     EXPECT_CALL(*testContext->m_glibWrapper, gSignalListIds(_, _))
@@ -651,12 +674,8 @@ void GenericTasksTestsBase::shouldSetupVideoElementAutoVideoSink()
         .WillOnce(Return(&testContext->m_iterator));
     EXPECT_CALL(*testContext->m_glibWrapper, gValueUnset(_));
     EXPECT_CALL(*testContext->m_gstWrapper, gstIteratorFree(&testContext->m_iterator));
-    EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory,
-                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
-        .WillOnce(Return(TRUE));
 
-    expectSetupVideoElement();
+    expectSetupVideoSinkElement();
 }
 
 void GenericTasksTestsBase::shouldSetupAudioElementAutoAudioSink()
@@ -685,15 +704,23 @@ void GenericTasksTestsBase::shouldSetupAudioElementAutoAudioSink()
     EXPECT_CALL(*testContext->m_glibWrapper, gValueUnset(_));
     EXPECT_CALL(*testContext->m_gstWrapper, gstIteratorFree(&testContext->m_iterator));
 
-    expectSetupAudioElement();
+    expectSetupAudioSinkElement();
 }
 
-void GenericTasksTestsBase::shouldSetupAudioElementOnly()
+void GenericTasksTestsBase::shouldSetupAudioSinkElementOnly()
 {
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
 
-    expectSetupAudioElement();
+    expectSetupAudioSinkElement();
+}
+
+void GenericTasksTestsBase::shouldSetupAudioDecoderElementOnly()
+{
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+
+    expectSetupAudioDecoderElement();
 }
 
 void GenericTasksTestsBase::shouldSetVideoUnderflowCallback()
@@ -2515,28 +2542,13 @@ void GenericTasksTestsBase::checkSegmentInfo()
 
 void GenericTasksTestsBase::shouldRenderFrame()
 {
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::VIDEO)).WillOnce(Return(&testContext->m_childElement));
-    EXPECT_CALL(*testContext->m_glibWrapper, gObjectClassFindProperty(G_OBJECT_GET_CLASS(&testContext->m_childElement),
-                                                                      StrEq("frame-step-on-preroll")))
-        .WillOnce(Return(&testContext->m_paramSpec));
-    EXPECT_CALL(*testContext->m_glibWrapper,
-                gObjectSetStub(&testContext->m_childElement, StrEq("frame-step-on-preroll")))
-        .Times(2);
-    EXPECT_CALL(*testContext->m_gstWrapper, gstEventNewStep(GST_FORMAT_BUFFERS, 1, 1.0, true, false))
-        .WillOnce(Return(&testContext->m_event));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstElementSendEvent(&testContext->m_childElement, &testContext->m_event));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(&testContext->m_childElement)));
+    EXPECT_CALL(testContext->m_gstPlayer, setRenderFrame()).WillOnce(Return(true));
 }
 
 void GenericTasksTestsBase::triggerRenderFrame()
 {
     firebolt::rialto::server::tasks::generic::RenderFrame task{testContext->m_context, testContext->m_gstPlayer};
     task.execute();
-}
-
-void GenericTasksTestsBase::shouldGetVideoSinkFailure()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::VIDEO)).WillOnce(Return(nullptr));
 }
 
 void GenericTasksTestsBase::shouldFindPropertyFailure()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -2880,7 +2880,7 @@ void GenericTasksTestsBase::triggerFailToCastDolbyVisionSource()
     EXPECT_EQ(testContext->m_context.streamInfo.end(),
               testContext->m_context.streamInfo.find(firebolt::rialto::MediaSourceType::VIDEO));
 }
-// TODO: PIPELINE NULL
+
 void GenericTasksTestsBase::shouldSetImmediateOutput()
 {
     EXPECT_CALL(testContext->m_gstPlayer, setImmediateOutput()).WillOnce(Return(true));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -2551,15 +2551,6 @@ void GenericTasksTestsBase::triggerRenderFrame()
     task.execute();
 }
 
-void GenericTasksTestsBase::shouldFindPropertyFailure()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::VIDEO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_glibWrapper,
-                gObjectClassFindProperty(G_OBJECT_GET_CLASS(testContext->m_element), StrEq("frame-step-on-preroll")))
-        .WillOnce(Return(nullptr));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element)));
-}
-
 void GenericTasksTestsBase::shouldInvalidateActiveAudioRequests()
 {
     EXPECT_CALL(testContext->m_gstPlayerClient, invalidateActiveRequests(firebolt::rialto::MediaSourceType::AUDIO));
@@ -2888,7 +2879,7 @@ void GenericTasksTestsBase::triggerFailToCastDolbyVisionSource()
     EXPECT_EQ(testContext->m_context.streamInfo.end(),
               testContext->m_context.streamInfo.find(firebolt::rialto::MediaSourceType::VIDEO));
 }
-
+// TODO: PIPELINE NULL
 void GenericTasksTestsBase::shouldSetImmediateOutput()
 {
     EXPECT_CALL(testContext->m_gstPlayer, setImmediateOutput()).WillOnce(Return(true));
@@ -2899,123 +2890,58 @@ void GenericTasksTestsBase::triggerSetImmediateOutput()
     firebolt::rialto::server::tasks::generic::SetImmediateOutput task{testContext->m_context, testContext->m_gstPlayer,
                                                                       MediaSourceType::VIDEO, true};
     task.execute();
-}
 
-void GenericTasksTestsBase::shouldFailToSetLowLatencyIfSinkIsNull()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::AUDIO)).WillOnce(Return(nullptr));
-}
-
-void GenericTasksTestsBase::shouldFailToSetLowLatencyIfPropertyDoesntExist()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
-
-    expectPropertyDoesntExist(kLowLatencyStr);
+    EXPECT_EQ(testContext->m_context.pendingImmediateOutputForVideo, true);
 }
 
 void GenericTasksTestsBase::shouldSetLowLatency()
 {
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
-
-    expectSetProperty(kLowLatencyStr, kLowLatency);
+    EXPECT_CALL(testContext->m_gstPlayer, setLowLatency()).WillOnce(Return(true));
 }
 
 void GenericTasksTestsBase::triggerSetLowLatency()
 {
     firebolt::rialto::server::tasks::generic::SetLowLatency task{testContext->m_context, testContext->m_gstPlayer, true};
     task.execute();
-}
 
-void GenericTasksTestsBase::shouldFailToSetSyncIfSinkIsNull()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::AUDIO)).WillOnce(Return(nullptr));
-}
-
-void GenericTasksTestsBase::shouldFailToSetSyncIfPropertyDoesntExist()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
-
-    expectPropertyDoesntExist(kSyncStr);
+    EXPECT_EQ(testContext->m_context.pendingLowLatency, true);
 }
 
 void GenericTasksTestsBase::shouldSetSync()
 {
-    EXPECT_CALL(testContext->m_gstPlayer, getSink(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    expectSetProperty(kSyncStr, kSync);
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
+    EXPECT_CALL(testContext->m_gstPlayer, setSync()).WillOnce(Return(true));
 }
 
 void GenericTasksTestsBase::triggerSetSync()
 {
     firebolt::rialto::server::tasks::generic::SetSync task{testContext->m_context, testContext->m_gstPlayer, true};
     task.execute();
-}
 
-void GenericTasksTestsBase::shouldFailToSetSyncOffIfDecoderIsNull()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getDecoder(MediaSourceType::AUDIO)).WillOnce(Return(nullptr));
-}
-
-void GenericTasksTestsBase::shouldFailToSetSyncOffIfPropertyDoesntExist()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getDecoder(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
-
-    expectPropertyDoesntExist(kSyncOffStr);
+    EXPECT_EQ(testContext->m_context.pendingSync, true);
 }
 
 void GenericTasksTestsBase::shouldSetSyncOff()
 {
-    EXPECT_CALL(testContext->m_gstPlayer, getDecoder(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
-
-    expectSetProperty(kSyncOffStr, kSyncOff);
+    EXPECT_CALL(testContext->m_gstPlayer, setSyncOff()).WillOnce(Return(true));
 }
 
 void GenericTasksTestsBase::triggerSetSyncOff()
 {
     firebolt::rialto::server::tasks::generic::SetSyncOff task{testContext->m_context, testContext->m_gstPlayer, true};
     task.execute();
-}
 
-void GenericTasksTestsBase::shouldFailToSetStreamSyncModeIfDecoderIsNull()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getDecoder(MediaSourceType::AUDIO)).WillOnce(Return(nullptr));
-}
-
-void GenericTasksTestsBase::shouldFailToSetStreamSyncModeIfPropertyDoesntExist()
-{
-    EXPECT_CALL(testContext->m_gstPlayer, getDecoder(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
-
-    expectPropertyDoesntExist(kStreamSyncModeStr);
+    EXPECT_EQ(testContext->m_context.pendingSyncOff, true);
 }
 
 void GenericTasksTestsBase::shouldSetStreamSyncMode()
 {
-    EXPECT_CALL(testContext->m_gstPlayer, getDecoder(MediaSourceType::AUDIO)).WillOnce(Return(testContext->m_element));
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(GST_OBJECT(testContext->m_element))).Times(1);
-
-    expectSetProperty(kStreamSyncModeStr, kStreamSyncMode);
+    EXPECT_CALL(testContext->m_gstPlayer, setStreamSyncMode()).WillOnce(Return(true));
 }
 
 void GenericTasksTestsBase::triggerSetStreamSyncMode()
 {
-    firebolt::rialto::server::tasks::generic::SetStreamSyncMode task{testContext->m_context, testContext->m_gstPlayer, true};
+    firebolt::rialto::server::tasks::generic::SetStreamSyncMode task{testContext->m_context, testContext->m_gstPlayer, 1};
     task.execute();
-}
 
-template <typename T> void GenericTasksTestsBase::expectSetProperty(const std::string &propertyName, const T &value)
-{
-    firebolt::rialto::server::testcommon::expectSetProperty<T>(testContext->m_glibWrapper, testContext->m_gstWrapper,
-                                                               testContext->m_element, propertyName, value);
-}
-
-void GenericTasksTestsBase::expectPropertyDoesntExist(const std::string &propertyName)
-{
-    firebolt::rialto::server::testcommon::expectPropertyDoesntExist(testContext->m_glibWrapper, testContext->m_gstWrapper,
-                                                                    testContext->m_element, propertyName);
+    EXPECT_EQ(testContext->m_context.pendingStreamSyncMode, 1);
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -613,7 +613,8 @@ void GenericTasksTestsBase::shouldSetupAudioElementBrcmAudioSink()
                                             GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
         .WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_gstWrapper,
-                gstElementFactoryListIsType(testContext->m_elementFactory, GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
         .WillOnce(Return(TRUE));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectType(testContext->m_element)).WillRepeatedly(Return(G_TYPE_PARAM));
     EXPECT_CALL(*testContext->m_glibWrapper, gSignalListIds(_, _))

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
@@ -80,6 +80,10 @@ protected:
     void shouldSetupVideoElementOnly();
     void shouldSetupVideoElementWithPendingGeometry();
     void shouldSetupVideoElementWithPendingImmediateOutput();
+    void shouldSetupAudioSinkElementWithPendingLowLatency();
+    void shouldSetupAudioSinkElementWithPendingSync();
+    void shouldSetupAudioDecoderElementWithPendingSyncOff();
+    void shouldSetupAudioDecoderElementWithPendingStreamSyncMode();
     void shouldSetupVideoElementAmlhalasink();
     void shouldSetupAudioElementBrcmAudioSink();
     void shouldSetupVideoElementAutoVideoSink();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
@@ -77,20 +77,23 @@ protected:
     void setContextSetupSourceFinished();
 
     // SetupElement test methods
-    void shouldSetupVideoElementOnly();
+    void shouldSetupVideoSinkElementOnly();
+    void shouldSetupVideoDecoderElementOnly();
     void shouldSetupVideoElementWithPendingGeometry();
     void shouldSetupVideoElementWithPendingImmediateOutput();
     void shouldSetupAudioSinkElementWithPendingLowLatency();
     void shouldSetupAudioSinkElementWithPendingSync();
     void shouldSetupAudioDecoderElementWithPendingSyncOff();
     void shouldSetupAudioDecoderElementWithPendingStreamSyncMode();
+    void shouldSetupVideoSinkElementWithPendingRenderFrame();
     void shouldSetupVideoElementAmlhalasink();
     void shouldSetupAudioElementBrcmAudioSink();
     void shouldSetupVideoElementAutoVideoSink();
     void shouldSetupAudioElementAutoAudioSink();
     void shouldSetupVideoElementAutoVideoSinkWithMultipleChildren();
     void shouldSetupAudioElementAutoAudioSinkWithMultipleChildren();
-    void shouldSetupAudioElementOnly();
+    void shouldSetupAudioSinkElementOnly();
+    void shouldSetupAudioDecoderElementOnly();
     void shouldSetVideoUnderflowCallback();
     void triggerSetupElement();
     void triggerVideoUnderflowCallback();
@@ -353,7 +356,6 @@ protected:
     // RenderFrame test methods
     void shouldRenderFrame();
     void triggerRenderFrame();
-    void shouldGetVideoSinkFailure();
     void shouldFindPropertyFailure();
     void shouldFlushAudioSrcSuccess();
     void shouldFlushAudioSrcFailure();
@@ -401,8 +403,10 @@ protected:
 
 private:
     // SetupElement helper methods
-    void expectSetupVideoElement();
-    void expectSetupAudioElement();
+    void expectSetupVideoSinkElement();
+    void expectSetupVideoDecoderElement();
+    void expectSetupAudioSinkElement();
+    void expectSetupAudioDecoderElement();
 
     // AttachSource helper methods
     void expectSetGenericVideoCaps();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
@@ -255,26 +255,18 @@ protected:
 
     // low-latency sink property test methods
     void shouldSetLowLatency();
-    void shouldFailToSetLowLatencyIfSinkIsNull();
-    void shouldFailToSetLowLatencyIfPropertyDoesntExist();
     void triggerSetLowLatency();
 
     // sync sink property test methods
     void shouldSetSync();
-    void shouldFailToSetSyncIfSinkIsNull();
-    void shouldFailToSetSyncIfPropertyDoesntExist();
     void triggerSetSync();
 
     // sync-off decoder property test methods
     void shouldSetSyncOff();
-    void shouldFailToSetSyncOffIfDecoderIsNull();
-    void shouldFailToSetSyncOffIfPropertyDoesntExist();
     void triggerSetSyncOff();
 
     // stream-sync-mode decoder property test methods
     void shouldSetStreamSyncMode();
-    void shouldFailToSetStreamSyncModeIfDecoderIsNull();
-    void shouldFailToSetStreamSyncModeIfPropertyDoesntExist();
     void triggerSetStreamSyncMode();
 
     // SetPosition test methods
@@ -356,7 +348,6 @@ protected:
     // RenderFrame test methods
     void shouldRenderFrame();
     void triggerRenderFrame();
-    void shouldFindPropertyFailure();
     void shouldFlushAudioSrcSuccess();
     void shouldFlushAudioSrcFailure();
 
@@ -414,10 +405,6 @@ private:
     void expectAddChannelAndRateAudioToCaps();
     void expectAddRawAudioDataToCaps();
     void expectSetCaps();
-
-    // Set property helpers
-    template <typename T> void expectSetProperty(const std::string &propertyName, const T &value);
-    void expectPropertyDoesntExist(const std::string &propertyName);
 };
 
 #endif // GENERIC_TASKS_TESTS_BASE_H_

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -21,6 +21,7 @@
 #include "Matchers.h"
 #include "PlayerTaskMock.h"
 #include <memory>
+#include <string>
 #include <utility>
 
 using ::testing::_;

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -203,14 +203,12 @@ void GstGenericPlayerTestCommon::expectSetMessageCallback()
 
 void GstGenericPlayerTestCommon::expectGetDecoder(GstElement *element)
 {
-    //getContext([&](const GenericPlayerContext &m_context) { m_pipeline = m_context.pipeline; });
-
     EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_OK));
     EXPECT_CALL(*m_glibWrapperMock, gValueGetObject(_)).WillOnce(Return(element));
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(element)).WillOnce(Return(m_factory));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(m_factory, (GST_ELEMENT_FACTORY_TYPE_DECODER |
-                                                                            GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO)))
+                                                                           GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO)))
         .WillOnce(Return(TRUE));
     EXPECT_CALL(*m_glibWrapperMock, gValueUnset(_));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorFree(&m_it));
@@ -225,7 +223,7 @@ void GstGenericPlayerTestCommon::expectGetSink(const std::string &sinkName, GstE
                 GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
                 *elementPtr = elementObj;
             }));
-    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(elementObj))).WillOnce(Return(m_kElementTypeName.c_str()));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(elementObj))).WillOnce(Return(kElementTypeName.c_str()));
 }
 
 void GstGenericPlayerTestCommon::expectNoDecoder()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -200,3 +200,38 @@ void GstGenericPlayerTestCommon::expectSetMessageCallback()
     EXPECT_CALL(m_gstDispatcherThreadFactoryMock, createGstDispatcherThread(_, _, _))
         .WillOnce(Return(ByMove(std::move(gstDispatcherThread))));
 }
+
+void GstGenericPlayerTestCommon::expectGetDecoder(GstElement *element)
+{
+    //getContext([&](const GenericPlayerContext &m_context) { m_pipeline = m_context.pipeline; });
+
+    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
+    EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_OK));
+    EXPECT_CALL(*m_glibWrapperMock, gValueGetObject(_)).WillOnce(Return(element));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(element)).WillOnce(Return(m_factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(m_factory, (GST_ELEMENT_FACTORY_TYPE_DECODER |
+                                                                            GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO)))
+        .WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_glibWrapperMock, gValueUnset(_));
+    EXPECT_CALL(*m_gstWrapperMock, gstIteratorFree(&m_it));
+}
+
+void GstGenericPlayerTestCommon::expectGetSink(const std::string &sinkName, GstElement *elementObj)
+{
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq(sinkName.c_str()), _))
+        .WillOnce(Invoke(
+            [elementObj](gpointer object, const gchar *first_property_name, void *element)
+            {
+                GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
+                *elementPtr = elementObj;
+            }));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(elementObj))).WillOnce(Return(m_kElementTypeName.c_str()));
+}
+
+void GstGenericPlayerTestCommon::expectNoDecoder()
+{
+    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
+    EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_DONE));
+    EXPECT_CALL(*m_glibWrapperMock, gValueUnset(_));
+    EXPECT_CALL(*m_gstWrapperMock, gstIteratorFree(&m_it));
+}

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -39,6 +39,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <string>
 
 using namespace firebolt::rialto;
 using namespace firebolt::rialto::server;

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -48,11 +48,11 @@ using ::testing::StrictMock;
 
 namespace
 {
-    // Test constants
-    const std::string m_kElementTypeName{"GenericSink"};
-    const std::string m_kAudioSinkStr{"audio-sink"};
-    const std::string m_kVideoSinkStr{"video-sink"};
-}
+// Test constants
+const std::string kElementTypeName{"GenericSink"};
+const std::string kAudioSinkStr{"audio-sink"};
+const std::string kVideoSinkStr{"video-sink"};
+} // namespace
 
 class GstGenericPlayerTestCommon : public ::testing::Test
 {

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -46,6 +46,14 @@ using namespace firebolt::rialto::wrappers;
 
 using ::testing::StrictMock;
 
+namespace
+{
+    // Test constants
+    const std::string m_kElementTypeName{"GenericSink"};
+    const std::string m_kAudioSinkStr{"audio-sink"};
+    const std::string m_kVideoSinkStr{"video-sink"};
+}
+
 class GstGenericPlayerTestCommon : public ::testing::Test
 {
 public:
@@ -101,6 +109,9 @@ protected:
     void expectSetUri();
     void expectCheckPlaySink();
     void expectSetMessageCallback();
+    void expectGetDecoder(GstElement *element);
+    void expectGetSink(const std::string &sinkName, GstElement *elementObj);
+    void expectNoDecoder();
 
 private:
     GstElement m_pipeline{};
@@ -124,6 +135,9 @@ private:
     GCallback m_deepElementAddedFunc;
     gulong m_deepElementAddedSignalId{2};
     GstObject m_sinkFactory{}; // GstElementFactory is an opaque data structure
+    GstIterator m_it{};
+    char m_dummy{0};
+    GstElementFactory *m_factory = reinterpret_cast<GstElementFactory *>(&m_dummy);
 };
 
 #endif // GST_GENERIC_PLAYER_TEST_COMMON_H_

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
@@ -255,7 +255,7 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetSync)
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetSyncOff)
 {
     constexpr bool kSyncOff{true};
-    auto task = m_sut.createSetSyncOff(m_gstPlayer, kSyncOff);
+    auto task = m_sut.createSetSyncOff(m_context, m_gstPlayer, kSyncOff);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::SetSyncOff &>(*task));
 }
@@ -263,7 +263,7 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetSyncOff)
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetStreamSyncMode)
 {
     constexpr int32_t kStreamSyncMode{1};
-    auto task = m_sut.createSetStreamSyncMode(m_gstPlayer, kStreamSyncMode);
+    auto task = m_sut.createSetStreamSyncMode(m_context, m_gstPlayer, kStreamSyncMode);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::SetStreamSyncMode &>(*task));
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
@@ -239,7 +239,7 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetMute)
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetLowLatency)
 {
     constexpr bool kLowLatency{true};
-    auto task = m_sut.createSetLowLatency(m_gstPlayer, kLowLatency);
+    auto task = m_sut.createSetLowLatency(m_context, m_gstPlayer, kLowLatency);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::SetLowLatency &>(*task));
 }
@@ -247,7 +247,7 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetLowLatency)
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetSync)
 {
     constexpr bool kSync{true};
-    auto task = m_sut.createSetSync(m_gstPlayer, kSync);
+    auto task = m_sut.createSetSync(m_context, m_gstPlayer, kSync);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::SetSync &>(*task));
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/RenderFrameTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/RenderFrameTest.cpp
@@ -28,15 +28,3 @@ TEST_F(RenderFrameTest, shouldRenderFrame)
     shouldRenderFrame();
     triggerRenderFrame();
 }
-
-TEST_F(RenderFrameTest, RenderFrameFailsOnGettingSink)
-{
-    shouldGetVideoSinkFailure();
-    triggerRenderFrame();
-}
-
-TEST_F(RenderFrameTest, RenderFrameFailsOnFindProperty)
-{
-    shouldFindPropertyFailure();
-    triggerRenderFrame();
-}

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetLowLatencyTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetLowLatencyTest.cpp
@@ -23,18 +23,6 @@ class SetLowLatencyTest : public GenericTasksTestsBase
 {
 };
 
-TEST_F(SetLowLatencyTest, shouldFailToSetLowLatencyIfSinkIsNull)
-{
-    shouldFailToSetLowLatencyIfSinkIsNull();
-    triggerSetLowLatency();
-}
-
-TEST_F(SetLowLatencyTest, shouldFailToSetLowLatencyIfPropertyDoesntExist)
-{
-    shouldFailToSetLowLatencyIfPropertyDoesntExist();
-    triggerSetLowLatency();
-}
-
 TEST_F(SetLowLatencyTest, shouldSetLowLatency)
 {
     shouldSetLowLatency();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetStreamSyncModeTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetStreamSyncModeTest.cpp
@@ -23,18 +23,6 @@ class SetStreamSyncModeTest : public GenericTasksTestsBase
 {
 };
 
-TEST_F(SetStreamSyncModeTest, shouldFailToSetStreamSyncModeIfDecoderIsNull)
-{
-    shouldFailToSetStreamSyncModeIfDecoderIsNull();
-    triggerSetStreamSyncMode();
-}
-
-TEST_F(SetStreamSyncModeTest, shouldFailToSetStreamSyncModeIfPropertyDoesntExist)
-{
-    shouldFailToSetStreamSyncModeIfPropertyDoesntExist();
-    triggerSetStreamSyncMode();
-}
-
 TEST_F(SetStreamSyncModeTest, shouldSetStreamSyncMode)
 {
     shouldSetStreamSyncMode();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetSyncOffTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetSyncOffTest.cpp
@@ -23,18 +23,6 @@ class SetSyncOffTest : public GenericTasksTestsBase
 {
 };
 
-TEST_F(SetSyncOffTest, shouldFailToSetSyncOffIfDecoderIsNull)
-{
-    shouldFailToSetSyncOffIfDecoderIsNull();
-    triggerSetSyncOff();
-}
-
-TEST_F(SetSyncOffTest, shouldFailToSetSyncOffIfPropertyDoesntExist)
-{
-    shouldFailToSetSyncOffIfPropertyDoesntExist();
-    triggerSetSyncOff();
-}
-
 TEST_F(SetSyncOffTest, shouldSetSyncOff)
 {
     shouldSetSyncOff();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetSyncTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetSyncTest.cpp
@@ -23,18 +23,6 @@ class SetSyncTest : public GenericTasksTestsBase
 {
 };
 
-TEST_F(SetSyncTest, shouldFailToSetSyncIfSinkIsNull)
-{
-    shouldFailToSetSyncIfSinkIsNull();
-    triggerSetSync();
-}
-
-TEST_F(SetSyncTest, shouldFailToSetSyncIfPropertyDoesntExist)
-{
-    shouldFailToSetSyncIfPropertyDoesntExist();
-    triggerSetSync();
-}
-
 TEST_F(SetSyncTest, shouldSetSync)
 {
     shouldSetSync();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
@@ -25,7 +25,7 @@ class SetupElementTest : public GenericTasksTestsBase
 
 TEST_F(SetupElementTest, shouldSetupVideoElement)
 {
-    shouldSetupVideoElementOnly();
+    shouldSetupVideoSinkElementOnly();
     triggerSetupElement();
 }
 
@@ -62,6 +62,12 @@ TEST_F(SetupElementTest, shouldSetupAudioElementWithPendingSyncOff)
 TEST_F(SetupElementTest, shouldSetupAudioElementWithPendingStreamSyncMode)
 {
     shouldSetupAudioDecoderElementWithPendingStreamSyncMode();
+    triggerSetupElement();
+}
+
+TEST_F(SetupElementTest, shouldSetupVideoElementWithPendingRenderFrame)
+{
+    shouldSetupVideoSinkElementWithPendingRenderFrame();
     triggerSetupElement();
 }
 
@@ -121,13 +127,13 @@ TEST_F(SetupElementTest, shouldSetupAudioElementWithMultpileChildSinkForAutoAudi
 
 TEST_F(SetupElementTest, shouldSetupAudioElement)
 {
-    shouldSetupAudioElementOnly();
+    shouldSetupAudioSinkElementOnly();
     triggerSetupElement();
 }
 
 TEST_F(SetupElementTest, shouldReportVideoUnderflow)
 {
-    shouldSetupVideoElementOnly();
+    shouldSetupVideoDecoderElementOnly();
     triggerSetupElement();
 
     shouldSetVideoUnderflowCallback();
@@ -136,7 +142,7 @@ TEST_F(SetupElementTest, shouldReportVideoUnderflow)
 
 TEST_F(SetupElementTest, shouldReportAudioUnderflow)
 {
-    shouldSetupAudioElementOnly();
+    shouldSetupAudioDecoderElementOnly();
     triggerSetupElement();
 
     shouldSetAudioUnderflowCallback();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
@@ -41,6 +41,30 @@ TEST_F(SetupElementTest, shouldSetupVideoElementWithPendingImmediateOutput)
     triggerSetupElement();
 }
 
+TEST_F(SetupElementTest, shouldSetupAudioElementWithPendingLowLatency)
+{
+    shouldSetupAudioSinkElementWithPendingLowLatency();
+    triggerSetupElement();
+}
+
+TEST_F(SetupElementTest, shouldSetupAudioElementWithPendingSync)
+{
+    shouldSetupAudioSinkElementWithPendingSync();
+    triggerSetupElement();
+}
+
+TEST_F(SetupElementTest, shouldSetupAudioElementWithPendingSyncOff)
+{
+    shouldSetupAudioDecoderElementWithPendingSyncOff();
+    triggerSetupElement();
+}
+
+TEST_F(SetupElementTest, shouldSetupAudioElementWithPendingStreamSyncMode)
+{
+    shouldSetupAudioDecoderElementWithPendingStreamSyncMode();
+    triggerSetupElement();
+}
+
 TEST_F(SetupElementTest, shouldSetupVideoElementForAmlhalasink)
 {
     shouldSetupVideoElementAmlhalasink();

--- a/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
@@ -86,9 +86,9 @@ public:
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetMute,
                 (GenericPlayerContext & context, const MediaSourceType &mediaSourceType, bool mute), (const, override));
-    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetLowLatency, (IGstGenericPlayerPrivate & player, bool lowLatency),
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetLowLatency, (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, bool lowLatency),
                 (const, override));
-    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSync, (IGstGenericPlayerPrivate & player, bool sync),
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSync, (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, bool sync),
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSyncOff, (IGstGenericPlayerPrivate & player, bool syncOff),
                 (const, override));

--- a/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
@@ -86,14 +86,15 @@ public:
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetMute,
                 (GenericPlayerContext & context, const MediaSourceType &mediaSourceType, bool mute), (const, override));
-    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetLowLatency, (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, bool lowLatency),
-                (const, override));
-    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSync, (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, bool sync),
-                (const, override));
-    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSyncOff, (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, bool syncOff),
-                (const, override));
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetLowLatency,
+                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, bool lowLatency), (const, override));
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSync,
+                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, bool sync), (const, override));
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSyncOff,
+                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, bool syncOff), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetStreamSyncMode,
-                (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, int32_t streamSyncMode), (const, override));
+                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, int32_t streamSyncMode),
+                (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createShutdown, (IGstGenericPlayerPrivate & player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createStop,
                 (GenericPlayerContext & context, IGstGenericPlayerPrivate &player), (const, override));

--- a/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
@@ -90,10 +90,10 @@ public:
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSync, (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, bool sync),
                 (const, override));
-    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSyncOff, (IGstGenericPlayerPrivate & player, bool syncOff),
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetSyncOff, (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, bool syncOff),
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createSetStreamSyncMode,
-                (IGstGenericPlayerPrivate & player, int32_t streamSyncMode), (const, override));
+                (GenericPlayerContext & context, IGstGenericPlayerPrivate & player, int32_t streamSyncMode), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createShutdown, (IGstGenericPlayerPrivate & player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createStop,
                 (GenericPlayerContext & context, IGstGenericPlayerPrivate &player), (const, override));

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -39,6 +39,11 @@ public:
     MOCK_METHOD(void, scheduleAllSourcesAttached, (), (override));
     MOCK_METHOD(bool, setVideoSinkRectangle, (), (override));
     MOCK_METHOD(bool, setImmediateOutput, (), (override));
+    MOCK_METHOD(bool, setLowLatency, (), (override));
+    MOCK_METHOD(bool, setSync, (), (override));
+    MOCK_METHOD(bool, setSyncOff, (), (override));
+    MOCK_METHOD(bool, setStreamSyncMode, (), (override));
+    MOCK_METHOD(bool, setRenderFrame, (), (override));
     MOCK_METHOD(void, notifyNeedMediaData, (const MediaSourceType mediaSource), (override));
     MOCK_METHOD(GstBuffer *, createBuffer, (const IMediaPipeline::MediaSegment &mediaSegment), (const, override));
     MOCK_METHOD(void, attachData, (const firebolt::rialto::MediaSourceType mediaType), (override));

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -63,6 +63,7 @@ public:
     MOCK_METHOD(void, addAutoAudioSinkChild, (GObject * object), (override));
     MOCK_METHOD(void, removeAutoVideoSinkChild, (GObject * object), (override));
     MOCK_METHOD(void, removeAutoAudioSinkChild, (GObject * object), (override));
+    MOCK_METHOD(GstElement *, getSink, (const MediaSourceType &mediaSourceType), (const, override));
     MOCK_METHOD(void, setPlaybinFlags, (bool enableAudio), (override));
 
     MOCK_METHOD(void, addAudioClippingToBuffer, (GstBuffer * buffer, uint64_t clippingStart, uint64_t clippingEnd),

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -63,11 +63,7 @@ public:
     MOCK_METHOD(void, addAutoAudioSinkChild, (GObject * object), (override));
     MOCK_METHOD(void, removeAutoVideoSinkChild, (GObject * object), (override));
     MOCK_METHOD(void, removeAutoAudioSinkChild, (GObject * object), (override));
-    MOCK_METHOD(GstElement *, getSinkChildIfAutoVideoSink, (GstElement * sink), (const, override));
-    MOCK_METHOD(GstElement *, getSinkChildIfAutoAudioSink, (GstElement * sink), (const, override));
-    MOCK_METHOD(GstElement *, getSink, (const MediaSourceType &mediaSourceType), (const, override));
     MOCK_METHOD(void, setPlaybinFlags, (bool enableAudio), (override));
-    MOCK_METHOD(GstElement *, getDecoder, (const MediaSourceType &mediaSourceType), (override));
 
     MOCK_METHOD(void, addAudioClippingToBuffer, (GstBuffer * buffer, uint64_t clippingStart, uint64_t clippingEnd),
                 (const, override));


### PR DESCRIPTION
Summary: Delays the setting of low latency properties if the sink has not yet been attached to the pipeline.
Type: Feature
Test Plan: UT/CT/Netflix Games Fullstack
Jira: RIALTO-619