### PR TITLE
Fix RialtoServer deadlock during pipeline shutdown.

### DIFF
--- a/media/server/gstplayer/CMakeLists.txt
+++ b/media/server/gstplayer/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(
         source/tasks/generic/SetVolume.cpp
         source/tasks/generic/SetupElement.cpp
         source/tasks/generic/SetupSource.cpp
+        source/tasks/generic/Shutdown.cpp
         source/tasks/generic/Stop.cpp
         source/tasks/generic/SwitchSource.cpp
         source/tasks/generic/Underflow.cpp
@@ -80,6 +81,7 @@ add_library(
         source/tasks/webAudio/Play.cpp
         source/tasks/webAudio/SetCaps.cpp
         source/tasks/webAudio/SetVolume.cpp
+        source/tasks/webAudio/Shutdown.cpp
         source/tasks/webAudio/Stop.cpp
         source/tasks/webAudio/WebAudioPlayerTaskFactory.cpp
         source/tasks/webAudio/WriteBuffer.cpp

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -169,6 +169,7 @@ private:
     bool changePipelineState(GstState newState) override;
     void startPositionReportingAndCheckAudioUnderflowTimer() override;
     void stopPositionReportingAndCheckAudioUnderflowTimer() override;
+    void stopWorkerThread() override;
     void cancelUnderflow(firebolt::rialto::MediaSourceType mediaSource) override;
     void setPendingPlaybackRate() override;
     void renderFrame() override;

--- a/media/server/gstplayer/include/GstWebAudioPlayer.h
+++ b/media/server/gstplayer/include/GstWebAudioPlayer.h
@@ -94,6 +94,7 @@ public:
     uint64_t getQueuedBytes() override;
 
     bool changePipelineState(GstState newState) override;
+    void stopWorkerThread() override;
     void handleBusMessage(GstMessage *message) override;
     void ping(std::unique_ptr<IHeartbeatHandler> &&heartbeatHandler) override;
 

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -189,6 +189,11 @@ public:
     virtual void stopPositionReportingAndCheckAudioUnderflowTimer() = 0;
 
     /**
+     * @brief Stops worker thread. Called by the worker thread.
+     */
+    virtual void stopWorkerThread() = 0;
+
+    /**
      * @brief Restores playback after underflow. Called by the worker thread.
      *
      * @param[in] underflowFlag    : The audio or video underflow flag to be cleared.

--- a/media/server/gstplayer/include/IGstWebAudioPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstWebAudioPlayerPrivate.h
@@ -43,6 +43,11 @@ public:
      * @retval true on success.
      */
     virtual bool changePipelineState(GstState newState) = 0;
+
+    /**
+     * @brief Stops worker thread. Called by the worker thread.
+     */
+    virtual void stopWorkerThread() = 0;
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/IWorkerThread.h
+++ b/media/server/gstplayer/include/IWorkerThread.h
@@ -51,6 +51,11 @@ public:
     virtual void stop() = 0;
 
     /**
+     * @brief Joins the task thread
+     */
+    virtual void join() = 0;
+
+    /**
      * @brief Queues a task in the task queue.
      */
     virtual void enqueueTask(std::unique_ptr<IPlayerTask> &&task) = 0;

--- a/media/server/gstplayer/include/WorkerThread.h
+++ b/media/server/gstplayer/include/WorkerThread.h
@@ -43,6 +43,7 @@ public:
     ~WorkerThread() override;
 
     void stop() override;
+    void join() override;
     void enqueueTask(std::unique_ptr<IPlayerTask> &&task) override;
 
 private:

--- a/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
@@ -356,6 +356,15 @@ public:
                                                                  int32_t streamSyncMode) const = 0;
 
     /**
+     * @brief Creates a Shutdown task.
+     *
+     * @param[in] context       : The GstGenericPlayer context
+     *
+     * @retval the new Shutdown task instance.
+     */
+    virtual std::unique_ptr<IPlayerTask> createShutdown(IGstGenericPlayerPrivate &player) const = 0;
+
+    /**
      * @brief Creates a Stop task.
      *
      * @param[in] context    : The GstGenericPlayer context

--- a/media/server/gstplayer/include/tasks/IWebAudioPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IWebAudioPlayerTaskFactory.h
@@ -39,6 +39,15 @@ public:
     virtual ~IWebAudioPlayerTaskFactory() = default;
 
     /**
+     * @brief Creates a Shutdown task.
+     *
+     * @param[in] player     : The GstWebAudioPlayer instance
+     *
+     * @retval the new Shutdown task instance.
+     */
+    virtual std::unique_ptr<IPlayerTask> createShutdown(IGstWebAudioPlayerPrivate &player) const = 0;
+
+    /**
      * @brief Creates a Stop task.
      *
      * @param[in] player     : The GstWebAudioPlayer instance

--- a/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
@@ -95,6 +95,7 @@ public:
     std::unique_ptr<IPlayerTask> createSetStreamSyncMode(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                                          const firebolt::rialto::MediaSourceType &type,
                                                          int32_t streamSyncMode) const override;
+    std::unique_ptr<IPlayerTask> createShutdown(IGstGenericPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createStop(GenericPlayerContext &context,
                                             IGstGenericPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createUnderflow(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,

--- a/media/server/gstplayer/include/tasks/generic/Shutdown.h
+++ b/media/server/gstplayer/include/tasks/generic/Shutdown.h
@@ -17,22 +17,29 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
-#define FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+#ifndef FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SHUTDOWN_H_
+#define FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SHUTDOWN_H_
 
-#include "IWorkerThread.h"
-#include <gmock/gmock.h>
-#include <memory>
+#include "IPlayerTask.h"
+#include <gst/gst.h>
 
 namespace firebolt::rialto::server
 {
-class WorkerThreadMock : public IWorkerThread
-{
-public:
-    MOCK_METHOD(void, stop, (), (override));
-    MOCK_METHOD(void, join, (), (override));
-    MOCK_METHOD(void, enqueueTask, (std::unique_ptr<IPlayerTask> && task), (override));
-};
+class IGstGenericPlayerPrivate;
 } // namespace firebolt::rialto::server
 
-#endif // FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+namespace firebolt::rialto::server::tasks::generic
+{
+class Shutdown : public IPlayerTask
+{
+public:
+    explicit Shutdown(IGstGenericPlayerPrivate &player);
+    ~Shutdown() override;
+    void execute() const override;
+
+private:
+    IGstGenericPlayerPrivate &m_player;
+};
+} // namespace firebolt::rialto::server::tasks::generic
+
+#endif // FIREBOLT_RIALTO_SERVER_TASKS_GENERIC_SHUTDOWN_H_

--- a/media/server/gstplayer/include/tasks/webAudio/Shutdown.h
+++ b/media/server/gstplayer/include/tasks/webAudio/Shutdown.h
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2022 Sky UK
+ * Copyright 2023 Sky UK
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,29 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
-#define FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+#ifndef FIREBOLT_RIALTO_SERVER_TASKS_WEBAUDIO_SHUTDOWN_H_
+#define FIREBOLT_RIALTO_SERVER_TASKS_WEBAUDIO_SHUTDOWN_H_
 
-#include "IWorkerThread.h"
-#include <gmock/gmock.h>
-#include <memory>
+#include "IPlayerTask.h"
+#include <gst/gst.h>
 
 namespace firebolt::rialto::server
 {
-class WorkerThreadMock : public IWorkerThread
-{
-public:
-    MOCK_METHOD(void, stop, (), (override));
-    MOCK_METHOD(void, join, (), (override));
-    MOCK_METHOD(void, enqueueTask, (std::unique_ptr<IPlayerTask> && task), (override));
-};
+class IGstWebAudioPlayerPrivate;
 } // namespace firebolt::rialto::server
 
-#endif // FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+namespace firebolt::rialto::server::tasks::webaudio
+{
+class Shutdown : public IPlayerTask
+{
+public:
+    explicit Shutdown(IGstWebAudioPlayerPrivate &player);
+    ~Shutdown() override;
+    void execute() const override;
+
+private:
+    IGstWebAudioPlayerPrivate &m_player;
+};
+} // namespace firebolt::rialto::server::tasks::webaudio
+
+#endif // FIREBOLT_RIALTO_SERVER_TASKS_WEBAUDIO_SHUTDOWN_H_

--- a/media/server/gstplayer/include/tasks/webAudio/WebAudioPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/webAudio/WebAudioPlayerTaskFactory.h
@@ -37,6 +37,7 @@ public:
                               const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper);
     ~WebAudioPlayerTaskFactory() override = default;
 
+    std::unique_ptr<IPlayerTask> createShutdown(IGstWebAudioPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createStop(IGstWebAudioPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createPlay(IGstWebAudioPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createPause(IGstWebAudioPlayerPrivate &player) const override;

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -247,6 +247,9 @@ void GstGenericPlayer::initMsePipeline()
 
 void GstGenericPlayer::resetWorkerThread()
 {
+    // Shutdown task thread
+    m_workerThread->enqueueTask(m_taskFactory->createShutdown(*this));
+    m_workerThread->join();
     m_workerThread.reset();
 }
 
@@ -1630,6 +1633,14 @@ void GstGenericPlayer::stopPositionReportingAndCheckAudioUnderflowTimer()
     {
         m_positionReportingAndCheckAudioUnderflowTimer->cancel();
         m_positionReportingAndCheckAudioUnderflowTimer.reset();
+    }
+}
+
+void GstGenericPlayer::stopWorkerThread()
+{
+    if (m_workerThread)
+    {
+        m_workerThread->stop();
     }
 }
 

--- a/media/server/gstplayer/source/GstWebAudioPlayer.cpp
+++ b/media/server/gstplayer/source/GstWebAudioPlayer.cpp
@@ -371,6 +371,8 @@ void GstWebAudioPlayer::termWebAudioPipeline()
 
 void GstWebAudioPlayer::resetWorkerThread()
 {
+    m_workerThread->enqueueTask(m_taskFactory->createShutdown(*this));
+    m_workerThread->join();
     m_workerThread.reset();
 }
 
@@ -439,6 +441,14 @@ bool GstWebAudioPlayer::changePipelineState(GstState newState)
         return false;
     }
     return true;
+}
+
+void GstWebAudioPlayer::stopWorkerThread()
+{
+    if (m_workerThread)
+    {
+        m_workerThread->stop();
+    }
 }
 
 void GstWebAudioPlayer::handleBusMessage(GstMessage *message)

--- a/media/server/gstplayer/source/WorkerThread.cpp
+++ b/media/server/gstplayer/source/WorkerThread.cpp
@@ -62,11 +62,8 @@ WorkerThread::WorkerThread()
 
 WorkerThread::~WorkerThread()
 {
-    if (m_taskThread.joinable())
-    {
-        stop();
-        m_taskThread.join();
-    }
+    stop();
+    join();
 }
 
 void WorkerThread::stop()
@@ -75,6 +72,14 @@ void WorkerThread::stop()
 
     auto shutdownTask = [this]() { m_isTaskThreadActive = false; };
     enqueueTask(std::make_unique<FunctionTask>(std::move(shutdownTask)));
+}
+
+void WorkerThread::join()
+{
+    if (m_taskThread.joinable())
+    {
+        m_taskThread.join();
+    }
 }
 
 void WorkerThread::enqueueTask(std::unique_ptr<IPlayerTask> &&task)

--- a/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
@@ -52,6 +52,7 @@
 #include "tasks/generic/SetVolume.h"
 #include "tasks/generic/SetupElement.h"
 #include "tasks/generic/SetupSource.h"
+#include "tasks/generic/Shutdown.h"
 #include "tasks/generic/Stop.h"
 #include "tasks/generic/SwitchSource.h"
 #include "tasks/generic/Underflow.h"
@@ -247,6 +248,11 @@ GenericPlayerTaskFactory::createSetStreamSyncMode(GenericPlayerContext &context,
                                                   int32_t streamSyncMode) const
 {
     return std::make_unique<tasks::generic::SetStreamSyncMode>(context, player, type, streamSyncMode);
+}
+
+std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createShutdown(IGstGenericPlayerPrivate &player) const
+{
+    return std::make_unique<tasks::generic::Shutdown>(player);
 }
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createStop(GenericPlayerContext &context,

--- a/media/server/gstplayer/source/tasks/generic/Shutdown.cpp
+++ b/media/server/gstplayer/source/tasks/generic/Shutdown.cpp
@@ -17,22 +17,25 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
-#define FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+#include "tasks/generic/Shutdown.h"
+#include "IGstGenericPlayerPrivate.h"
+#include "RialtoServerLogging.h"
 
-#include "IWorkerThread.h"
-#include <gmock/gmock.h>
-#include <memory>
-
-namespace firebolt::rialto::server
+namespace firebolt::rialto::server::tasks::generic
 {
-class WorkerThreadMock : public IWorkerThread
+Shutdown::Shutdown(IGstGenericPlayerPrivate &player) : m_player{player}
 {
-public:
-    MOCK_METHOD(void, stop, (), (override));
-    MOCK_METHOD(void, join, (), (override));
-    MOCK_METHOD(void, enqueueTask, (std::unique_ptr<IPlayerTask> && task), (override));
-};
-} // namespace firebolt::rialto::server
+    RIALTO_SERVER_LOG_DEBUG("Constructing Shutdown");
+}
 
-#endif // FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+Shutdown::~Shutdown()
+{
+    RIALTO_SERVER_LOG_DEBUG("Shutdown finished");
+}
+
+void Shutdown::execute() const
+{
+    RIALTO_SERVER_LOG_DEBUG("Executing Shutdown");
+    m_player.stopWorkerThread();
+}
+} // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/webAudio/Shutdown.cpp
+++ b/media/server/gstplayer/source/tasks/webAudio/Shutdown.cpp
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2022 Sky UK
+ * Copyright 2023 Sky UK
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,25 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
-#define FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+#include "tasks/webAudio/Shutdown.h"
+#include "IGstWebAudioPlayerPrivate.h"
+#include "RialtoServerLogging.h"
 
-#include "IWorkerThread.h"
-#include <gmock/gmock.h>
-#include <memory>
-
-namespace firebolt::rialto::server
+namespace firebolt::rialto::server::tasks::webaudio
 {
-class WorkerThreadMock : public IWorkerThread
+Shutdown::Shutdown(IGstWebAudioPlayerPrivate &player) : m_player{player}
 {
-public:
-    MOCK_METHOD(void, stop, (), (override));
-    MOCK_METHOD(void, join, (), (override));
-    MOCK_METHOD(void, enqueueTask, (std::unique_ptr<IPlayerTask> && task), (override));
-};
-} // namespace firebolt::rialto::server
+    RIALTO_SERVER_LOG_DEBUG("Constructing Shutdown");
+}
 
-#endif // FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+Shutdown::~Shutdown()
+{
+    RIALTO_SERVER_LOG_DEBUG("Shutdown finished");
+}
+
+void Shutdown::execute() const
+{
+    RIALTO_SERVER_LOG_DEBUG("Executing Shutdown");
+    m_player.stopWorkerThread();
+}
+} // namespace firebolt::rialto::server::tasks::webaudio

--- a/media/server/gstplayer/source/tasks/webAudio/WebAudioPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/webAudio/WebAudioPlayerTaskFactory.cpp
@@ -24,6 +24,7 @@
 #include "tasks/webAudio/Play.h"
 #include "tasks/webAudio/SetCaps.h"
 #include "tasks/webAudio/SetVolume.h"
+#include "tasks/webAudio/Shutdown.h"
 #include "tasks/webAudio/Stop.h"
 #include "tasks/webAudio/WriteBuffer.h"
 
@@ -34,6 +35,11 @@ WebAudioPlayerTaskFactory::WebAudioPlayerTaskFactory(
     const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper)
     : m_client{client}, m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}
 {
+}
+
+std::unique_ptr<IPlayerTask> WebAudioPlayerTaskFactory::createShutdown(IGstWebAudioPlayerPrivate &player) const
+{
+    return std::make_unique<tasks::webaudio::Shutdown>(player);
 }
 
 std::unique_ptr<IPlayerTask> WebAudioPlayerTaskFactory::createStop(IGstWebAudioPlayerPrivate &player) const

--- a/tests/unittests/media/server/gstplayer/CMakeLists.txt
+++ b/tests/unittests/media/server/gstplayer/CMakeLists.txt
@@ -63,6 +63,7 @@ add_gtests(RialtoServerGstPlayerUnitTests
     genericPlayer/tasksTests/SetVolumeTest.cpp
     genericPlayer/tasksTests/SetupElementTest.cpp
     genericPlayer/tasksTests/SetupSourceTest.cpp
+    genericPlayer/tasksTests/ShutdownTest.cpp
     genericPlayer/tasksTests/StopTest.cpp
     genericPlayer/tasksTests/SwitchSourceTest.cpp
     genericPlayer/tasksTests/UnderflowTest.cpp
@@ -85,6 +86,7 @@ add_gtests(RialtoServerGstPlayerUnitTests
     webAudioPlayer/taskTests/EosTest.cpp
     webAudioPlayer/taskTests/HandleBusMessageTest.cpp
     webAudioPlayer/taskTests/SetVolumeTest.cpp
+    webAudioPlayer/taskTests/ShutdownTest.cpp
     webAudioPlayer/taskTests/StopTest.cpp
     webAudioPlayer/taskTests/SetCapsTest.cpp
     webAudioPlayer/taskTests/WriteBufferTest.cpp

--- a/tests/unittests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -408,6 +408,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, UnknownMediaType)
 {
     EXPECT_CALL(m_gstInitialiserMock, waitForInitialisation());
     initFactories();
+    expectShutdown();
     executeTaskWhenEnqueued();
     EXPECT_CALL(*m_gstSrcMock, initSrc());
     EXPECT_CALL(m_workerThreadFactoryMock, createWorkerThread()).WillOnce(Return(ByMove(std::move(workerThread))));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -1679,6 +1679,12 @@ TEST_F(GstGenericPlayerPrivateTest, shouldNotStopInactivePositionReportingTimerW
     m_sut->stopPositionReportingAndCheckAudioUnderflowTimer();
 }
 
+TEST_F(GstGenericPlayerPrivateTest, shouldStopWorkerThread)
+{
+    EXPECT_CALL(m_workerThreadMock, stop());
+    m_sut->stopWorkerThread();
+}
+
 TEST_F(GstGenericPlayerPrivateTest, shouldUpdatePlaybackGroup)
 {
     GstElement typefind;

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -57,6 +57,7 @@
 #include "tasks/generic/SetVolume.h"
 #include "tasks/generic/SetupElement.h"
 #include "tasks/generic/SetupSource.h"
+#include "tasks/generic/Shutdown.h"
 #include "tasks/generic/Stop.h"
 #include "tasks/generic/SwitchSource.h"
 #include "tasks/generic/Underflow.h"
@@ -2370,6 +2371,17 @@ void GenericTasksTestsBase::triggerVideoUnderflow()
 void GenericTasksTestsBase::shouldNotifyVideoUnderflow()
 {
     EXPECT_CALL(testContext->m_gstPlayerClient, notifyBufferUnderflow(firebolt::rialto::MediaSourceType::VIDEO));
+}
+
+void GenericTasksTestsBase::shouldStopWorkerThread()
+{
+    EXPECT_CALL(testContext->m_gstPlayer, stopWorkerThread());
+}
+
+void GenericTasksTestsBase::triggerShutdown()
+{
+    firebolt::rialto::server::tasks::generic::Shutdown task{testContext->m_gstPlayer};
+    task.execute();
 }
 
 void GenericTasksTestsBase::shouldSetVideoMute()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
@@ -259,6 +259,10 @@ protected:
     void triggerVideoUnderflow();
     void shouldNotifyVideoUnderflow();
 
+    // Shutdown test methods
+    void shouldStopWorkerThread();
+    void triggerShutdown();
+
     // SetMute test methods
     void triggerSetAudioMute();
     void triggerSetVideoMute();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -50,11 +50,20 @@ void GstGenericPlayerTestCommon::gstPlayerWillBeCreated()
 
 void GstGenericPlayerTestCommon::gstPlayerWillBeDestroyed()
 {
+    expectShutdown();
     expectStop();
     EXPECT_CALL(*m_gstWrapperMock, gstPipelineGetBus(GST_PIPELINE(&m_pipeline))).WillOnce(Return(&m_bus));
     EXPECT_CALL(*m_gstWrapperMock, gstBusSetSyncHandler(&m_bus, nullptr, nullptr, nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_bus));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pipeline));
+}
+
+void GstGenericPlayerTestCommon::expectShutdown()
+{
+    std::unique_ptr<IPlayerTask> shutdownTask{std::make_unique<StrictMock<PlayerTaskMock>>()};
+    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*shutdownTask), execute());
+    EXPECT_CALL(m_taskFactoryMock, createShutdown(_)).WillOnce(Return(ByMove(std::move(shutdownTask))));
+    EXPECT_CALL(m_workerThreadMock, join());
 }
 
 void GstGenericPlayerTestCommon::expectStop()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -106,6 +106,7 @@ public:
 protected:
     void gstPlayerWillBeCreated();
     void gstPlayerWillBeDestroyed();
+    void expectShutdown();
     void expectStop();
     void executeTaskWhenEnqueued();
     void initFactories();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
@@ -64,6 +64,7 @@
 #include "tasks/generic/SetVolume.h"
 #include "tasks/generic/SetupElement.h"
 #include "tasks/generic/SetupSource.h"
+#include "tasks/generic/Shutdown.h"
 #include "tasks/generic/Stop.h"
 #include "tasks/generic/SwitchSource.h"
 #include "tasks/generic/Underflow.h"
@@ -277,6 +278,13 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetStreamSyncMode)
                                               kStreamSyncMode);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::SetStreamSyncMode &>(*task));
+}
+
+TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateShutdown)
+{
+    auto task = m_sut.createShutdown(m_gstPlayer);
+    EXPECT_NE(task, nullptr);
+    EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::Shutdown &>(*task));
 }
 
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateStop)

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/ShutdownTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/ShutdownTest.cpp
@@ -17,22 +17,14 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
-#define FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+#include "GenericTasksTestsBase.h"
 
-#include "IWorkerThread.h"
-#include <gmock/gmock.h>
-#include <memory>
-
-namespace firebolt::rialto::server
+class ShutdownTest : public GenericTasksTestsBase
 {
-class WorkerThreadMock : public IWorkerThread
-{
-public:
-    MOCK_METHOD(void, stop, (), (override));
-    MOCK_METHOD(void, join, (), (override));
-    MOCK_METHOD(void, enqueueTask, (std::unique_ptr<IPlayerTask> && task), (override));
 };
-} // namespace firebolt::rialto::server
 
-#endif // FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+TEST_F(ShutdownTest, shouldShutdown)
+{
+    shouldStopWorkerThread();
+    triggerShutdown();
+}

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/CreateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/CreateTest.cpp
@@ -184,6 +184,9 @@ TEST_F(RialtoServerCreateGstWebAudioPlayerTest, createPipelineFailure)
     expectInitWorkerThread();
     EXPECT_CALL(*m_gstWrapperMock, gstPipelineNew(_)).WillOnce(Return(nullptr));
 
+    // Reset worker thread on failure
+    expectResetWorkerThread();
+
     EXPECT_THROW(m_gstPlayer = std::make_unique<GstWebAudioPlayer>(&m_gstPlayerClient, m_priority, m_gstWrapperMock,
                                                                    m_glibWrapperMock, m_gstInitialiserMock,
                                                                    m_gstSrcFactoryMock, std::move(m_taskFactory),
@@ -208,6 +211,7 @@ TEST_F(RialtoServerCreateGstWebAudioPlayerTest, createAppSrcFailure)
     EXPECT_CALL(*m_gstWrapperMock, gstPipelineGetBus(GST_PIPELINE(&m_pipeline))).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pipeline));
     expectTaskStop();
+    expectResetWorkerThread();
 
     EXPECT_THROW(m_gstPlayer = std::make_unique<GstWebAudioPlayer>(&m_gstPlayerClient, m_priority, m_gstWrapperMock,
                                                                    m_glibWrapperMock, m_gstInitialiserMock,
@@ -526,6 +530,7 @@ TEST_F(RialtoServerCreateGstWebAudioPlayerTest, createGstDispatcherAfterFailureT
 
     expectTaskStop();
     expectTermPipeline();
+    expectResetWorkerThread();
 
     EXPECT_THROW(m_gstPlayer = std::make_unique<GstWebAudioPlayer>(&m_gstPlayerClient, m_priority, m_gstWrapperMock,
                                                                    m_glibWrapperMock, m_gstInitialiserMock,

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/GstWebAudioPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/GstWebAudioPlayerPrivateTest.cpp
@@ -52,3 +52,9 @@ TEST_F(GstWebAudioPlayerPrivateTest, shouldChangePlaybackState)
     EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(_, GST_STATE_PLAYING)).WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
     EXPECT_TRUE(m_sut->changePipelineState(GST_STATE_PLAYING));
 }
+
+TEST_F(GstWebAudioPlayerPrivateTest, shouldStopWorkerThread)
+{
+    EXPECT_CALL(m_workerThreadMock, stop());
+    m_sut->stopWorkerThread();
+}

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.cpp
@@ -55,8 +55,18 @@ void GstWebAudioPlayerTestCommon::gstPlayerWillBeCreatedForGenericPlatform()
 
 void GstWebAudioPlayerTestCommon::gstPlayerWillBeDestroyed()
 {
+    expectResetWorkerThread();
     expectTaskStop();
     expectTermPipeline();
+}
+
+void GstWebAudioPlayerTestCommon::expectResetWorkerThread()
+{
+    std::unique_ptr<IPlayerTask> shutdownTask{std::make_unique<StrictMock<PlayerTaskMock>>()};
+    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*shutdownTask), execute());
+    EXPECT_CALL(m_taskFactoryMock, createShutdown(_)).WillOnce(Return(ByMove(std::move(shutdownTask))));
+    EXPECT_CALL(m_workerThreadMock, join());
+    executeTaskWhenEnqueued();
 }
 
 void GstWebAudioPlayerTestCommon::expectTermPipeline()

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.h
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/common/GstWebAudioPlayerTestCommon.h
@@ -100,6 +100,7 @@ protected:
     void expectAddBinFailure();
     void expectLinkElementFailure();
     void expectTermPipeline();
+    void expectResetWorkerThread();
     void expectTaskStop();
 
     GstElement m_pipeline{};

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/common/WebAudioTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/common/WebAudioTasksTestsBase.cpp
@@ -30,6 +30,7 @@
 #include "tasks/webAudio/Play.h"
 #include "tasks/webAudio/SetCaps.h"
 #include "tasks/webAudio/SetVolume.h"
+#include "tasks/webAudio/Shutdown.h"
 #include "tasks/webAudio/Stop.h"
 #include "tasks/webAudio/WriteBuffer.h"
 
@@ -122,6 +123,17 @@ void WebAudioTasksTestsBase::shouldGstSetVolume()
 void WebAudioTasksTestsBase::triggerSetVolume()
 {
     firebolt::rialto::server::tasks::webaudio::SetVolume task{testContext->m_context, testContext->m_gstWrapper, kVolume};
+    task.execute();
+}
+
+void WebAudioTasksTestsBase::shouldStopWorkerThread()
+{
+    EXPECT_CALL(testContext->m_gstPlayer, stopWorkerThread());
+}
+
+void WebAudioTasksTestsBase::triggerShutdown()
+{
+    firebolt::rialto::server::tasks::webaudio::Shutdown task{testContext->m_gstPlayer};
     task.execute();
 }
 

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/common/WebAudioTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/common/WebAudioTasksTestsBase.h
@@ -68,6 +68,10 @@ protected:
     void shouldGstSetVolume();
     void triggerSetVolume();
 
+    // Shutdown test methods
+    void shouldStopWorkerThread();
+    void triggerShutdown();
+
     // Stop test methods
     void shouldChangePlayerStateNull();
     void triggerStop();

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/taskTests/ShutdownTest.cpp
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/taskTests/ShutdownTest.cpp
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2022 Sky UK
+ * Copyright 2023 Sky UK
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,14 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
-#define FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+#include "WebAudioTasksTestsBase.h"
 
-#include "IWorkerThread.h"
-#include <gmock/gmock.h>
-#include <memory>
-
-namespace firebolt::rialto::server
+class WebAudioShutdownTest : public WebAudioTasksTestsBase
 {
-class WorkerThreadMock : public IWorkerThread
-{
-public:
-    MOCK_METHOD(void, stop, (), (override));
-    MOCK_METHOD(void, join, (), (override));
-    MOCK_METHOD(void, enqueueTask, (std::unique_ptr<IPlayerTask> && task), (override));
 };
-} // namespace firebolt::rialto::server
 
-#endif // FIREBOLT_RIALTO_SERVER_WORKER_THREAD_MOCK_H_
+TEST_F(WebAudioShutdownTest, shouldShutdown)
+{
+    shouldStopWorkerThread();
+    triggerShutdown();
+}

--- a/tests/unittests/media/server/gstplayer/webAudioPlayer/taskTests/WebAudioPlayerTaskFactoryTest.cpp
+++ b/tests/unittests/media/server/gstplayer/webAudioPlayer/taskTests/WebAudioPlayerTaskFactoryTest.cpp
@@ -32,6 +32,7 @@
 #include "tasks/webAudio/Play.h"
 #include "tasks/webAudio/SetCaps.h"
 #include "tasks/webAudio/SetVolume.h"
+#include "tasks/webAudio/Shutdown.h"
 #include "tasks/webAudio/Stop.h"
 #include "tasks/webAudio/WriteBuffer.h"
 #include <gtest/gtest.h>
@@ -88,6 +89,13 @@ TEST_F(WebAudioPlayerTaskFactoryTest, ShouldStop)
     auto task = m_sut.createStop(m_gstPlayer);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::webaudio::Stop &>(*task));
+}
+
+TEST_F(WebAudioPlayerTaskFactoryTest, ShouldShutdown)
+{
+    auto task = m_sut.createShutdown(m_gstPlayer);
+    EXPECT_NE(task, nullptr);
+    EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::webaudio::Shutdown &>(*task));
 }
 
 TEST_F(WebAudioPlayerTaskFactoryTest, ShouldSetVolume)

--- a/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
@@ -101,6 +101,7 @@ public:
                 (GenericPlayerContext & context, IGstGenericPlayerPrivate &player,
                  const firebolt::rialto::MediaSourceType &type, int32_t streamSyncMode),
                 (const, override));
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createShutdown, (IGstGenericPlayerPrivate & player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createStop,
                 (GenericPlayerContext & context, IGstGenericPlayerPrivate &player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createUnderflow,

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -58,6 +58,7 @@ public:
     MOCK_METHOD(bool, changePipelineState, (GstState newState), (override));
     MOCK_METHOD(void, startPositionReportingAndCheckAudioUnderflowTimer, (), (override));
     MOCK_METHOD(void, stopPositionReportingAndCheckAudioUnderflowTimer, (), (override));
+    MOCK_METHOD(void, stopWorkerThread, (), (override));
     MOCK_METHOD(void, cancelUnderflow, (firebolt::rialto::MediaSourceType mediaSource), (override));
     MOCK_METHOD(void, setPendingPlaybackRate, (), (override));
     MOCK_METHOD(void, updatePlaybackGroup, (GstElement * typefind, const GstCaps *caps), (override));

--- a/tests/unittests/media/server/mocks/gstplayer/GstWebAudioPlayerPrivateMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstWebAudioPlayerPrivateMock.h
@@ -29,6 +29,7 @@ class GstWebAudioPlayerPrivateMock : public IGstWebAudioPlayerPrivate
 {
 public:
     MOCK_METHOD(bool, changePipelineState, (GstState newState), (override));
+    MOCK_METHOD(void, stopWorkerThread, (), (override));
 };
 } // namespace firebolt::rialto::server
 

--- a/tests/unittests/media/server/mocks/gstplayer/WebAudioPlayerTaskFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/WebAudioPlayerTaskFactoryMock.h
@@ -29,6 +29,7 @@ namespace firebolt::rialto::server
 class WebAudioPlayerTaskFactoryMock : public IWebAudioPlayerTaskFactory
 {
 public:
+    MOCK_METHOD(std::unique_ptr<IPlayerTask>, createShutdown, (IGstWebAudioPlayerPrivate & player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createStop, (IGstWebAudioPlayerPrivate & player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createPlay, (IGstWebAudioPlayerPrivate & player), (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createPause, (IGstWebAudioPlayerPrivate & player), (const, override));


### PR DESCRIPTION
Summary: Fix RialtoServer deadlock during pipeline shutdown.
Type: Fix
Test Plan: UT/ CT, Fullstack
Jira: ENTDAI-748