### PR TITLE
Require Audio Easing support on RialtoMSEAudioSink for Netflix (fade-volume prop) 

### DIFF
--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -1486,13 +1486,13 @@ bool GstGenericPlayer::getVolume(double &currentVolume)
         {
             currentVolume = fadeVolume / 100.0;
         }
-        m_gstWrapper->gstObjectUnref(sink);
     }
     else
     {
         currentVolume = m_gstWrapper->gstStreamVolumeGetVolume(GST_STREAM_VOLUME(m_context.pipeline),
                                                                GST_STREAM_VOLUME_FORMAT_LINEAR);
     }
+    m_gstWrapper->gstObjectUnref(sink);
     return true;
 }
 

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -832,9 +832,7 @@ bool MediaPipelineServerInternal::setVolumeInternal(double targetVolume, uint32_
         RIALTO_SERVER_LOG_ERROR("Failed to set volume - Gstreamer player has not been loaded");
         return false;
     }
-
-    
-
+    m_gstPlayer->setVolume(targetVolume, volumeDuration, easeType);
     return true;
 }
 
@@ -849,18 +847,6 @@ bool MediaPipelineServerInternal::getVolume(double &currentVolume)
     return result;
 }
 
-// bool MediaPipelineServerInternal::getVolumeInternal(double &currentVolume)
-// {
-//     RIALTO_SERVER_LOG_DEBUG("entry:");
-
-//     if (!m_gstPlayer)
-//     {
-//         RIALTO_SERVER_LOG_ERROR("Failed to get volume - Gstreamer player has not been loaded");
-//         return false;
-//     }
-//     return m_gstPlayer->getVolume(currentVolume);
-// }
-
 bool MediaPipelineServerInternal::getVolumeInternal(double &currentVolume)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
@@ -870,25 +856,7 @@ bool MediaPipelineServerInternal::getVolumeInternal(double &currentVolume)
         RIALTO_SERVER_LOG_ERROR("Failed to get volume - Gstreamer player has not been loaded");
         return false;
     }
-
-    // // Get fade volume
-    // GstElement *sink{getSink(mediaSourceType)};
-    // int fadeVolume = -100;
-    // m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(sink), "fade-volume")
-
-    // if (fadeVolume < 0)
-    // {
-    //     // Goes back tto the current volume
-    //     m_gstPlayer->getVolume(currentVolume);
-    // }
-    // else
-    // {
-    //     // rmr to convert fade-volume to double
-    //     currentVolume = fadeVolume / 100.0;
-    // }
-
-    RIALTO_SERVER_LOG_DEBUG("Retrieved volume: %lf", currentVolume);
-    return true;
+    return m_gstPlayer->getVolume(currentVolume);
 }
 
 bool MediaPipelineServerInternal::setMute(std::int32_t sourceId, bool mute)

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -832,7 +832,9 @@ bool MediaPipelineServerInternal::setVolumeInternal(double targetVolume, uint32_
         RIALTO_SERVER_LOG_ERROR("Failed to set volume - Gstreamer player has not been loaded");
         return false;
     }
-    m_gstPlayer->setVolume(targetVolume, volumeDuration, easeType);
+
+    
+
     return true;
 }
 
@@ -847,6 +849,18 @@ bool MediaPipelineServerInternal::getVolume(double &currentVolume)
     return result;
 }
 
+// bool MediaPipelineServerInternal::getVolumeInternal(double &currentVolume)
+// {
+//     RIALTO_SERVER_LOG_DEBUG("entry:");
+
+//     if (!m_gstPlayer)
+//     {
+//         RIALTO_SERVER_LOG_ERROR("Failed to get volume - Gstreamer player has not been loaded");
+//         return false;
+//     }
+//     return m_gstPlayer->getVolume(currentVolume);
+// }
+
 bool MediaPipelineServerInternal::getVolumeInternal(double &currentVolume)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
@@ -856,7 +870,25 @@ bool MediaPipelineServerInternal::getVolumeInternal(double &currentVolume)
         RIALTO_SERVER_LOG_ERROR("Failed to get volume - Gstreamer player has not been loaded");
         return false;
     }
