### PR TITLE
Remove waiting for video in audio-only

### DIFF
--- a/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetupElement.cpp
@@ -198,8 +198,11 @@ void SetupElement::execute() const
 
     if (m_glibWrapper->gStrHasPrefix(GST_ELEMENT_NAME(m_element), "amlhalasink"))
     {
-        // Wait for video so that the audio aligns at the starting point with timeout of 4000ms.
-        m_glibWrapper->gObjectSet(m_element, "wait-video", TRUE, "a-wait-timeout", 4000, nullptr);
+        if (m_context.streamInfo.find(MediaSourceType::VIDEO) != m_context.streamInfo.end())
+        {
+            // Wait for video so that the audio aligns at the starting point with timeout of 4000ms.
+            m_glibWrapper->gObjectSet(m_element, "wait-video", TRUE, "a-wait-timeout", 4000, nullptr);
+        }
 
         // Xrun occasionally pauses the underlying sink due to unstable playback, but the rest of the pipeline
         // remains in the playing state. This causes problems with the synchronization of gst element and rialto

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -668,7 +668,6 @@ void GenericTasksTestsBase::shouldSetupAudioElementAmlhalasinkWhenNoVideo()
     expectSetupAudioSinkElement();
 }
 
-
 void GenericTasksTestsBase::shouldSetupAudioElementBrcmAudioSink()
 {
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -434,8 +434,6 @@ void GenericTasksTestsBase::expectSetupVideoDecoderElement()
 
 void GenericTasksTestsBase::expectSetupAudioSinkElement()
 {
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
     EXPECT_CALL(*testContext->m_gstWrapper,
                 gstElementFactoryListIsType(testContext->m_elementFactory,
@@ -572,6 +570,8 @@ void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingLowLatency()
 
     // This is the extra EXPECT caused by setting pendingLowLatency...
     EXPECT_CALL(testContext->m_gstPlayer, setLowLatency());
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     expectSetupAudioSinkElement();
 }
 
@@ -583,6 +583,8 @@ void GenericTasksTestsBase::shouldSetupAudioSinkElementWithPendingSync()
 
     // This is the extra EXPECT caused by setting pendingSync...
     EXPECT_CALL(testContext->m_gstPlayer, setSync());
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     expectSetupAudioSinkElement();
 }
 
@@ -643,8 +645,9 @@ void GenericTasksTestsBase::shouldSetupVideoSinkElementWithPendingRenderFrame()
     expectSetupVideoSinkElement();
 }
 
-void GenericTasksTestsBase::shouldSetupVideoElementAmlhalasink()
+void GenericTasksTestsBase::shouldSetupAudioElementAmlhalasinkWhenVideoExists()
 {
+    setContextStreamInfo(firebolt::rialto::MediaSourceType::VIDEO);
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(TRUE));
@@ -652,8 +655,19 @@ void GenericTasksTestsBase::shouldSetupVideoElementAmlhalasink()
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("wait-video")));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("a-wait-timeout")));
     EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("disable-xrun")));
-    expectSetupVideoSinkElement();
+    expectSetupAudioSinkElement();
 }
+
+void GenericTasksTestsBase::shouldSetupAudioElementAmlhalasinkWhenNoVideo()
+{
+    EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
+        .WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(TRUE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gObjectSetStub(G_OBJECT(testContext->m_element), StrEq("disable-xrun")));
+    expectSetupAudioSinkElement();
+}
+
 
 void GenericTasksTestsBase::shouldSetupAudioElementBrcmAudioSink()
 {
@@ -763,7 +777,8 @@ void GenericTasksTestsBase::shouldSetupAudioElementAutoAudioSink()
         .WillOnce(Return(&testContext->m_iterator));
     EXPECT_CALL(*testContext->m_glibWrapper, gValueUnset(_));
     EXPECT_CALL(*testContext->m_gstWrapper, gstIteratorFree(&testContext->m_iterator));
-
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     expectSetupAudioSinkElement();
 }
 
@@ -771,7 +786,8 @@ void GenericTasksTestsBase::shouldSetupAudioSinkElementOnly()
 {
     EXPECT_CALL(*testContext->m_glibWrapper, gTypeName(G_OBJECT_TYPE(testContext->m_element)))
         .WillOnce(Return(kElementTypeName.c_str()));
-
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_glibWrapper, gStrHasPrefix(_, StrEq("brcmaudiosink"))).WillOnce(Return(FALSE));
     expectSetupAudioSinkElement();
 }
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
@@ -88,7 +88,8 @@ protected:
     void shouldSetupVideoParserElementWithPendingStreamSyncMode();
     void shouldSetupAudioDecoderElementWithPendingBufferingLimit();
     void shouldSetupVideoSinkElementWithPendingRenderFrame();
-    void shouldSetupVideoElementAmlhalasink();
+    void shouldSetupAudioElementAmlhalasinkWhenNoVideo();
+    void shouldSetupAudioElementAmlhalasinkWhenVideoExists();
     void shouldSetupAudioElementBrcmAudioSink();
     void shouldSetupVideoElementAutoVideoSink();
     void shouldSetupAudioElementAutoAudioSink();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/SetupElementTest.cpp
@@ -83,9 +83,15 @@ TEST_F(SetupElementTest, shouldSetupVideoElementWithPendingRenderFrame)
     triggerSetupElement();
 }
 
-TEST_F(SetupElementTest, shouldSetupVideoElementForAmlhalasink)
+TEST_F(SetupElementTest, shouldSetupAudioElementAmlhalasinkWhenNoVideo)
 {
-    shouldSetupVideoElementAmlhalasink();
+    shouldSetupAudioElementAmlhalasinkWhenNoVideo();
+    triggerSetupElement();
+}
+
+TEST_F(SetupElementTest, shouldSetupAudioElementAmlhalasinkWhenVideoExists)
+{
+    shouldSetupAudioElementAmlhalasinkWhenVideoExists();
     triggerSetupElement();
 }
 


### PR DESCRIPTION
Summary: Remove waiting for video in audio-only on amlogic
Type: Fix
Test Plan: UT/ CT, fullstack
Jira: RIALTO-688