### PR TITLE
ENTDAI-1354 : Investigate Coverity output in Rialto - CCP JIRA

### DIFF
--- a/media/client/ipc/source/IpcModule.cpp
+++ b/media/client/ipc/source/IpcModule.cpp
@@ -126,7 +126,8 @@ bool IpcModule::reattachChannelIfRequired()
 
 std::shared_ptr<ipc::IChannel> IpcModule::getConnectedChannel()
 {
-    std::shared_ptr<ipc::IChannel> ipcChannel = m_ipc.getChannel().lock();
+    std::weak_ptr<ipc::IChannel> weakChannel = m_ipc.getChannel();
+    std::shared_ptr<ipc::IChannel> ipcChannel = weakChannel.lock();
     if (ipcChannel && ipcChannel->isConnected())
     {
         return ipcChannel;

--- a/media/public/include/IMediaPipeline.h
+++ b/media/public/include/IMediaPipeline.h
@@ -543,7 +543,7 @@ public:
          *
          * @retval the media key session id.
          */
-        const int32_t getMediaKeySessionId() const { return m_mediaKeySessionId; }
+        int32_t getMediaKeySessionId() const { return m_mediaKeySessionId; }
 
         /**
          * @brief Returns the key id. Empty if unencrypted.
@@ -571,14 +571,14 @@ public:
          *
          * @retval the initWithLast15 value.
          */
-        const uint32_t getInitWithLast15() const { return m_initWithLast15; }
+        uint32_t getInitWithLast15() const { return m_initWithLast15; }
 
         /**
          * @brief Returns the segment alignment
          *
          * @retval the segment alignment
          */
-        const SegmentAlignment getSegmentAlignment() const { return m_alignment; }
+        SegmentAlignment getSegmentAlignment() const { return m_alignment; }
 
         /**
          * @brief Gets the codec data
@@ -602,7 +602,7 @@ public:
          *
          * @retval if the encryption pattern has been set
          */
-        const bool getEncryptionPattern(uint32_t &crypt, uint32_t &skip) const
+        bool getEncryptionPattern(uint32_t &crypt, uint32_t &skip) const
         {
             crypt = m_crypt;
             skip = m_skip;

--- a/media/server/gstplayer/source/GstSrc.cpp
+++ b/media/server/gstplayer/source/GstSrc.cpp
@@ -48,7 +48,9 @@ static void gstRialtoSrcFinalize(GObject *object)
 {
     GstRialtoSrc *src = GST_RIALTO_SRC(object);
     GstRialtoSrcPrivate *priv = src->priv;
+    GST_OBJECT_LOCK(src);
     g_free(priv->uri);
+    GST_OBJECT_UNLOCK(src);
     priv->~GstRialtoSrcPrivate();
     GST_CALL_PARENT(G_OBJECT_CLASS, finalize, (object));
 }

--- a/media/server/main/interface/IMainThread.h
+++ b/media/server/main/interface/IMainThread.h
@@ -20,7 +20,6 @@
 #ifndef FIREBOLT_RIALTO_SERVER_I_MAIN_THREAD_H_
 #define FIREBOLT_RIALTO_SERVER_I_MAIN_THREAD_H_
 
-#include "IMainThread.h"
 #include <functional>
 #include <memory>
 #include <utility>

--- a/media/server/main/source/ActiveRequests.cpp
+++ b/media/server/main/source/ActiveRequests.cpp
@@ -104,6 +104,7 @@ AddSegmentStatus ActiveRequests::addSegment(std::uint32_t requestId,
         return AddSegmentStatus::ERROR;
     }
 
+    std::unique_lock<std::mutex> lock{m_mutex};
     auto requestIter{m_requestMap.find(requestId)};
     if (requestIter != m_requestMap.end())
     {
@@ -115,6 +116,7 @@ AddSegmentStatus ActiveRequests::addSegment(std::uint32_t requestId,
 
 const IMediaPipeline::MediaSegmentVector &ActiveRequests::getSegments(std::uint32_t requestId) const
 {
+    std::unique_lock<std::mutex> lock{m_mutex};
     auto requestIter{m_requestMap.find(requestId)};
     if (requestIter != m_requestMap.end())
     {

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -70,7 +70,7 @@ const char *convertInitDataType(const firebolt::rialto::InitDataType &initDataTy
     }
     }
 }
-const firebolt::rialto::KeyStatus convertKeyStatus(const KeyStatus &ocdmKeyStatus)
+firebolt::rialto::KeyStatus convertKeyStatus(const KeyStatus &ocdmKeyStatus)
 {
     switch (ocdmKeyStatus)
     {


### PR DESCRIPTION
Summary: To clear the Coverity warnings [MISSING_LOCK, PW.INCLUDE_RECURSION, PW.USELESS_TYPE_QUALIFIER_ON_RETURN_TYPE and RETURN_LOCAL]
Type: Fix
Jira: ENTDAI-1354/RDKECOREMW-356