-    return m_gstPlayer->getVolume(currentVolume);
+
+    // // Get fade volume
+    // GstElement *sink{getSink(mediaSourceType)};
+    // int fadeVolume = -100;
+    // m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(sink), "fade-volume")
+
+    // if (fadeVolume < 0)
+    // {
+    //     // Goes back tto the current volume
+    //     m_gstPlayer->getVolume(currentVolume);
+    // }
+    // else
+    // {
+    //     // rmr to convert fade-volume to double
+    //     currentVolume = fadeVolume / 100.0;
+    // }
+
+    RIALTO_SERVER_LOG_DEBUG("Retrieved volume: %lf", currentVolume);
+    return true;
 }
 
 bool MediaPipelineServerInternal::setMute(std::int32_t sourceId, bool mute)

--- a/tests/componenttests/server/common/Constants.h
+++ b/tests/componenttests/server/common/Constants.h
@@ -44,7 +44,7 @@ constexpr int kAllLogs{RIALTO_DEBUG_LEVEL_FATAL | RIALTO_DEBUG_LEVEL_ERROR | RIA
                        RIALTO_DEBUG_LEVEL_MILESTONE | RIALTO_DEBUG_LEVEL_INFO | RIALTO_DEBUG_LEVEL_DEBUG};
 constexpr double kPlaybackRate{0.5};
 constexpr std::int64_t kCurrentPosition{1234};
-constexpr double kVolume{10};
+constexpr double kVolume{0.5};
 constexpr uint32_t kNoVolumeDuration{0};
 constexpr uint32_t kVolumeDuration{10};
 constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};

--- a/tests/componenttests/server/tests/mediaPipeline/VolumeTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/VolumeTest.cpp
@@ -79,8 +79,15 @@ public:
 
     void willGetVolume()
     {
+        mockAudioSink();
+
+        EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(_, StrEq("fade-volume"))).WillOnce(Return(nullptr));
+
         EXPECT_CALL(*m_gstWrapperMock, gstStreamVolumeGetVolume(_, GST_STREAM_VOLUME_FORMAT_LINEAR))
             .WillOnce(Return(kVolume));
+
+        EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_audioSink))
+            .WillOnce(Invoke(this, &MediaPipelineTest::workerFinished));
     }
 
     void setVolumeNormal()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -546,14 +546,16 @@ TEST_F(GstGenericPlayerTest, shouldGetVolumeWithNonNegativeFadeVolume)
 TEST_F(GstGenericPlayerTest, shouldGetVolumeWithoutFadeVolumeProperty)
 {
     setPipelineState(GST_STATE_PLAYING);
-    GstElement *sink = m_element;
 
-    expectGetSink(kAudioSinkStr, sink);
-    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(G_OBJECT_GET_CLASS(sink), StrEq("fade-volume")))
+    expectGetSink(kAudioSinkStr, m_element);
+
+    EXPECT_CALL(*m_glibWrapperMock, gObjectClassFindProperty(G_OBJECT_GET_CLASS(m_element), StrEq("fade-volume")))
         .WillOnce(Return(nullptr));
 
     constexpr double kVolume{0.5};
     EXPECT_CALL(*m_gstWrapperMock, gstStreamVolumeGetVolume(_, GST_STREAM_VOLUME_FORMAT_LINEAR)).WillOnce(Return(kVolume));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_element)).Times(1);
 
     double currentVolume;
     EXPECT_TRUE(m_sut->getVolume(currentVolume));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -490,7 +490,7 @@ TEST_F(GstGenericPlayerTest, shouldFailToGetStatsInPlayingStateIfStructIncomplet
     EXPECT_FALSE(m_sut->getStats(MediaSourceType::VIDEO, returnedRenderedFrames, returnedDroppedFrames));
 }
 
-TEST_F(GstGenericPlayerTest, shouldFailToGetFadeVolumeWhenAudioSinkIsNull)
+TEST_F(GstGenericPlayerTest, ShouldGetVolumeWhenAudioSinkIsNull)
 {
     setPipelineState(GST_STATE_PLAYING);
 


### PR DESCRIPTION
Summary: Require Audio Easing support on RialtoMSEAudioSink for Netflix - fade volume prop
Type: Fix
Test Plan: UT/ CT
Jira: RIALTO-593