### PR TITLE
Add MP3 support to rialto

### DIFF
--- a/media/server/gstplayer/include/CapsBuilder.h
+++ b/media/server/gstplayer/include/CapsBuilder.h
@@ -61,7 +61,8 @@ protected:
     GstCaps *createOpusCaps();
     GstCaps *getAudioSpecificConfiguration() const;
     void addSampleRateAndChannelsToCaps(GstCaps *caps) const;
-    void addMpegVersionToCaps(GstCaps *caps) const;
+    void addMpegVersion4ToCaps(GstCaps *caps) const;
+    void addMp3Caps(GstCaps *caps) const;
     void addRawAudioData(GstCaps *caps) const;
     void addFlacSpecificData(GstCaps *caps) const;
 

--- a/media/server/gstplayer/include/GstMimeMapping.h
+++ b/media/server/gstplayer/include/GstMimeMapping.h
@@ -46,21 +46,15 @@ namespace firebolt::rialto::server
 inline GstCaps *createSimpleCapsFromMimeType(std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper,
                                              const IMediaPipeline::MediaSource &m_attachedSource)
 {
-    static const std::unordered_map<std::string, std::string> mimeToMediaType = {{"video/h264", "video/x-h264"},
-                                                                                 {"video/h265", "video/x-h265"},
-                                                                                 {"video/x-av1", "video/x-av1"},
-                                                                                 {"video/x-vp9", "video/x-vp9"},
-                                                                                 {"video/mp4", "video/mpeg"},
-                                                                                 {"audio/mp4", "audio/mpeg"},
-                                                                                 {"audio/aac", "audio/mpeg"},
-                                                                                 {"audio/x-eac3", "audio/x-eac3"},
-                                                                                 {"audio/x-opus", "audio/x-opus"},
-                                                                                 {"audio/b-wav", "audio/b-wav"},
-                                                                                 {"audio/x-raw", "audio/x-raw"},
-                                                                                 {"audio/x-flac", "audio/x-flac"},
-                                                                                 {"text/vtt",
-                                                                                  "application/x-subtitle-vtt"},
-                                                                                 {"text/ttml", "application/ttml+xml"}};
+    static const std::unordered_map<std::string, std::string> mimeToMediaType =
+        {{"video/h264", "video/x-h264"},       {"video/h265", "video/x-h265"},
+         {"video/x-av1", "video/x-av1"},       {"video/x-vp9", "video/x-vp9"},
+         {"video/mp4", "video/mpeg"},          {"audio/mp4", "audio/mpeg"},
+         {"audio/mp3", "audio/mpeg"},          {"audio/aac", "audio/mpeg"},
+         {"audio/x-eac3", "audio/x-eac3"},     {"audio/x-opus", "audio/x-opus"},
+         {"audio/b-wav", "audio/b-wav"},       {"audio/x-raw", "audio/x-raw"},
+         {"audio/x-flac", "audio/x-flac"},     {"text/vtt", "application/x-subtitle-vtt"},
+         {"text/ttml", "application/ttml+xml"}};
     auto mimeToMediaTypeIt = mimeToMediaType.find(m_attachedSource.getMimeType());
     if (mimeToMediaTypeIt != mimeToMediaType.end())
     {
@@ -85,6 +79,7 @@ convertFromCapsVectorToMimeSet(const std::vector<GstCaps *> &supportedCaps,
 {
     std::vector<std::pair<GstCaps *, std::vector<std::string>>> capsToMimeVec =
         {{m_gstWrapper->gstCapsFromString("audio/mpeg, mpegversion=(int)4"), {"audio/mp4", "audio/aac", "audio/x-eac3"}},
+         {m_gstWrapper->gstCapsFromString("audio/mpeg, mpegversion=(int)1, layer=(int)3"), {"audio/mp3"}},
          {m_gstWrapper->gstCapsFromString("audio/x-eac3"), {"audio/x-eac3"}},
          {m_gstWrapper->gstCapsFromString("audio/b-wav"), {"audio/b-wav"}},
          {m_gstWrapper->gstCapsFromString("audio/x-raw"), {"audio/x-raw"}},

--- a/media/server/gstplayer/source/CapsBuilder.cpp
+++ b/media/server/gstplayer/source/CapsBuilder.cpp
@@ -109,7 +109,11 @@ GstCaps *MediaSourceAudioCapsBuilder::buildCaps()
     GstCaps *caps = MediaSourceCapsBuilder::buildCaps();
     if (mimeType == "audio/mp4" || mimeType == "audio/aac")
     {
-        addMpegVersionToCaps(caps);
+        addMpegVersion4ToCaps(caps);
+    }
+    else if (mimeType == "audio/mp3")
+    {
+        addMp3Caps(caps);
     }
     else if (mimeType == "audio/b-wav" || mimeType == "audio/x-raw")
     {
@@ -166,9 +170,15 @@ void MediaSourceAudioCapsBuilder::addSampleRateAndChannelsToCaps(GstCaps *caps) 
         m_gstWrapper->gstCapsSetSimple(caps, "rate", G_TYPE_INT, audioConfig.sampleRate, nullptr);
 }
 
-void MediaSourceAudioCapsBuilder::addMpegVersionToCaps(GstCaps *caps) const
+void MediaSourceAudioCapsBuilder::addMpegVersion4ToCaps(GstCaps *caps) const
 {
     m_gstWrapper->gstCapsSetSimple(caps, "mpegversion", G_TYPE_INT, 4, nullptr);
+}
+
+void MediaSourceAudioCapsBuilder::addMp3Caps(GstCaps *caps) const
+{
+    m_gstWrapper->gstCapsSetSimple(caps, "mpegversion", G_TYPE_INT, 1, nullptr);
+    m_gstWrapper->gstCapsSetSimple(caps, "layer", G_TYPE_INT, 3, nullptr);
 }
 
 void MediaSourceAudioCapsBuilder::addRawAudioData(GstCaps *caps) const

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstCapabilitiesTest.cpp
@@ -74,6 +74,7 @@ public:
     GstCapabilitiesTest()
         // valid values of GstCaps are not needed, only addresses will be used
         : m_capsMap{{"audio/mpeg, mpegversion=(int)4", {}},
+                    {"audio/mpeg, mpegversion=(int)1, layer=(int)3", {}},
                     {"audio/x-eac3", {}},
                     {"audio/x-opus", {}},
                     {"audio/x-opus, channel-mapping-family=(int)0", {}},
@@ -584,6 +585,9 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecoderWithOneSinkPad_Parse
         .WillOnce(Return(true));
     EXPECT_CALL(*m_gstWrapperMock, gstCapsCanIntersect(&m_capsMap["audio/x-raw"], &m_sinkTemplateCaps))
         .WillOnce(Return(true));
+    EXPECT_CALL(*m_gstWrapperMock,
+                gstCapsCanIntersect(&m_capsMap["audio/mpeg, mpegversion=(int)1, layer=(int)3"], &m_sinkTemplateCaps))
+        .WillOnce(Return(true));
     EXPECT_CALL(m_gstInitialiserMock, waitForInitialisation());
 
     m_sut = std::make_unique<GstCapabilities>(m_gstWrapperMock, m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
@@ -593,6 +597,7 @@ TEST_F(GstCapabilitiesTest, CreateGstCapabilities_OneDecoderWithOneSinkPad_Parse
 
     EXPECT_TRUE(m_sut->isMimeTypeSupported("video/h264"));
     EXPECT_TRUE(m_sut->isMimeTypeSupported("audio/x-raw"));
+    EXPECT_TRUE(m_sut->isMimeTypeSupported("audio/mp3"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("video/x-av1"));
     EXPECT_FALSE(m_sut->isMimeTypeSupported("audio/x-opus"));
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -1540,6 +1540,30 @@ void GenericTasksTestsBase::triggerAttachFlacAudioSource()
     task.execute();
 }
 
+void GenericTasksTestsBase::shouldAttachMp3AudioSource()
+{
+    EXPECT_CALL(*testContext->m_gstWrapper, gstCapsNewEmptySimple(StrEq("audio/mpeg")))
+        .WillOnce(Return(&testContext->m_gstCaps1));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstCapsSetSimpleIntStub(&testContext->m_gstCaps1, StrEq("mpegversion"), G_TYPE_INT, 1));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstCapsSetSimpleIntStub(&testContext->m_gstCaps1, StrEq("layer"), G_TYPE_INT, 3));
+    expectSetCaps();
+}
+
+void GenericTasksTestsBase::triggerAttachMp3AudioSource()
+{
+    std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/mp3", false);
+    firebolt::rialto::server::tasks::generic::AttachSource task{testContext->m_context,
+                                                                testContext->m_gstWrapper,
+                                                                testContext->m_glibWrapper,
+                                                                testContext->m_gstTextTrackSinkFactoryMock,
+                                                                testContext->m_gstPlayer,
+                                                                source};
+    task.execute();
+}
+
 void GenericTasksTestsBase::expectAddChannelAndRateAudioToCaps()
 {
     EXPECT_CALL(*testContext->m_gstWrapper,

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
@@ -168,6 +168,8 @@ protected:
     void triggerAttachXrawAudioSource();
     void shouldAttachFlacAudioSource();
     void triggerAttachFlacAudioSource();
+    void shouldAttachMp3AudioSource();
+    void triggerAttachMp3AudioSource();
     void shouldAttachVideoSource(const std::string &mime, const std::string &alignment, const std::string &format);
     void triggerAttachVideoSource(const std::string &mimeType, firebolt::rialto::SegmentAlignment segmentAligment,
                                   firebolt::rialto::StreamFormat streamFormat);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/AttachSourceTest.cpp
@@ -65,6 +65,13 @@ TEST_F(AttachSourceTest, shouldAttachFlacAudioSource)
     checkAudioSourceAttachedWithDrm();
 }
 
+TEST_F(AttachSourceTest, shouldAttachMp3AudioSource)
+{
+    shouldAttachMp3AudioSource();
+    triggerAttachMp3AudioSource();
+    checkAudioSourceAttached();
+}
+
 TEST_F(AttachSourceTest, shouldAttachVideoSourceAuAvc)
 {
     std::string mimeType = "video/h264";


### PR DESCRIPTION
Summary: Add MP3 support to rialto
Type: Fix
Test Plan: UT/ CT, Fullstack
Jira: ENTDAI-748