### PR TITLE
Crash fix in Rialto Server getChallenge procedure

### DIFF
--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -152,6 +152,11 @@ void MediaKeySession::getChallenge()
     {
         uint32_t challengeSize = 0;
         MediaKeyErrorStatus status = m_ocdmSession->getChallengeData(m_kIsLDL, nullptr, &challengeSize);
+        if (MediaKeyErrorStatus::OK != status || challengeSize == 0)
+        {
+            RIALTO_SERVER_LOG_ERROR("Failed to get the challenge data size, no onLicenseRequest will be generated");
+            return;
+        }
         std::vector<uint8_t> challenge(challengeSize, 0x00);
         status = m_ocdmSession->getChallengeData(m_kIsLDL, &challenge[0], &challengeSize);
         if (MediaKeyErrorStatus::OK != status)

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -152,7 +152,7 @@ void MediaKeySession::getChallenge()
     {
         uint32_t challengeSize = 0;
         MediaKeyErrorStatus status = m_ocdmSession->getChallengeData(m_kIsLDL, nullptr, &challengeSize);
-        if (MediaKeyErrorStatus::OK != status || challengeSize == 0)
+        if (challengeSize == 0)
         {
             RIALTO_SERVER_LOG_ERROR("Failed to get the challenge data size, no onLicenseRequest will be generated");
             return;

--- a/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
+++ b/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
@@ -89,26 +89,6 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessNetflix)
 }
 
 /**
- * Test that GenerateRequest fails when get challenge data size fails
- */
-TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, FailNetflixWhenGettingChallengeDataSizeFails)
-{
-    createKeySession(kNetflixKeySystem);
-
-    EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
-        .WillOnce(Return(MediaKeyErrorStatus::OK));
-    mainThreadWillEnqueueTask();
-    EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, nullptrMatcher(), _))
-        .WillOnce(Return(MediaKeyErrorStatus::FAIL));
-
-    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData));
-
-    // Close ocdm before destroying
-    expectCloseKeySession(kNetflixKeySystem);
-}
-
-/**
  * Test that GenerateRequest fails when returned challenge data size is zero
  */
 TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, FailNetflixWhenChallengeDataSizeIsZero)


### PR DESCRIPTION
Summary: Crash fix in Rialto Server getChallenge procedure
Type: Fix
Test Plan: UT, CT, Fullstack
Jira: RIALTO-680