### PR TITLE
Add a volume property to the web audio

### DIFF
--- a/media/server/gstplayer/include/WebAudioPlayerContext.h
+++ b/media/server/gstplayer/include/WebAudioPlayerContext.h
@@ -20,12 +20,15 @@
 #ifndef FIREBOLT_RIALTO_SERVER_WEB_AUDIO_PLAYER_CONTEXT_H_
 #define FIREBOLT_RIALTO_SERVER_WEB_AUDIO_PLAYER_CONTEXT_H_
 
-#include "IGstSrc.h"
-#include <condition_variable>
 #include <gst/gst.h>
+#include <gst/pbutils/pbutils.h>
+
+#include <condition_variable>
 #include <list>
 #include <memory>
 #include <mutex>
+
+#include "IGstSrc.h"
 
 namespace firebolt::rialto::server
 {
@@ -67,6 +70,11 @@ struct WebAudioPlayerContext
      * @brief The number of bytes per sample.
      */
     uint32_t bytesPerSample{};
+
+    /**
+     * @brief Pointer to the gstremer volume element
+     */
+    GstStreamVolume *gstVolumeElement{nullptr};
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/source/tasks/webAudio/SetVolume.cpp
+++ b/media/server/gstplayer/source/tasks/webAudio/SetVolume.cpp
@@ -38,8 +38,7 @@ SetVolume::~SetVolume()
 
 void SetVolume::execute() const
 {
-    RIALTO_SERVER_LOG_DEBUG("Executing SetVolume");
-    m_gstWrapper->gstStreamVolumeSetVolume(GST_STREAM_VOLUME(m_context.pipeline), GST_STREAM_VOLUME_FORMAT_LINEAR,
-                                           m_volume);
+    RIALTO_SERVER_LOG_DEBUG("WebAudio Executing SetVolume %f", m_volume);
+    m_gstWrapper->gstStreamVolumeSetVolume(m_context.gstVolumeElement, GST_STREAM_VOLUME_FORMAT_LINEAR, m_volume);
 }
 } // namespace firebolt::rialto::server::tasks::webaudio

--- a/tests/componenttests/server/tests/webAudio/WebAudioTestMethods.cpp
+++ b/tests/componenttests/server/tests/webAudio/WebAudioTestMethods.cpp
@@ -64,6 +64,7 @@ WebAudioTestMethods::WebAudioTestMethods()
     memset(&m_gstCaps2, 0x00, sizeof(m_gstCaps2));
     memset(&m_convert, 0x00, sizeof(m_convert));
     memset(&m_resample, 0x00, sizeof(m_resample));
+    memset(&m_volume, 0x00, sizeof(m_volume));
     memset(&m_buffer, 0x00, sizeof(m_buffer));
     memset(&m_capsStr, 0x00, sizeof(m_capsStr));
 
@@ -198,13 +199,16 @@ void WebAudioTestMethods::willCreateWebAudioPlayer()
     //   GstWebAudioPlayerTestCommon::expectLinkElements()
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioconvert"), _)).WillOnce(Return(&m_convert));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioresample"), _)).WillOnce(Return(&m_resample));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("volume"), _)).WillOnce(Return(&m_volume));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), GST_ELEMENT(&m_appSrc))).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_convert)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_resample)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_volume)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_sink)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstElementLink(GST_ELEMENT(&m_appSrc), &m_convert)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&m_convert, &m_resample)).WillOnce(Return(TRUE));
-    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&m_resample, &m_sink)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&m_resample, &m_volume)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&m_volume, &m_sink)).WillOnce(Return(TRUE));
 
     EXPECT_CALL(*m_gstWrapperMock, gstCapsNewEmptySimple(StrEq(kAudioMimeType))).WillOnce(Return(&m_gstCaps1));
     EXPECT_CALL(*m_gstWrapperMock, gstCapsSetSimpleIntStub(&m_gstCaps1, StrEq("channels"), G_TYPE_INT, kPcmChannels));

--- a/tests/componenttests/server/tests/webAudio/WebAudioTestMethods.h
+++ b/tests/componenttests/server/tests/webAudio/WebAudioTestMethods.h
@@ -108,6 +108,7 @@ protected:
     GstCaps m_gstCaps2;
     GstElement m_convert;
     GstElement m_resample;
+    GstElement m_volume;
     GstBuffer m_buffer;
     gchar m_capsStr;
 

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.cpp
@@ -188,28 +188,35 @@ void GstWebAudioPlayerTestCommon::expectLinkElements()
 {
     GstElement convert{};
     GstElement resample{};
+    memset(&m_volume, 0x00, sizeof(m_volume));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioconvert"), _)).WillOnce(Return(&convert));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioresample"), _)).WillOnce(Return(&resample));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("volume"), _)).WillOnce(Return(&m_volume));
 
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_appSrc)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &convert)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &resample)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_volume)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_sink)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&m_appSrc, &convert)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&convert, &resample)).WillOnce(Return(TRUE));
-    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&resample, &m_sink)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&resample, &m_volume)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&m_volume, &m_sink)).WillOnce(Return(TRUE));
 }
 
 void GstWebAudioPlayerTestCommon::expectAddBinFailure()
 {
     GstElement convert{};
     GstElement resample{};
+    memset(&m_volume, 0x00, sizeof(m_volume));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioconvert"), _)).WillOnce(Return(&convert));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioresample"), _)).WillOnce(Return(&resample));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("volume"), _)).WillOnce(Return(&m_volume));
 
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_appSrc)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &convert)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &resample)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_volume)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_sink)).WillOnce(Return(FALSE));
 }
 
@@ -217,12 +224,15 @@ void GstWebAudioPlayerTestCommon::expectLinkElementFailure()
 {
     GstElement convert{};
     GstElement resample{};
+    memset(&m_volume, 0x00, sizeof(m_volume));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioconvert"), _)).WillOnce(Return(&convert));
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("audioresample"), _)).WillOnce(Return(&resample));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("volume"), _)).WillOnce(Return(&m_volume));
 
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_appSrc)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &convert)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &resample)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_volume)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(GST_BIN(&m_pipeline), &m_sink)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&m_appSrc, &convert)).WillOnce(Return(FALSE));
 }

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.h
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.h
@@ -106,6 +106,7 @@ protected:
     GstElement m_sink{};
     GstBus m_bus{};
     const uint32_t m_priority{5};
+    GstElement m_volume{};
 };
 
 #endif // GST_WEB_AUDIO_PLAYER_TEST_COMMON_H_

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -20,12 +20,14 @@
 #ifndef FIREBOLT_RIALTO_WRAPPERS_GST_WRAPPER_H_
 #define FIREBOLT_RIALTO_WRAPPERS_GST_WRAPPER_H_
 
-#include "IGstWrapper.h"
 #include <cassert>
-#include <gst/pbutils/pbutils.h>
 #include <memory>
 #include <mutex>
 #include <string>
+
+#include <gst/pbutils/pbutils.h>
+
+#include "IGstWrapper.h"
 
 namespace firebolt::rialto::wrappers
 {


### PR DESCRIPTION
Summary: Implement a "volume" property on Web Audio to set/attenuate the volume before mixing with the Media Player & TTS audio output (the volume of the latter will not be affected)
Type: Feature
Test Plan: UT, CT and test on XiOne US 
Jira: RIALTO-595