### PR TITLE
getDecoder and getFilter methods fixed

### DIFF
--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -180,7 +180,7 @@ public:
                 (GstStructure * structure, const gchar *firstname, GType type, const char *value), (const));
     MOCK_METHOD(void, gstMessageParseError, (GstMessage * message, GError **gerror, gchar **debug), (const));
     MOCK_METHOD(GstIterator *, gstBinIterateSinks, (GstBin * bin), (const, override));
-    MOCK_METHOD(GstIterator *, gstBinIterateElements, (GstBin * bin), (const, override));
+    MOCK_METHOD(GstIterator *, gstBinIterateRecurse, (GstBin * bin), (const, override));
     MOCK_METHOD(GstIteratorResult, gstIteratorNext, (GstIterator * it, GValue *elem), (const, override));
     MOCK_METHOD(void, gstIteratorResync, (GstIterator * it), (const, override));
     MOCK_METHOD(void, gstIteratorFree, (GstIterator * it), (const, override));

--- a/tests/componenttests/server/tests/mediaPipeline/PipelinePropertyTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/PipelinePropertyTest.cpp
@@ -108,7 +108,7 @@ public:
     template <typename T>
     void willSetDecoderProperty(GstElementFactoryListType type, const std::string &propertyName, const T &value)
     {
-        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(_)).WillOnce(Return(&m_it));
+        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(_)).WillOnce(Return(&m_it));
         EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_OK));
         EXPECT_CALL(*m_glibWrapperMock, gValueGetObject(_)).WillOnce(Return(m_element));
         EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(_)).WillOnce(Return(m_factory));
@@ -136,7 +136,7 @@ public:
     template <typename T>
     void willGetDecoderProperty(GstElementFactoryListType type, const std::string &propertyName, const T &value)
     {
-        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(_)).WillOnce(Return(&m_it));
+        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(_)).WillOnce(Return(&m_it));
         EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_OK));
         EXPECT_CALL(*m_glibWrapperMock, gValueGetObject(_)).WillOnce(Return(m_element));
         EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(_)).WillOnce(Return(m_factory));
@@ -186,7 +186,7 @@ public:
 
     void willFailToSetDecoderProperty()
     {
-        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(_)).WillOnce(Return(&m_it));
+        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(_)).WillOnce(Return(&m_it));
         EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_OK));
         EXPECT_CALL(*m_glibWrapperMock, gValueGetObject(_)).WillOnce(Return(m_element));
         EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(_)).WillOnce(Return(m_factory));
@@ -206,7 +206,7 @@ public:
 
     void willFailToGetDecoder()
     {
-        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(_)).WillOnce(Return(&m_it));
+        EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(_)).WillOnce(Return(&m_it));
         EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_ERROR));
         EXPECT_CALL(*m_glibWrapperMock, gValueUnset(_));
         EXPECT_CALL(*m_gstWrapperMock, gstIteratorFree(&m_it)).WillOnce(Invoke(this, &MediaPipelineTest::workerFinished));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -748,7 +748,7 @@ TEST_F(GstGenericPlayerTest, shouldGetStreamSyncModeWithIteratorResync)
     const int32_t kStreamSyncModeValue{1};
     const std::string kPropertyStr{"stream-sync-mode"};
 
-    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(_)).WillOnce(Return(&m_it));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(_)).WillOnce(Return(&m_it));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(_, _))
         .WillOnce(Return(GST_ITERATOR_RESYNC))
         .WillOnce(Return(GST_ITERATOR_OK));
@@ -894,7 +894,7 @@ TEST_F(GstGenericPlayerTest, shouldGetBufferingLimitWithIteratorResync)
     const uint32_t kBufferingLimitValue{1};
     const std::string kPropertyStr{"limit-buffering-ms"};
 
-    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(_)).WillOnce(Return(&m_it));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(_)).WillOnce(Return(&m_it));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(_, _))
         .WillOnce(Return(GST_ITERATOR_RESYNC))
         .WillOnce(Return(GST_ITERATOR_OK));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -204,7 +204,7 @@ void GstGenericPlayerTestCommon::expectSetMessageCallback()
 
 void GstGenericPlayerTestCommon::expectGetDecoder(GstElement *element)
 {
-    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_OK));
     EXPECT_CALL(*m_glibWrapperMock, gValueGetObject(_)).WillOnce(Return(element));
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(element)).WillOnce(Return(m_factory));
@@ -217,7 +217,7 @@ void GstGenericPlayerTestCommon::expectGetDecoder(GstElement *element)
 
 void GstGenericPlayerTestCommon::expectGetVideoParser(GstElement *element)
 {
-    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_OK));
     EXPECT_CALL(*m_glibWrapperMock, gValueGetObject(_)).WillOnce(Return(element));
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(element)).WillOnce(Return(m_factory));
@@ -242,7 +242,7 @@ void GstGenericPlayerTestCommon::expectGetSink(const std::string &sinkName, GstE
 
 void GstGenericPlayerTestCommon::expectNoDecoder()
 {
-    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateElements(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinIterateRecurse(GST_BIN(&m_pipeline))).WillOnce(Return(&m_it));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorNext(&m_it, _)).WillOnce(Return(GST_ITERATOR_DONE));
     EXPECT_CALL(*m_glibWrapperMock, gValueUnset(_));
     EXPECT_CALL(*m_gstWrapperMock, gstIteratorFree(&m_it));

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -465,7 +465,7 @@ public:
 
     GstIterator *gstBinIterateSinks(GstBin *bin) const override { return gst_bin_iterate_sinks(bin); }
 
-    GstIterator *gstBinIterateElements(GstBin *bin) const override { return gst_bin_iterate_elements(bin); }
+    GstIterator *gstBinIterateRecurse(GstBin *bin) const override { return gst_bin_iterate_recurse(bin); }
 
     GstIteratorResult gstIteratorNext(GstIterator *it, GValue *elem) const override
     {

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -1085,13 +1085,13 @@ public:
     virtual GstIterator *gstBinIterateSinks(GstBin *bin) const = 0;
 
     /**
-     * @brief Gets an iterator for the bin that contains all the elements.
+     * @brief Gets an iterator for the elements in this bin. This iterator recurses into GstBin children.
      *
      * @param[in]  bin  : the bin.
      *
      * @retval an iterator of elements.
      */
-    virtual GstIterator *gstBinIterateElements(GstBin *bin) const = 0;
+    virtual GstIterator *gstBinIterateRecurse(GstBin *bin) const = 0;
 
     /**
      * @brief Gets the next item from the iterator.


### PR DESCRIPTION
Summary: getDecoder and getFilter methods fixed
Type: Fix
Test Plan: UT, CT, Fullstack
Jira: RIALTO-639