### PR TITLE
Added profiler to Rialto Server

### DIFF
--- a/build_ut.py
+++ b/build_ut.py
@@ -36,7 +36,7 @@ suiteInfo = {
     "client" : {"suite" : "RialtoClientUnitTests", "path" : "/tests/unittests/media/client/main/"},
     "clientipc" : {"suite" : "RialtoClientIpcUnitTests", "path" : "/tests/unittests/media/client/ipc/"},
     "playercommon" : {"suite" : "RialtoPlayerCommonUnitTests", "path" : "/tests/unittests/media/common/"},
-    "common" : {"suite" : "RialtoCommonUnitTests", "path" : "/tests/unittests/common/unittests/"},
+    "common" : {"suite" : "RialtoCommonUnitTests", "path" : "/tests/unittests/common/unittests/", "env" : {"PROFILER_ENABLED" : "true"}},
     "logging" : {"suite" : "RialtoLoggingUnitTests", "path" : "/tests/unittests/logging/"},
     "manager" : {"suite" : "RialtoServerManagerUnitTests", "path" : "/tests/unittests/serverManager/"},
     "ipc" : {"suite" : "RialtoIpcUnitTests", "path" : "/tests/unittests/ipc/"},

--- a/build_ut.py
+++ b/build_ut.py
@@ -36,7 +36,7 @@ suiteInfo = {
     "client" : {"suite" : "RialtoClientUnitTests", "path" : "/tests/unittests/media/client/main/"},
     "clientipc" : {"suite" : "RialtoClientIpcUnitTests", "path" : "/tests/unittests/media/client/ipc/"},
     "playercommon" : {"suite" : "RialtoPlayerCommonUnitTests", "path" : "/tests/unittests/media/common/"},
-    "common" : {"suite" : "RialtoCommonUnitTests", "path" : "/tests/unittests/common/unittests/", "env" : {"PROFILER_ENABLED" : "true"}},
+    "common" : {"suite" : "RialtoCommonUnitTests", "path" : "/tests/unittests/common/unittests/"},
     "logging" : {"suite" : "RialtoLoggingUnitTests", "path" : "/tests/unittests/logging/"},
     "manager" : {"suite" : "RialtoServerManagerUnitTests", "path" : "/tests/unittests/serverManager/"},
     "ipc" : {"suite" : "RialtoIpcUnitTests", "path" : "/tests/unittests/ipc/"},

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
         source/EventThread.cpp
         source/LinuxUtils.cpp
         source/Timer.cpp
+        source/Profiler.cpp
     )
 
 set_property (

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -1,0 +1,47 @@
+#ifndef FIREBOLT_RIALTO_COMMON_PROFILER_H_
+#define FIREBOLT_RIALTO_COMMON_PROFILER_H_
+
+#include <chrono>
+#include <mutex>
+#include <string_view>
+#include <vector>
+
+// namespace firebolt::rialto::common
+// {
+class Profiler final
+{
+public:
+    using Clock = std::chrono::steady_clock;
+
+    struct Record
+    {
+        std::string_view module;
+        uint64_t id{0};
+        std::string stage;
+        Clock::time_point time;
+    };
+
+    Profiler() = delete;
+    ~Profiler() = default;
+
+    Profiler(const Profiler&) = delete;
+    Profiler& operator=(const Profiler&) = delete;
+
+    Profiler(std::string_view module, uint64_t id);
+
+    void record(std::string stage);
+
+    std::vector<Record> snapshot() const;
+
+    void dump(std::ostream& os) const;
+
+private:
+    mutable std::mutex m_mutex;
+    std::string_view m_module{};
+    uint64_t m_id{0};
+    std::vector<Record> m_records;
+};
+
+// }; // namespace firebolt::rialto::common
+
+#endif // FIREBOLT_RIALTO_COMMON_PROFILER_H_

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -1,13 +1,33 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef FIREBOLT_RIALTO_COMMON_PROFILER_H_
 #define FIREBOLT_RIALTO_COMMON_PROFILER_H_
 
 #include "IProfiler.h"
 
 #include <chrono>
+#include <memory>
 #include <mutex>
-#include <string_view>
-#include <vector>
 #include <optional>
+#include <string>
+#include <vector>
 
 namespace firebolt::rialto::common
 {
@@ -43,11 +63,11 @@ public:
 
     void log(const RecordId id) override;
 
-    bool dump(const std::string& path) const override;
+    bool dump(const std::string &path) const override;
 
 private:
     static bool parseEnv(const char *value, bool defaultValue);
-    const Record* findById(RecordId id);
+    const Record *findById(RecordId id);
 
     std::string m_module;
     const bool m_enabled;
@@ -56,7 +76,7 @@ private:
     RecordId m_id{1};
     std::vector<Record> m_records;
 
-    static constexpr const char* kProfilerEnv = "PROFILER_ENABLED";
+    static constexpr const char *kProfilerEnv = "PROFILER_ENABLED";
     static constexpr size_t kMaxRecords = 100;
 };
 

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -33,6 +33,8 @@ public:
 
     explicit Profiler(std::string module);
 
+    bool enabled() const noexcept override;
+
     std::optional<RecordId> record(std::string stage) override;
     std::optional<RecordId> record(std::string stage, std::string info) override;
 
@@ -44,12 +46,17 @@ public:
     bool dump(const std::string& path) const override;
 
 private:
+    static bool parseEnv(const char *value, bool defaultValue);
     const Record* findById(RecordId id);
 
-    mutable std::mutex m_mutex;
     std::string m_module;
+    const bool m_enabled;
+
+    mutable std::mutex m_mutex;
     RecordId m_id{1};
     std::vector<Record> m_records;
+
+    static constexpr const char* kProfilerEnv = "PROFILER_ENABLED";
     static constexpr size_t kMaxRecords = 100;
 };
 

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -5,12 +5,14 @@
 #include <mutex>
 #include <string_view>
 #include <vector>
+#include <optional>
 
-// namespace firebolt::rialto::common
-// {
+namespace firebolt::rialto::common
+{
 class Profiler final
 {
 public:
+    using RecordId = std::uint64_t;
     using Clock = std::chrono::steady_clock;
 
     struct Record
@@ -18,6 +20,7 @@ public:
         std::string_view module;
         uint64_t id{0};
         std::string stage;
+        std::string info;
         Clock::time_point time;
     };
 
@@ -27,21 +30,28 @@ public:
     Profiler(const Profiler&) = delete;
     Profiler& operator=(const Profiler&) = delete;
 
-    Profiler(std::string_view module, uint64_t id);
+    Profiler(std::string_view module);
 
-    void record(std::string stage);
+    std::optional<RecordId> record(std::string stage);
+    std::optional<RecordId> record(std::string stage, std::string info);
 
-    std::vector<Record> snapshot() const;
+    std::optional<RecordId> find(std::string stage);
+    std::optional<RecordId> find(std::string stage, std::string info);
+
+    void log(const RecordId id);
 
     void dump(std::ostream& os) const;
 
 private:
+    const Record* findById(RecordId id);
+
     mutable std::mutex m_mutex;
     std::string_view m_module{};
-    uint64_t m_id{0};
+    RecordId m_id{1};
     std::vector<Record> m_records;
+    static constexpr size_t kMaxRecords = 100;
 };
 
-// }; // namespace firebolt::rialto::common
+}; // namespace firebolt::rialto::common
 
 #endif // FIREBOLT_RIALTO_COMMON_PROFILER_H_

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -40,7 +40,7 @@ public:
 class Profiler final : public IProfiler
 {
 public:
-    using Clock = std::chrono::steady_clock;
+    using Clock = std::chrono::system_clock;
 
     struct Record
     {

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -42,8 +42,6 @@ class Profiler final : public IProfiler
 public:
     explicit Profiler(std::string module);
 
-    void enable() noexcept override;
-    void disable() noexcept override;
     bool isEnabled() const noexcept override;
 
     std::optional<RecordId> record(std::string stage) override;

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -49,21 +49,24 @@ public:
 
     void log(const RecordId id) override;
 
-    bool dump(const std::string &path) const override;
+    bool dumpToFile() const override;
     const std::vector<Record> &getRecords() const override;
 
 private:
     static bool parseEnv(const char *value, bool defaultValue);
+    static std::optional<std::string> parseOptionalEnv(const char *value);
     const Record *findById(RecordId id);
 
     std::string m_module;
     bool m_enabled;
+    std::optional<std::string> m_dumpFileName;
 
     mutable std::mutex m_mutex;
     RecordId m_id{1};
     std::vector<Record> m_records;
 
     static constexpr const char *kProfilerEnv = "PROFILER_ENABLED";
+    static constexpr const char *kProfilerDumpFileEnv = "PROFILER_DUMP_FILE_NAME";
     static constexpr size_t kMaxRecords = 100;
 };
 

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -40,8 +40,6 @@ public:
 class Profiler final : public IProfiler
 {
 public:
-    // using Record = IProfiler::Record;
-
     explicit Profiler(std::string module);
 
     void enable() noexcept override;

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -47,9 +47,6 @@ public:
     std::optional<RecordId> record(std::string stage) override;
     std::optional<RecordId> record(std::string stage, std::string info) override;
 
-    std::optional<RecordId> find(std::string stage) override;
-    std::optional<RecordId> find(std::string stage, std::string info) override;
-
     void log(const RecordId id) override;
 
     bool dump(const std::string &path) const override;

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -40,16 +40,7 @@ public:
 class Profiler final : public IProfiler
 {
 public:
-    using Clock = std::chrono::system_clock;
-
-    struct Record
-    {
-        std::string module;
-        uint64_t id{0};
-        std::string stage;
-        std::string info;
-        Clock::time_point time;
-    };
+    // using Record = IProfiler::Record;
 
     explicit Profiler(std::string module);
 
@@ -64,6 +55,7 @@ public:
     void log(const RecordId id) override;
 
     bool dump(const std::string &path) const override;
+    const std::vector<Record>& getRecords() const override;
 
 private:
     static bool parseEnv(const char *value, bool defaultValue);

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -44,7 +44,9 @@ public:
 
     explicit Profiler(std::string module);
 
-    bool enabled() const noexcept override;
+    void enable() noexcept override;
+    void disable() noexcept override;
+    bool isEnabled() const noexcept override;
 
     std::optional<RecordId> record(std::string stage) override;
     std::optional<RecordId> record(std::string stage, std::string info) override;
@@ -55,14 +57,14 @@ public:
     void log(const RecordId id) override;
 
     bool dump(const std::string &path) const override;
-    const std::vector<Record>& getRecords() const override;
+    const std::vector<Record> &getRecords() const override;
 
 private:
     static bool parseEnv(const char *value, bool defaultValue);
     const Record *findById(RecordId id);
 
     std::string m_module;
-    const bool m_enabled;
+    bool m_enabled;
 
     mutable std::mutex m_mutex;
     RecordId m_id{1};

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -44,8 +44,8 @@ public:
 
     bool isEnabled() const noexcept override;
 
-    std::optional<RecordId> record(std::string stage) override;
-    std::optional<RecordId> record(std::string stage, std::string info) override;
+    std::optional<RecordId> record(const std::string &stage) override;
+    std::optional<RecordId> record(const std::string &stage, const std::string &info) override;
 
     void log(const RecordId id) override;
 
@@ -53,9 +53,7 @@ public:
     const std::vector<Record> &getRecords() const override;
 
 private:
-    static bool parseEnv(const char *value, bool defaultValue);
-    static std::optional<std::string> parseOptionalEnv(const char *value);
-    const Record *findById(RecordId id);
+    std::optional<Record> findById(RecordId id) const;
 
     std::string m_module;
     bool m_enabled;
@@ -64,10 +62,6 @@ private:
     mutable std::mutex m_mutex;
     RecordId m_id{1};
     std::vector<Record> m_records;
-
-    static constexpr const char *kProfilerEnv = "PROFILER_ENABLED";
-    static constexpr const char *kProfilerDumpFileEnv = "PROFILER_DUMP_FILE_NAME";
-    static constexpr size_t kMaxRecords = 100;
 };
 
 }; // namespace firebolt::rialto::common

--- a/common/include/Profiler.h
+++ b/common/include/Profiler.h
@@ -50,7 +50,7 @@ public:
     void log(const RecordId id) override;
 
     bool dumpToFile() const override;
-    const std::vector<Record> &getRecords() const override;
+    std::vector<Record> getRecords() const override;
 
 private:
     std::optional<Record> findById(RecordId id) const;

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -48,16 +48,65 @@ public:
     IProfiler(IProfiler &&) = delete;
     IProfiler &operator=(IProfiler &&) = delete;
 
+    /**
+     * @brief Checks if profiler is enabled.
+     *
+     * @retval true if profiler is enabled, false otherwise.
+     */
     virtual bool enabled() const noexcept = 0;
 
+    /**
+     * @brief Creates a record for given stage.
+     *
+     * @param[in] stage : Stage name used for record creation
+     *
+     * @retval Record identificator for created record or std::nullopt.
+     */
     virtual std::optional<RecordId> record(std::string stage) = 0;
+
+    /**
+     * @brief Creates a record for given stage and info.
+     *
+     * @param[in] stage : Stage name used for record creation
+     * @param[in] info  : Additional information used for record creation
+     *
+     * @retval Record identificator for created record or std::nullopt.
+     */
     virtual std::optional<RecordId> record(std::string stage, std::string info) = 0;
 
+    /**
+     * @brief Finds an existing record for given stage.
+     *
+     * @param[in] stage : Stage name of the record to be found
+     *
+     * @retval Record identificator for found record or std::nullopt.
+     */
     virtual std::optional<RecordId> find(std::string stage) = 0;
+
+    /**
+     * @brief Finds an existing record for given stage and info.
+     *
+     * @param[in] stage : Stage name of the record to be found
+     * @param[in] info  : Additional information of the record to be found
+     *
+     * @retval Record identificator for found record or std::nullopt.
+     */
     virtual std::optional<RecordId> find(std::string stage, std::string info) = 0;
 
+    /**
+     * @brief Logs a record for given identificator.
+     *
+     * @param[in] id : Record identificator
+     */
     virtual void log(RecordId id) = 0;
 
+    /**
+     * @brief Dumps all records into file.
+     *
+     * @param[in] path : Full path to the directory where the file will be stored
+     *
+     * @retval true if file is created and records are dumped, false otherwise.
+     */
     virtual bool dump(const std::string& path) const = 0;
 
 protected:

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -1,0 +1,67 @@
+#ifndef FIREBOLT_RIALTO_COMMON_I_PROFILER_H_
+#define FIREBOLT_RIALTO_COMMON_I_PROFILER_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <optional>
+
+namespace firebolt::rialto::common
+{
+class IProfiler;
+
+/**
+ * @brief IProfiler factory class, returns a concrete implementation of IProfiler
+ */
+class IProfilerFactory
+{
+public:
+    IProfilerFactory() = default;
+    virtual ~IProfilerFactory() = default;
+
+    /**
+     * @brief Creates a IProfilerFactory instance.
+     *
+     * @retval the factory instance or null on error.
+     */
+    static std::shared_ptr<IProfilerFactory> createFactory();
+
+    /**
+     * @brief Creates an IProfiler object.
+     *
+     * @param[in] moduleName    : The name of the module
+     *
+     * @retval the new profiler instance or null on error.
+     */
+    virtual std::unique_ptr<IProfiler> createProfiler(std::string moduleName) const = 0;
+};
+
+class IProfiler
+{
+public:
+    using RecordId = std::uint64_t;
+
+    virtual ~IProfiler() = default;
+
+    IProfiler(const IProfiler &) = delete;
+    IProfiler &operator=(const IProfiler &) = delete;
+    IProfiler(IProfiler &&) = delete;
+    IProfiler &operator=(IProfiler &&) = delete;
+
+    virtual std::optional<RecordId> record(std::string stage) = 0;
+    virtual std::optional<RecordId> record(std::string stage, std::string info) = 0;
+
+    virtual std::optional<RecordId> find(std::string stage) = 0;
+    virtual std::optional<RecordId> find(std::string stage, std::string info) = 0;
+
+    virtual void log(RecordId id) = 0;
+
+    virtual bool dump(const std::string& path) const = 0;
+
+protected:
+    IProfiler() = default;
+};
+
+} // namespace firebolt::rialto::common
+
+#endif // FIREBOLT_RIALTO_COMMON_I_PROFILER_H_

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -1,10 +1,30 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef FIREBOLT_RIALTO_COMMON_I_PROFILER_H_
 #define FIREBOLT_RIALTO_COMMON_I_PROFILER_H_
 
+#include <cstdint>
 #include <functional>
 #include <memory>
-#include <string>
 #include <optional>
+#include <string>
 
 namespace firebolt::rialto::common
 {
@@ -60,7 +80,7 @@ public:
      *
      * @param[in] stage : Stage name used for record creation
      *
-     * @retval Record identificator for created record or std::nullopt.
+     * @retval Record identifier for created record or std::nullopt.
      */
     virtual std::optional<RecordId> record(std::string stage) = 0;
 
@@ -70,7 +90,7 @@ public:
      * @param[in] stage : Stage name used for record creation
      * @param[in] info  : Additional information used for record creation
      *
-     * @retval Record identificator for created record or std::nullopt.
+     * @retval Record identifier for created record or std::nullopt.
      */
     virtual std::optional<RecordId> record(std::string stage, std::string info) = 0;
 
@@ -79,7 +99,7 @@ public:
      *
      * @param[in] stage : Stage name of the record to be found
      *
-     * @retval Record identificator for found record or std::nullopt.
+     * @retval Record identifier for found record or std::nullopt.
      */
     virtual std::optional<RecordId> find(std::string stage) = 0;
 
@@ -89,25 +109,25 @@ public:
      * @param[in] stage : Stage name of the record to be found
      * @param[in] info  : Additional information of the record to be found
      *
-     * @retval Record identificator for found record or std::nullopt.
+     * @retval Record identifier for found record or std::nullopt.
      */
     virtual std::optional<RecordId> find(std::string stage, std::string info) = 0;
 
     /**
-     * @brief Logs a record for given identificator.
+     * @brief Logs a record for given identifier.
      *
-     * @param[in] id : Record identificator
+     * @param[in] id : Record identifier
      */
     virtual void log(RecordId id) = 0;
 
     /**
      * @brief Dumps all records into file.
      *
-     * @param[in] path : Full path to the directory where the file will be stored
+     * @param[in] path : Full path to the output file
      *
      * @retval true if file is created and records are dumped, false otherwise.
      */
-    virtual bool dump(const std::string& path) const = 0;
+    virtual bool dump(const std::string &path) const = 0;
 
 protected:
     IProfiler() = default;

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -48,6 +48,8 @@ public:
     IProfiler(IProfiler &&) = delete;
     IProfiler &operator=(IProfiler &&) = delete;
 
+    virtual bool enabled() const noexcept = 0;
+
     virtual std::optional<RecordId> record(std::string stage) = 0;
     virtual std::optional<RecordId> record(std::string stage, std::string info) = 0;
 

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -20,6 +20,7 @@
 #ifndef FIREBOLT_RIALTO_COMMON_I_PROFILER_H_
 #define FIREBOLT_RIALTO_COMMON_I_PROFILER_H_
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -60,6 +61,16 @@ class IProfiler
 {
 public:
     using RecordId = std::uint64_t;
+    using Clock = std::chrono::system_clock;
+
+    struct Record
+    {
+        std::string module;
+        uint64_t id{0};
+        std::string stage;
+        std::string info;
+        Clock::time_point time;
+    };
 
     virtual ~IProfiler() = default;
 
@@ -128,6 +139,8 @@ public:
      * @retval true if file is created and records are dumped, false otherwise.
      */
     virtual bool dump(const std::string &path) const = 0;
+
+    virtual const std::vector<Record>& getRecords() const = 0;
 
 protected:
     IProfiler() = default;

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -107,25 +107,6 @@ public:
     virtual std::optional<RecordId> record(std::string stage, std::string info) = 0;
 
     /**
-     * @brief Finds an existing record for given stage.
-     *
-     * @param[in] stage : Stage name of the record to be found
-     *
-     * @retval Record identifier for found record or std::nullopt.
-     */
-    virtual std::optional<RecordId> find(std::string stage) = 0;
-
-    /**
-     * @brief Finds an existing record for given stage and info.
-     *
-     * @param[in] stage : Stage name of the record to be found
-     * @param[in] info  : Additional information of the record to be found
-     *
-     * @retval Record identifier for found record or std::nullopt.
-     */
-    virtual std::optional<RecordId> find(std::string stage, std::string info) = 0;
-
-    /**
      * @brief Logs a record for given identifier.
      *
      * @param[in] id : Record identifier

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -81,20 +81,6 @@ public:
     IProfiler &operator=(IProfiler &&) = delete;
 
     /**
-     * @brief Enable profiler.
-     *
-     * @retval none.
-     */
-    virtual void enable() noexcept = 0;
-
-    /**
-     * @brief Disable profiler.
-     *
-     * @retval none.
-     */
-    virtual void disable() noexcept = 0;
-
-    /**
      * @brief Checks if profiler is enabled.
      *
      * @retval true if profiler is enabled, false otherwise.

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -114,14 +114,17 @@ public:
     virtual void log(RecordId id) = 0;
 
     /**
-     * @brief Dumps all records into file.
-     *
-     * @param[in] path : Full path to the output file
+     * @brief Dumps all records into pre-configured file.
      *
      * @retval true if file is created and records are dumped, false otherwise.
      */
-    virtual bool dump(const std::string &path) const = 0;
+    virtual bool dumpToFile() const = 0;
 
+    /**
+     * @brief Retrieves existing records.
+     *
+     * @retval Reference to existing Record vector.
+     */
     virtual const std::vector<Record> &getRecords() const = 0;
 
 protected:

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace firebolt::rialto::common
 {
@@ -80,11 +81,25 @@ public:
     IProfiler &operator=(IProfiler &&) = delete;
 
     /**
+     * @brief Enable profiler.
+     *
+     * @retval none.
+     */
+    virtual void enable() noexcept = 0;
+
+    /**
+     * @brief Disable profiler.
+     *
+     * @retval none.
+     */
+    virtual void disable() noexcept = 0;
+
+    /**
      * @brief Checks if profiler is enabled.
      *
      * @retval true if profiler is enabled, false otherwise.
      */
-    virtual bool enabled() const noexcept = 0;
+    virtual bool isEnabled() const noexcept = 0;
 
     /**
      * @brief Creates a record for given stage.
@@ -140,7 +155,7 @@ public:
      */
     virtual bool dump(const std::string &path) const = 0;
 
-    virtual const std::vector<Record>& getRecords() const = 0;
+    virtual const std::vector<Record> &getRecords() const = 0;
 
 protected:
     IProfiler() = default;

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -123,9 +123,9 @@ public:
     /**
      * @brief Retrieves existing records.
      *
-     * @retval Reference to existing Record vector.
+     * @retval Snapshot copy of existing records.
      */
-    virtual const std::vector<Record> &getRecords() const = 0;
+    virtual std::vector<Record> getRecords() const = 0;
 
 protected:
     IProfiler() = default;

--- a/common/interface/IProfiler.h
+++ b/common/interface/IProfiler.h
@@ -66,7 +66,7 @@ public:
 
     struct Record
     {
-        std::string module;
+        std::string moduleName;
         uint64_t id{0};
         std::string stage;
         std::string info;
@@ -94,7 +94,7 @@ public:
      *
      * @retval Record identifier for created record or std::nullopt.
      */
-    virtual std::optional<RecordId> record(std::string stage) = 0;
+    virtual std::optional<RecordId> record(const std::string &stage) = 0;
 
     /**
      * @brief Creates a record for given stage and info.
@@ -104,7 +104,7 @@ public:
      *
      * @retval Record identifier for created record or std::nullopt.
      */
-    virtual std::optional<RecordId> record(std::string stage, std::string info) = 0;
+    virtual std::optional<RecordId> record(const std::string &stage, const std::string &info) = 0;
 
     /**
      * @brief Logs a record for given identifier.

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -1,0 +1,47 @@
+#include "Profiler.h"
+#include "RialtoCommonLogging.h"
+
+#include <algorithm>
+
+// namespace firebolt::rialto::common
+// {
+Profiler::Profiler(std::string_view module, uint64_t id)
+    : m_module(module), m_id(id)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_records.clear();
+}
+
+void Profiler::record(std::string stage)
+{
+    auto now = Clock::now();
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    Record record = Record{m_module, m_id, stage, now};
+    m_records.push_back(record);
+
+
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(record.time.time_since_epoch()).count();
+    RIALTO_COMMON_LOG_FATAL("RECORD: Module[%s] id[%llu] stage=%s time_since_epoch_ns=%lld",
+                            record.module.data(), static_cast<unsigned long long>(record.id), record.stage.c_str(), (long long)ns);
+}
+
+std::vector<Profiler::Record> Profiler::snapshot() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_records;
+}
+
+void Profiler::dump(std::ostream& os) const
+{
+    auto copy = snapshot();
+    if (copy.empty())
+        return;
+
+    std::sort(copy.begin(), copy.end(),
+            [](const Record& x, const Record& y) { return x.time < y.time; });
+
+    // TODO dump()
+}
+
+// }; // namespace firebolt::rialto::common

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -3,45 +3,113 @@
 
 #include <algorithm>
 
-// namespace firebolt::rialto::common
-// {
-Profiler::Profiler(std::string_view module, uint64_t id)
-    : m_module(module), m_id(id)
+namespace firebolt::rialto::common
+{
+Profiler::Profiler(std::string_view module)
+    : m_module(module)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_records.clear();
 }
 
-void Profiler::record(std::string stage)
+std::optional<Profiler::RecordId> Profiler::record(std::string stage)
 {
     auto now = Clock::now();
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    Record record = Record{m_module, m_id, stage, now};
-    m_records.push_back(record);
+    if (m_records.size() >= kMaxRecords)
+    {
+        return std::nullopt;
+    }
 
+    const Profiler::RecordId id = m_id++;
 
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(record.time.time_since_epoch()).count();
-    RIALTO_COMMON_LOG_FATAL("RECORD: Module[%s] id[%llu] stage=%s time_since_epoch_ns=%lld",
-                            record.module.data(), static_cast<unsigned long long>(record.id), record.stage.c_str(), (long long)ns);
+    m_records.push_back(Record{
+        std::string(m_module),
+        id,
+        std::move(stage),
+        std::string{},
+        now
+    });
+
+    return id;
 }
 
-std::vector<Profiler::Record> Profiler::snapshot() const
+std::optional<Profiler::RecordId> Profiler::record(std::string stage, std::string info)
+{
+    auto now = Clock::now();
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (m_records.size() >= kMaxRecords)
+    {
+        return std::nullopt;
+    }
+
+    const Profiler::RecordId id = m_id++;
+
+    m_records.push_back(Record{
+        std::string(m_module),
+        id,
+        std::move(stage),
+        std::move(info),
+        now
+    });
+
+    return id;
+}
+
+std::optional<Profiler::RecordId> Profiler::find(std::string stage)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    return m_records;
+
+    for (const auto& record : m_records)
+        if (record.stage == stage)
+            return record.id;
+
+    return std::nullopt;
+}
+
+std::optional<Profiler::RecordId> Profiler::find(std::string stage, std::string info)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    for (const auto& record : m_records)
+        if (record.stage == stage && record.info == info)
+            return record.id;
+
+    return std::nullopt;
+}
+
+void Profiler::log(const RecordId id)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    const auto* record = findById(id);
+    if(record)
+    {
+        const auto us = std::chrono::duration_cast<std::chrono::microseconds>(record->time.time_since_epoch()).count();
+        RIALTO_COMMON_LOG_MIL("PROFILER | RECORD | MODULE[%s] ID[%llu] STAGE[%s] INFO[%s] TIMESTAMP[%lld]",
+                            record->module.data(), static_cast<unsigned long long>(record->id),
+                            record->stage.c_str(), record->info.c_str(), (long long)us);
+    }
 }
 
 void Profiler::dump(std::ostream& os) const
 {
-    auto copy = snapshot();
-    if (copy.empty())
-        return;
-
-    std::sort(copy.begin(), copy.end(),
-            [](const Record& x, const Record& y) { return x.time < y.time; });
-
     // TODO dump()
 }
 
-// }; // namespace firebolt::rialto::common
+const Profiler::Record* Profiler::findById(Profiler::RecordId id)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    for (const auto& record : m_records)
+    {
+        if (record.id == id)
+            return &record;
+    }
+
+    return nullptr;
+}
+
+}; // namespace firebolt::rialto::common

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -51,7 +51,8 @@ std::unique_ptr<IProfiler> ProfilerFactory::createProfiler(std::string moduleNam
 }
 
 Profiler::Profiler(std::string module)
-    : m_module(std::move(module)), m_enabled(parseEnv(std::getenv(kProfilerEnv), false))
+    : m_module(std::move(module)), m_enabled(parseEnv(std::getenv(kProfilerEnv), false)),
+      m_dumpFileName(parseOptionalEnv(std::getenv(kProfilerDumpFileEnv)))
 {
 }
 
@@ -121,8 +122,11 @@ void Profiler::log(const RecordId id)
     }
 }
 
-bool Profiler::dump(const std::string &path) const
+bool Profiler::dumpToFile() const
 {
+    if (!m_dumpFileName)
+        return true;
+
     if (!m_enabled)
         return false;
 
@@ -132,7 +136,7 @@ bool Profiler::dump(const std::string &path) const
         copy = m_records;
     }
 
-    std::ofstream out(path, std::ios::out | std::ios::trunc);
+    std::ofstream out(*m_dumpFileName, std::ios::out | std::ios::app);
     if (!out.is_open())
         return false;
 
@@ -171,6 +175,14 @@ bool Profiler::parseEnv(const char *value, bool defaultValue)
         return false;
 
     return defaultValue;
+}
+
+std::optional<std::string> Profiler::parseOptionalEnv(const char *value)
+{
+    if (!value || value[0] == '\0')
+        return std::nullopt;
+
+    return std::string{value};
 }
 
 const Profiler::Record *Profiler::findById(Profiler::RecordId id)

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -139,10 +139,10 @@ void Profiler::log(const RecordId id)
     const auto *record = findById(id);
     if (record)
     {
-        const auto us = std::chrono::duration_cast<std::chrono::microseconds>(record->time.time_since_epoch()).count();
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(record->time.time_since_epoch()).count();
 
         const auto idStr = std::to_string(static_cast<std::uint64_t>(record->id));
-        const auto tsStr = std::to_string(static_cast<std::int64_t>(us));
+        const auto tsStr = std::to_string(static_cast<std::int64_t>(ms));
 
         RIALTO_COMMON_LOG_MIL("PROFILER | RECORD | MODULE[%s] ID[%s] STAGE[%s] INFO[%s] TIMESTAMP[%s]",
                               record->module.c_str(), idStr.c_str(), record->stage.c_str(), record->info.c_str(),

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -176,6 +176,11 @@ bool Profiler::dump(const std::string &path) const
     return static_cast<bool>(out);
 }
 
+const std::vector<IProfiler::Record>& Profiler::getRecords() const
+{
+    return m_records;
+}
+
 bool Profiler::parseEnv(const char *value, bool defaultValue)
 {
     if (!value || (value[0] == '\0'))

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -55,16 +55,6 @@ Profiler::Profiler(std::string module)
 {
 }
 
-void Profiler::enable() noexcept
-{
-    m_enabled = true;
-}
-
-void Profiler::disable() noexcept
-{
-    m_enabled = false;
-}
-
 bool Profiler::isEnabled() const noexcept
 {
     return m_enabled;

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -53,7 +53,17 @@ Profiler::Profiler(std::string module)
 {
 }
 
-bool Profiler::enabled() const noexcept
+void Profiler::enable() noexcept
+{
+    m_enabled = true;
+}
+
+void Profiler::disable() noexcept
+{
+    m_enabled = false;
+}
+
+bool Profiler::isEnabled() const noexcept
 {
     return m_enabled;
 }
@@ -176,7 +186,7 @@ bool Profiler::dump(const std::string &path) const
     return static_cast<bool>(out);
 }
 
-const std::vector<IProfiler::Record>& Profiler::getRecords() const
+const std::vector<IProfiler::Record> &Profiler::getRecords() const
 {
     return m_records;
 }

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -21,7 +21,9 @@
 #include "RialtoCommonLogging.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
+#include <cstdlib>
 #include <fstream>
 #include <string>
 
@@ -188,6 +190,10 @@ bool Profiler::dump(const std::string &path) const
 
 const std::vector<IProfiler::Record> &Profiler::getRecords() const
 {
+    static const std::vector<IProfiler::Record> empty{};
+    if (!m_enabled)
+        return empty;
+
     return m_records;
 }
 

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -100,37 +100,6 @@ std::optional<Profiler::RecordId> Profiler::record(std::string stage, std::strin
     return id;
 }
 
-std::optional<Profiler::RecordId> Profiler::find(std::string stage)
-{
-    if (!m_enabled)
-        return std::nullopt;
-
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    const auto it =
-        std::find_if(m_records.begin(), m_records.end(), [&](const auto &record) { return record.stage == stage; });
-
-    if (it != m_records.end())
-        return it->id;
-
-    return std::nullopt;
-}
-
-std::optional<Profiler::RecordId> Profiler::find(std::string stage, std::string info)
-{
-    if (!m_enabled)
-        return std::nullopt;
-
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    const auto it = std::find_if(m_records.begin(), m_records.end(),
-                                 [&](const auto &record) { return record.stage == stage && record.info == info; });
-    if (it != m_records.end())
-        return it->id;
-
-    return std::nullopt;
-}
-
 void Profiler::log(const RecordId id)
 {
     if (!m_enabled)

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
+#include <memory>
 #include <string>
 
 namespace firebolt::rialto::common

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -22,11 +22,46 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
 #include <memory>
 #include <string>
+
+namespace
+{
+inline constexpr const char *kProfilerEnv{"PROFILER_ENABLED"};
+inline constexpr const char *kProfilerDumpFileEnv{"PROFILER_DUMP_FILE_NAME"};
+inline constexpr std::size_t kMaxRecords{100};
+
+bool getProfilerEnabled()
+{
+    const char *value = std::getenv(kProfilerEnv);
+    if (!value || (value[0] == '\0'))
+        return false;
+
+    std::string stringValue(value);
+    std::transform(stringValue.begin(), stringValue.end(), stringValue.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    if (stringValue == "1" || stringValue == "true" || stringValue == "yes" || stringValue == "on")
+        return true;
+    if (stringValue == "0" || stringValue == "false" || stringValue == "no" || stringValue == "off")
+        return false;
+
+    return false;
+}
+
+std::optional<std::string> getDumpFileName()
+{
+    const char *value = std::getenv(kProfilerDumpFileEnv);
+    if (!value || value[0] == '\0')
+        return std::nullopt;
+
+    return std::string{value};
+}
+} // namespace
 
 namespace firebolt::rialto::common
 {
@@ -52,8 +87,7 @@ std::unique_ptr<IProfiler> ProfilerFactory::createProfiler(std::string moduleNam
 }
 
 Profiler::Profiler(std::string module)
-    : m_module(std::move(module)), m_enabled(parseEnv(std::getenv(kProfilerEnv), false)),
-      m_dumpFileName(parseOptionalEnv(std::getenv(kProfilerDumpFileEnv)))
+    : m_module(std::move(module)), m_enabled(getProfilerEnabled()), m_dumpFileName(getDumpFileName())
 {
 }
 
@@ -62,7 +96,7 @@ bool Profiler::isEnabled() const noexcept
     return m_enabled;
 }
 
-std::optional<Profiler::RecordId> Profiler::record(std::string stage)
+std::optional<Profiler::RecordId> Profiler::record(const std::string &stage)
 {
     if (!m_enabled)
         return std::nullopt;
@@ -77,12 +111,12 @@ std::optional<Profiler::RecordId> Profiler::record(std::string stage)
 
     const Profiler::RecordId id = m_id++;
 
-    m_records.push_back(Record{m_module, id, std::move(stage), std::string{}, now});
+    m_records.push_back(Record{m_module, id, stage, std::string{}, now});
 
     return id;
 }
 
-std::optional<Profiler::RecordId> Profiler::record(std::string stage, std::string info)
+std::optional<Profiler::RecordId> Profiler::record(const std::string &stage, const std::string &info)
 {
     if (!m_enabled)
         return std::nullopt;
@@ -97,7 +131,7 @@ std::optional<Profiler::RecordId> Profiler::record(std::string stage, std::strin
 
     const Profiler::RecordId id = m_id++;
 
-    m_records.push_back(Record{m_module, id, std::move(stage), std::move(info), now});
+    m_records.push_back(Record{m_module, id, stage, info, now});
 
     return id;
 }
@@ -107,9 +141,7 @@ void Profiler::log(const RecordId id)
     if (!m_enabled)
         return;
 
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    const auto *record = findById(id);
+    const auto record = findById(id);
     if (record)
     {
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(record->time.time_since_epoch()).count();
@@ -118,7 +150,7 @@ void Profiler::log(const RecordId id)
         const auto tsStr = std::to_string(static_cast<std::int64_t>(ms));
 
         RIALTO_COMMON_LOG_MIL("PROFILER | RECORD | MODULE[%s] ID[%s] STAGE[%s] INFO[%s] TIMESTAMP[%s]",
-                              record->module.c_str(), idStr.c_str(), record->stage.c_str(), record->info.c_str(),
+                              record->moduleName.c_str(), idStr.c_str(), record->stage.c_str(), record->info.c_str(),
                               tsStr.c_str());
     }
 }
@@ -126,7 +158,7 @@ void Profiler::log(const RecordId id)
 bool Profiler::dumpToFile() const
 {
     if (!m_dumpFileName)
-        return true;
+        return false;
 
     if (!m_enabled)
         return false;
@@ -145,7 +177,7 @@ bool Profiler::dumpToFile() const
     {
         const auto us = std::chrono::duration_cast<std::chrono::microseconds>(record.time.time_since_epoch()).count();
 
-        out << "MODULE[" << record.module << "] " << "ID[" << record.id << "] " << "STAGE[" << record.stage << "] "
+        out << "MODULE[" << record.moduleName << "] " << "ID[" << record.id << "] " << "STAGE[" << record.stage << "] "
             << "INFO[" << record.info << "] " << "TIMESTAMP[" << us << "]" << '\n';
     }
 
@@ -161,39 +193,16 @@ const std::vector<IProfiler::Record> &Profiler::getRecords() const
     return m_records;
 }
 
-bool Profiler::parseEnv(const char *value, bool defaultValue)
+std::optional<Profiler::Record> Profiler::findById(Profiler::RecordId id) const
 {
-    if (!value || (value[0] == '\0'))
-        return defaultValue;
+    std::lock_guard<std::mutex> lock(m_mutex);
 
-    std::string stringValue(value);
-    std::transform(stringValue.begin(), stringValue.end(), stringValue.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-
-    if (stringValue == "1" || stringValue == "true" || stringValue == "yes" || stringValue == "on")
-        return true;
-    if (stringValue == "0" || stringValue == "false" || stringValue == "no" || stringValue == "off")
-        return false;
-
-    return defaultValue;
-}
-
-std::optional<std::string> Profiler::parseOptionalEnv(const char *value)
-{
-    if (!value || value[0] == '\0')
-        return std::nullopt;
-
-    return std::string{value};
-}
-
-const Profiler::Record *Profiler::findById(Profiler::RecordId id)
-{
     const auto it = std::find_if(m_records.begin(), m_records.end(), [&](const auto &record) { return record.id == id; });
 
     if (it != m_records.end())
-        return &(*it);
+        return *it;
 
-    return nullptr;
+    return std::nullopt;
 }
 
 }; // namespace firebolt::rialto::common

--- a/common/source/Profiler.cpp
+++ b/common/source/Profiler.cpp
@@ -184,12 +184,12 @@ bool Profiler::dumpToFile() const
     return static_cast<bool>(out);
 }
 
-const std::vector<IProfiler::Record> &Profiler::getRecords() const
+std::vector<IProfiler::Record> Profiler::getRecords() const
 {
-    static const std::vector<IProfiler::Record> empty{};
     if (!m_enabled)
-        return empty;
+        return {};
 
+    std::lock_guard<std::mutex> lock(m_mutex);
     return m_records;
 }
 

--- a/media/server/gstplayer/CMakeLists.txt
+++ b/media/server/gstplayer/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(
         source/GstGenericPlayer.cpp
         source/GstInitialiser.cpp
         source/GstLogForwarding.cpp
+        source/GstProfiler.cpp
         source/GstProtectionMetadata.cpp
         source/GstProtectionMetadataHelper.cpp
         source/GstSrc.cpp
@@ -124,6 +125,7 @@ target_include_directories(
         $<TARGET_PROPERTY:RialtoWrappers,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoCommon,INTERFACE_INCLUDE_DIRECTORIES>
         ${GStreamerApp_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_LIST_DIR}/../../../common/include
 
         )
 

--- a/media/server/gstplayer/CMakeLists.txt
+++ b/media/server/gstplayer/CMakeLists.txt
@@ -125,7 +125,6 @@ target_include_directories(
         $<TARGET_PROPERTY:RialtoWrappers,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:RialtoCommon,INTERFACE_INCLUDE_DIRECTORIES>
         ${GStreamerApp_INCLUDE_DIRS}
-        ${CMAKE_CURRENT_LIST_DIR}/../../../common/include
 
         )
 

--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -21,7 +21,7 @@
 #define FIREBOLT_RIALTO_SERVER_GENERIC_PLAYER_CONTEXT_H_
 
 #include "FlushOnPrerollController.h"
-#include "GstProfiler.h"
+#include "IGstProfiler.h"
 #include "IGstSrc.h"
 #include "IRdkGstreamerUtilsWrapper.h"
 #include "ITimer.h"

--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -23,6 +23,7 @@
 #include "FlushOnPrerollController.h"
 #include "IGstSrc.h"
 #include "IRdkGstreamerUtilsWrapper.h"
+#include "GstProfiler.h"
 #include "ITimer.h"
 #include "MediaCommon.h"
 #include <gst/gst.h>
@@ -275,6 +276,7 @@ struct GenericPlayerContext
      *        This is a workaround for Broadcom decoder issue with audio cuts during playback rate change.
      */
     bool isLive{false};
+    std::unique_ptr<GstProfiler> m_gstProfiler;
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -276,7 +276,11 @@ struct GenericPlayerContext
      *        This is a workaround for Broadcom decoder issue with audio cuts during playback rate change.
      */
     bool isLive{false};
-    std::unique_ptr<GstProfiler> m_gstProfiler;
+
+    /**
+     * @brief Profiler for player pipeline
+     */
+    std::unique_ptr<GstProfiler> gstProfiler;
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -21,9 +21,9 @@
 #define FIREBOLT_RIALTO_SERVER_GENERIC_PLAYER_CONTEXT_H_
 
 #include "FlushOnPrerollController.h"
+#include "GstProfiler.h"
 #include "IGstSrc.h"
 #include "IRdkGstreamerUtilsWrapper.h"
-#include "GstProfiler.h"
 #include "ITimer.h"
 #include "MediaCommon.h"
 #include <gst/gst.h>
@@ -280,7 +280,7 @@ struct GenericPlayerContext
     /**
      * @brief Profiler for player pipeline
      */
-    std::unique_ptr<GstProfiler> gstProfiler;
+    std::unique_ptr<IGstProfiler> gstProfiler;
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -28,6 +28,7 @@
 #include "IGstGenericPlayer.h"
 #include "IGstGenericPlayerPrivate.h"
 #include "IGstInitialiser.h"
+#include "IGstProfiler.h"
 #include "IGstProtectionMetadataHelperFactory.h"
 #include "IGstSrc.h"
 #include "IGstWrapper.h"
@@ -83,6 +84,7 @@ public:
      * @param[in] gstInitialiser               : The gst initialiser
      * @param[in] flushWatcher                 : The flush watcher
      * @param[in] gstSrcFactory                : The gstreamer rialto src factory.
+     * @param[in] gstProfilerFactory           : The gstreamer rialto profiler factory.
      * @param[in] timerFactory                 : The Timer factory
      * @param[in] taskFactory                  : The task factory
      * @param[in] workerThreadFactory          : The worker thread factory
@@ -95,6 +97,7 @@ public:
                      const std::shared_ptr<firebolt::rialto::wrappers::IRdkGstreamerUtilsWrapper> &rdkGstreamerUtilsWrapper,
                      const IGstInitialiser &gstInitialiser, std::unique_ptr<IFlushWatcher> &&flushWatcher,
                      const std::shared_ptr<IGstSrcFactory> &gstSrcFactory,
+                     const std::shared_ptr<IGstProfilerFactory> &gstProfilerFactory,
                      std::shared_ptr<common::ITimerFactory> timerFactory,
                      std::unique_ptr<IGenericPlayerTaskFactory> taskFactory,
                      std::unique_ptr<IWorkerThreadFactory> workerThreadFactory,
@@ -430,6 +433,11 @@ private:
      * @brief The rdk gstreamer utils wrapper object
      */
     std::shared_ptr<firebolt::rialto::wrappers::IRdkGstreamerUtilsWrapper> m_rdkGstreamerUtilsWrapper;
+
+    /**
+     * @brief Factory creating gst profilers
+     */
+    std::shared_ptr<IGstProfilerFactory> m_gstProfilerFactory;
 
     /**
      * @brief Thread for handling player tasks.

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -1,0 +1,47 @@
+#ifndef FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_
+#define FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_
+
+#include "Profiler.h"
+#include "IGstWrapper.h"
+#include "IGlibWrapper.h"
+
+#include <gst/gst.h>
+
+#include <memory>
+
+namespace firebolt::rialto::server
+{
+class GstProfiler
+{
+public:
+    enum class Stage {AppSrc, Decryptor, Decoder};
+
+    GstProfiler(GstElement* pipeline,
+                const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
+                const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper);
+    ~GstProfiler();
+
+    void createRecord(std::string stage);
+    void scheduleGstElementRecord(GstElement* element);
+
+private:
+    struct ProbeCtx {
+        GstProfiler* self;
+        std::string stage;
+    };
+
+    static uint64_t generateId();
+    bool checkElement(GstElement* element);
+
+    static GstPadProbeReturn probeCb(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
+    static void probeCtxDestroy(gpointer data);
+
+    GstElement* m_pipeline = nullptr;
+    uint64_t m_id;
+    Profiler m_profiler;
+    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
+    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
+    static constexpr std::string_view k_module = "GstProfiler";
+};
+} // namespace firebolt::rialto::server
+#endif // FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -1,57 +1,73 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_
 #define FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_
 
-#include "IProfiler.h"
-#include "IGstWrapper.h"
 #include "IGlibWrapper.h"
+#include "IGstProfiler.h"
+#include "IGstWrapper.h"
+#include "IProfiler.h"
 
 #include <gst/gst.h>
 
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace firebolt::rialto::server
 {
-class GstProfiler
+class GstProfiler : public IGstProfiler
 {
 public:
     using IGstWrapper = firebolt::rialto::wrappers::IGstWrapper;
     using IGlibWrapper = firebolt::rialto::wrappers::IGlibWrapper;
-    using IProfilerFactory = firebolt::rialto::common::IProfilerFactory;
     using IProfiler = firebolt::rialto::common::IProfiler;
-    using RecordId = IProfiler::RecordId;
+    using RecordId = IGstProfiler::RecordId;
 
-    enum class Stage {AppSrc, Decryptor, Decoder};
+    GstProfiler(GstElement *pipeline, const std::shared_ptr<IGstWrapper> &gstWrapper,
+                const std::shared_ptr<IGlibWrapper> &glibWrapper);
+    ~GstProfiler() override;
 
-    GstProfiler(GstElement* pipeline,
-                const std::shared_ptr<IGstWrapper> &gstWrapper,
-                const std::shared_ptr<IGlibWrapper> &glibWrapper,
-                std::shared_ptr<IProfilerFactory> profilerFactory);
-    ~GstProfiler();
+    std::optional<RecordId> createRecord(std::string stage) override;
+    std::optional<RecordId> createRecord(std::string stage, std::string info) override;
 
-    std::optional<RecordId> createRecord(std::string stage);
-    std::optional<RecordId> createRecord(std::string stage, std::string info);
+    void scheduleGstElementRecord(GstElement *element) override;
 
-    void scheduleGstElementRecord(GstElement* element);
-
-    void logRecord(const RecordId id);
+    void logRecord(const RecordId id) override;
 
 private:
-    struct ProbeCtx {
-        GstProfiler* self;
+    struct ProbeCtx
+    {
+        GstProfiler *self;
         std::string stage;
         std::string info;
     };
 
-    std::optional<std::string> checkElement(GstElement* element);
+    std::optional<std::string> checkElement(GstElement *element);
 
-    static GstPadProbeReturn probeCb(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
+    static GstPadProbeReturn probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
     static void probeCtxDestroy(gpointer data);
 
-    GstElement* m_pipeline = nullptr;
+    GstElement *m_pipeline = nullptr;
     std::shared_ptr<IGstWrapper> m_gstWrapper;
     std::shared_ptr<IGlibWrapper> m_glibWrapper;
-    std::shared_ptr<IProfilerFactory> m_profilerFactory;
     std::unique_ptr<IProfiler> m_profiler;
     bool m_enabled = false;
     static constexpr std::string_view k_module = "GstProfiler";

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -53,6 +53,7 @@ private:
     std::shared_ptr<IGlibWrapper> m_glibWrapper;
     std::shared_ptr<IProfilerFactory> m_profilerFactory;
     std::unique_ptr<IProfiler> m_profiler;
+    bool m_enabled = false;
     static constexpr std::string_view k_module = "GstProfiler";
 };
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -1,7 +1,7 @@
 #ifndef FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_
 #define FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_
 
-#include "Profiler.h"
+#include "IProfiler.h"
 #include "IGstWrapper.h"
 #include "IGlibWrapper.h"
 
@@ -17,14 +17,16 @@ class GstProfiler
 public:
     using IGstWrapper = firebolt::rialto::wrappers::IGstWrapper;
     using IGlibWrapper = firebolt::rialto::wrappers::IGlibWrapper;
-    using Profiler = firebolt::rialto::common::Profiler;
-    using RecordId = Profiler::RecordId;
+    using IProfilerFactory = firebolt::rialto::common::IProfilerFactory;
+    using IProfiler = firebolt::rialto::common::IProfiler;
+    using RecordId = IProfiler::RecordId;
 
     enum class Stage {AppSrc, Decryptor, Decoder};
 
     GstProfiler(GstElement* pipeline,
                 const std::shared_ptr<IGstWrapper> &gstWrapper,
-                const std::shared_ptr<IGlibWrapper> &glibWrapper);
+                const std::shared_ptr<IGlibWrapper> &glibWrapper,
+                std::shared_ptr<IProfilerFactory> profilerFactory);
     ~GstProfiler();
 
     std::optional<RecordId> createRecord(std::string stage);
@@ -47,9 +49,10 @@ private:
     static void probeCtxDestroy(gpointer data);
 
     GstElement* m_pipeline = nullptr;
-    Profiler m_profiler;
     std::shared_ptr<IGstWrapper> m_gstWrapper;
     std::shared_ptr<IGlibWrapper> m_glibWrapper;
+    std::shared_ptr<IProfilerFactory> m_profilerFactory;
+    std::unique_ptr<IProfiler> m_profiler;
     static constexpr std::string_view k_module = "GstProfiler";
 };
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -61,6 +61,7 @@ private:
     };
 
     std::optional<std::string> checkElement(GstElement *element);
+    const gchar* getElementClass(GstElement *element);
 
     static GstPadProbeReturn probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
     static void probeCtxDestroy(gpointer data);

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -34,6 +34,15 @@
 
 namespace firebolt::rialto::server
 {
+class GstProfilerFactory : public IGstProfilerFactory
+{
+public:
+    std::unique_ptr<IGstProfiler> createGstProfiler(GstElement *pipeline, const std::shared_ptr<IGstWrapper> &gstWrapper,
+                                                    const std::shared_ptr<IGlibWrapper> &glibWrapper) const override;
+
+    static std::weak_ptr<IGstProfilerFactory> m_factory;
+};
+
 class GstProfiler : public IGstProfiler
 {
 public:
@@ -47,8 +56,6 @@ public:
                 const std::shared_ptr<IGlibWrapper> &glibWrapper);
     ~GstProfiler() override;
 
-    void enable() override;
-    void disable() override;
     bool isEnabled() const override;
 
     std::optional<RecordId> createRecord(std::string stage) override;

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -47,6 +47,10 @@ public:
                 const std::shared_ptr<IGlibWrapper> &glibWrapper);
     ~GstProfiler() override;
 
+    void enable() override;
+    void disable() override;
+    bool isEnabled() const override;
+
     std::optional<RecordId> createRecord(std::string stage) override;
     std::optional<RecordId> createRecord(std::string stage, std::string info) override;
 

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -64,6 +64,7 @@ public:
     void scheduleGstElementRecord(GstElement *element) override;
 
     void logRecord(const RecordId id) override;
+    void dumpToFile() const override;
     void logPipeline() const override;
 
 private:

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -27,6 +27,7 @@
 
 #include <gst/gst.h>
 
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
@@ -36,6 +37,7 @@ namespace firebolt::rialto::server
 class GstProfiler : public IGstProfiler
 {
 public:
+    using Clock = std::chrono::system_clock;
     using IGstWrapper = firebolt::rialto::wrappers::IGstWrapper;
     using IGlibWrapper = firebolt::rialto::wrappers::IGlibWrapper;
     using IProfiler = firebolt::rialto::common::IProfiler;
@@ -51,6 +53,7 @@ public:
     void scheduleGstElementRecord(GstElement *element) override;
 
     void logRecord(const RecordId id) override;
+    void logPipeline() const override;
 
 private:
     struct ProbeCtx
@@ -60,11 +63,57 @@ private:
         std::string info;
     };
 
+    struct PipelineStageTimestamps
+    {
+        std::optional<Clock::time_point> pipelineCreated;
+        std::optional<Clock::time_point> allSourcesAttached;
+
+        std::optional<Clock::time_point> firstSegmentReceivedVideo;
+        std::optional<Clock::time_point> firstSegmentReceivedAudio;
+
+        std::optional<Clock::time_point> sourceFbExitVideo;
+        std::optional<Clock::time_point> sourceFbExitAudio;
+
+        std::optional<Clock::time_point> decryptorFbExitVideo;
+        std::optional<Clock::time_point> decryptorFbExitAudio;
+
+        std::optional<Clock::time_point> decoderFbExitVideo;
+        std::optional<Clock::time_point> decoderFbExitAudio;
+
+        std::optional<Clock::time_point> pipelinePaused;
+        std::optional<Clock::time_point> pipelinePlaying;
+    };
+
+    struct PipelineMetrics
+    {
+        std::optional<int64_t> preparation;
+        std::optional<int64_t> videoDownload;
+        std::optional<int64_t> audioDownload;
+        std::optional<int64_t> videoSource;
+        std::optional<int64_t> audioSource;
+        std::optional<int64_t> videoDecryption;
+        std::optional<int64_t> audioDecryption;
+        std::optional<int64_t> videoDecode;
+        std::optional<int64_t> audioDecode;
+        std::optional<int64_t> preRoll;
+        std::optional<int64_t> play;
+        std::optional<int64_t> total;
+        std::optional<int64_t> totalWithoutApp;
+    };
+
     std::optional<std::string> checkElement(GstElement *element);
     const gchar* getElementClass(GstElement *element);
+    std::string processElementName(std::string name);
+
+    std::optional<GstProfiler::PipelineMetrics> calculateMetrics() const;
 
     static GstPadProbeReturn probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
     static void probeCtxDestroy(gpointer data);
+
+    static std::optional<int64_t> diffMs(const std::optional<Clock::time_point>& end,
+                                     const std::optional<Clock::time_point>& start);
+    static std::optional<Clock::time_point> maxTime(const std::optional<Clock::time_point>& a,
+                                                const std::optional<Clock::time_point>& b);
 
     GstElement *m_pipeline = nullptr;
     std::shared_ptr<IGstWrapper> m_gstWrapper;

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -115,6 +115,7 @@ private:
 
     std::optional<std::string> checkElement(GstElement *element);
     const gchar *getElementClass(GstElement *element);
+    std::string classifyElementName(std::string name) const;
 
     std::optional<GstProfiler::PipelineMetrics> calculateMetrics() const;
 

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -114,7 +114,6 @@ private:
 
     std::optional<std::string> checkElement(GstElement *element);
     const gchar *getElementClass(GstElement *element);
-    std::string processElementName(std::string name);
 
     std::optional<GstProfiler::PipelineMetrics> calculateMetrics() const;
 

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -102,7 +102,7 @@ private:
     };
 
     std::optional<std::string> checkElement(GstElement *element);
-    const gchar* getElementClass(GstElement *element);
+    const gchar *getElementClass(GstElement *element);
     std::string processElementName(std::string name);
 
     std::optional<GstProfiler::PipelineMetrics> calculateMetrics() const;
@@ -110,10 +110,10 @@ private:
     static GstPadProbeReturn probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
     static void probeCtxDestroy(gpointer data);
 
-    static std::optional<int64_t> diffMs(const std::optional<Clock::time_point>& end,
-                                     const std::optional<Clock::time_point>& start);
-    static std::optional<Clock::time_point> maxTime(const std::optional<Clock::time_point>& a,
-                                                const std::optional<Clock::time_point>& b);
+    static std::optional<int64_t> diffMs(const std::optional<Clock::time_point> &end,
+                                         const std::optional<Clock::time_point> &start);
+    static std::optional<Clock::time_point> maxTime(const std::optional<Clock::time_point> &a,
+                                                    const std::optional<Clock::time_point> &b);
 
     GstElement *m_pipeline = nullptr;
     std::shared_ptr<IGstWrapper> m_gstWrapper;

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -32,6 +32,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace firebolt::rialto::server
 {
@@ -63,15 +64,18 @@ public:
     std::optional<RecordId> createRecord(std::string stage, std::string info) override;
 
     void scheduleGstElementRecord(GstElement *element) override;
+    const std::vector<Record> &getRecords() const override;
 
     void logRecord(const RecordId id) override;
     void dumpToFile() const override;
     void logPipeline() const override;
 
 private:
+    friend class GstProfilerAccessor;
+
     struct ProbeCtx
     {
-        GstProfiler *self;
+        std::shared_ptr<IProfiler> profiler;
         std::string stage;
         std::string info;
     };
@@ -131,7 +135,7 @@ private:
     GstElement *m_pipeline = nullptr;
     std::shared_ptr<IGstWrapper> m_gstWrapper;
     std::shared_ptr<IGlibWrapper> m_glibWrapper;
-    std::unique_ptr<IProfiler> m_profiler;
+    std::shared_ptr<IProfiler> m_profiler;
     bool m_enabled = false;
     static constexpr std::string_view k_module = "GstProfiler";
 };

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace firebolt::rialto::server
 {

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -48,37 +48,29 @@ public:
 class GstProfiler : public IGstProfiler
 {
 public:
-    using Clock = std::chrono::system_clock;
-    using IGstWrapper = firebolt::rialto::wrappers::IGstWrapper;
-    using IGlibWrapper = firebolt::rialto::wrappers::IGlibWrapper;
-    using IProfiler = firebolt::rialto::common::IProfiler;
     using RecordId = IGstProfiler::RecordId;
 
-    GstProfiler(GstElement *pipeline, const std::shared_ptr<IGstWrapper> &gstWrapper,
-                const std::shared_ptr<IGlibWrapper> &glibWrapper);
+    GstProfiler(GstElement *pipeline, const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
+                const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper);
     ~GstProfiler() override;
 
     bool isEnabled() const override;
 
-    std::optional<RecordId> createRecord(std::string stage) override;
-    std::optional<RecordId> createRecord(std::string stage, std::string info) override;
+    std::optional<RecordId> createRecord(const std::string &stage) override;
+    std::optional<RecordId> createRecord(const std::string &stage, const std::string &info) override;
 
     void scheduleGstElementRecord(GstElement *element) override;
     const std::vector<Record> &getRecords() const override;
 
     void logRecord(const RecordId id) override;
     void dumpToFile() const override;
-    void logPipeline() const override;
+    void logPipelineSummary() const override;
 
 private:
-    friend class GstProfilerAccessor;
-
-    struct ProbeCtx
-    {
-        std::shared_ptr<IProfiler> profiler;
-        std::string stage;
-        std::string info;
-    };
+    using Clock = std::chrono::system_clock;
+    using IGstWrapper = firebolt::rialto::wrappers::IGstWrapper;
+    using IGlibWrapper = firebolt::rialto::wrappers::IGlibWrapper;
+    using IProfiler = firebolt::rialto::common::IProfiler;
 
     struct PipelineStageTimestamps
     {
@@ -118,26 +110,17 @@ private:
         std::optional<int64_t> totalWithoutApp;
     };
 
-    std::optional<std::string> checkElement(GstElement *element);
-    const gchar *getElementClass(GstElement *element);
-    std::string classifyElementName(std::string name) const;
+    std::optional<std::string> getFirstBufferExitStage(GstElement *element);
+    const gchar *getElementClassMetadata(GstElement *element);
+    std::string deriveElementInfoFromName(const std::string &name) const;
 
     std::optional<GstProfiler::PipelineMetrics> calculateMetrics() const;
-
-    static GstPadProbeReturn probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
-    static void probeCtxDestroy(gpointer data);
-
-    static std::optional<int64_t> diffMs(const std::optional<Clock::time_point> &end,
-                                         const std::optional<Clock::time_point> &start);
-    static std::optional<Clock::time_point> maxTime(const std::optional<Clock::time_point> &a,
-                                                    const std::optional<Clock::time_point> &b);
 
     GstElement *m_pipeline = nullptr;
     std::shared_ptr<IGstWrapper> m_gstWrapper;
     std::shared_ptr<IGlibWrapper> m_glibWrapper;
     std::shared_ptr<IProfiler> m_profiler;
     bool m_enabled = false;
-    static constexpr std::string_view k_module = "GstProfiler";
 };
 } // namespace firebolt::rialto::server
 #endif // FIREBOLT_RIALTO_SERVER_GST_PROFILER_H_

--- a/media/server/gstplayer/include/GstProfiler.h
+++ b/media/server/gstplayer/include/GstProfiler.h
@@ -22,6 +22,7 @@
 
 #include "IGlibWrapper.h"
 #include "IGstProfiler.h"
+#include "IGstProfilerPrivate.h"
 #include "IGstWrapper.h"
 #include "IProfiler.h"
 
@@ -45,7 +46,7 @@ public:
     static std::weak_ptr<IGstProfilerFactory> m_factory;
 };
 
-class GstProfiler : public IGstProfiler
+class GstProfiler : public IGstProfiler, public IGstProfilerPrivate
 {
 public:
     using RecordId = IGstProfiler::RecordId;
@@ -54,13 +55,11 @@ public:
                 const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper);
     ~GstProfiler() override;
 
-    bool isEnabled() const override;
-
     std::optional<RecordId> createRecord(const std::string &stage) override;
     std::optional<RecordId> createRecord(const std::string &stage, const std::string &info) override;
 
     void scheduleGstElementRecord(GstElement *element) override;
-    const std::vector<Record> &getRecords() const override;
+    std::vector<Record> getRecords() const override;
 
     void logRecord(const RecordId id) override;
     void dumpToFile() const override;
@@ -113,13 +112,25 @@ private:
     std::optional<std::string> getFirstBufferExitStage(GstElement *element);
     const gchar *getElementClassMetadata(GstElement *element);
     std::string deriveElementInfoFromName(const std::string &name) const;
+    GstPadProbeReturn handleProbeCb(GstPad *pad, GstPadProbeInfo *info) override;
+    void removeProbeCtx(GstPad *pad);
 
     std::optional<GstProfiler::PipelineMetrics> calculateMetrics() const;
+
+    struct ProbeCtx
+    {
+        std::shared_ptr<IProfiler> profiler;
+        std::string stage;
+        std::string info;
+        GstPad *pad;
+        gulong id;
+    };
 
     GstElement *m_pipeline = nullptr;
     std::shared_ptr<IGstWrapper> m_gstWrapper;
     std::shared_ptr<IGlibWrapper> m_glibWrapper;
     std::shared_ptr<IProfiler> m_profiler;
+    std::vector<ProbeCtx> m_probeCtxs;
     bool m_enabled = false;
 };
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -17,24 +17,32 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_COMMON_PROFILER_FACTORY_MOCK_H_
-#define FIREBOLT_RIALTO_COMMON_PROFILER_FACTORY_MOCK_H_
+#ifndef FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_H_
+#define FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_H_
 
-#include "IProfiler.h"
-#include <gmock/gmock.h>
-#include <memory>
+#include <cstdint>
+#include <optional>
 #include <string>
 
-namespace firebolt::rialto::common
+struct _GstElement;
+using GstElement = _GstElement;
+
+namespace firebolt::rialto::server
 {
-class ProfilerFactoryMock : public IProfilerFactory
+class IGstProfiler
 {
 public:
-    ProfilerFactoryMock() = default;
-    virtual ~ProfilerFactoryMock() = default;
+    using RecordId = std::uint64_t;
 
-    MOCK_METHOD(std::unique_ptr<IProfiler>, createProfiler, (std::string moduleName), (const, override));
+    virtual ~IGstProfiler() = default;
+
+    virtual std::optional<RecordId> createRecord(std::string stage) = 0;
+    virtual std::optional<RecordId> createRecord(std::string stage, std::string info) = 0;
+
+    virtual void scheduleGstElementRecord(GstElement *element) = 0;
+
+    virtual void logRecord(RecordId id) = 0;
 };
-} // namespace firebolt::rialto::common
+} // namespace firebolt::rialto::server
 
-#endif // FIREBOLT_RIALTO_COMMON_PROFILER_FACTORY_MOCK_H_
+#endif // FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_H_

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -36,6 +36,10 @@ public:
 
     virtual ~IGstProfiler() = default;
 
+    virtual void enable() = 0;
+    virtual void disable() = 0;
+    virtual bool isEnabled() const = 0;
+
     virtual std::optional<RecordId> createRecord(std::string stage) = 0;
     virtual std::optional<RecordId> createRecord(std::string stage, std::string info) = 0;
 

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -66,6 +66,7 @@ public:
     virtual void scheduleGstElementRecord(GstElement *element) = 0;
 
     virtual void logRecord(RecordId id) = 0;
+    virtual void dumpToFile() const = 0;
     virtual void logPipeline() const = 0;
 };
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -20,7 +20,11 @@
 #ifndef FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_H_
 #define FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_H_
 
+#include "IGlibWrapper.h"
+#include "IGstWrapper.h"
+
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -29,6 +33,24 @@ using GstElement = _GstElement;
 
 namespace firebolt::rialto::server
 {
+class IGstProfiler;
+
+class IGstProfilerFactory
+{
+public:
+    using IGstWrapper = firebolt::rialto::wrappers::IGstWrapper;
+    using IGlibWrapper = firebolt::rialto::wrappers::IGlibWrapper;
+
+    IGstProfilerFactory() = default;
+    virtual ~IGstProfilerFactory() = default;
+
+    static std::shared_ptr<IGstProfilerFactory> getFactory();
+
+    virtual std::unique_ptr<IGstProfiler> createGstProfiler(GstElement *pipeline,
+                                                            const std::shared_ptr<IGstWrapper> &gstWrapper,
+                                                            const std::shared_ptr<IGlibWrapper> &glibWrapper) const = 0;
+};
+
 class IGstProfiler
 {
 public:
@@ -36,8 +58,6 @@ public:
 
     virtual ~IGstProfiler() = default;
 
-    virtual void enable() = 0;
-    virtual void disable() = 0;
     virtual bool isEnabled() const = 0;
 
     virtual std::optional<RecordId> createRecord(std::string stage) = 0;

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -42,6 +42,7 @@ public:
     virtual void scheduleGstElementRecord(GstElement *element) = 0;
 
     virtual void logRecord(RecordId id) = 0;
+    virtual void logPipeline() const = 0;
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -24,14 +24,13 @@
 #include "IGstWrapper.h"
 #include "IProfiler.h"
 
+#include <gst/gst.h>
+
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
-
-struct _GstElement;
-using GstElement = _GstElement;
 
 namespace firebolt::rialto::server
 {
@@ -63,15 +62,15 @@ public:
 
     virtual bool isEnabled() const = 0;
 
-    virtual std::optional<RecordId> createRecord(std::string stage) = 0;
-    virtual std::optional<RecordId> createRecord(std::string stage, std::string info) = 0;
+    virtual std::optional<RecordId> createRecord(const std::string &stage) = 0;
+    virtual std::optional<RecordId> createRecord(const std::string &stage, const std::string &info) = 0;
 
     virtual void scheduleGstElementRecord(GstElement *element) = 0;
     virtual const std::vector<Record> &getRecords() const = 0;
 
     virtual void logRecord(RecordId id) = 0;
     virtual void dumpToFile() const = 0;
-    virtual void logPipeline() const = 0;
+    virtual void logPipelineSummary() const = 0;
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -60,13 +60,11 @@ public:
 
     virtual ~IGstProfiler() = default;
 
-    virtual bool isEnabled() const = 0;
-
     virtual std::optional<RecordId> createRecord(const std::string &stage) = 0;
     virtual std::optional<RecordId> createRecord(const std::string &stage, const std::string &info) = 0;
 
     virtual void scheduleGstElementRecord(GstElement *element) = 0;
-    virtual const std::vector<Record> &getRecords() const = 0;
+    virtual std::vector<Record> getRecords() const = 0;
 
     virtual void logRecord(RecordId id) = 0;
     virtual void dumpToFile() const = 0;

--- a/media/server/gstplayer/include/IGstProfiler.h
+++ b/media/server/gstplayer/include/IGstProfiler.h
@@ -22,11 +22,13 @@
 
 #include "IGlibWrapper.h"
 #include "IGstWrapper.h"
+#include "IProfiler.h"
 
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 struct _GstElement;
 using GstElement = _GstElement;
@@ -55,6 +57,7 @@ class IGstProfiler
 {
 public:
     using RecordId = std::uint64_t;
+    using Record = firebolt::rialto::common::IProfiler::Record;
 
     virtual ~IGstProfiler() = default;
 
@@ -64,6 +67,7 @@ public:
     virtual std::optional<RecordId> createRecord(std::string stage, std::string info) = 0;
 
     virtual void scheduleGstElementRecord(GstElement *element) = 0;
+    virtual const std::vector<Record> &getRecords() const = 0;
 
     virtual void logRecord(RecordId id) = 0;
     virtual void dumpToFile() const = 0;

--- a/media/server/gstplayer/include/IGstProfilerPrivate.h
+++ b/media/server/gstplayer/include/IGstProfilerPrivate.h
@@ -1,0 +1,50 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_PRIVATE_H_
+#define FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_PRIVATE_H_
+
+#include <gst/gst.h>
+
+namespace firebolt::rialto::server
+{
+class IGstProfilerPrivate
+{
+public:
+    IGstProfilerPrivate() = default;
+    virtual ~IGstProfilerPrivate() = default;
+
+    IGstProfilerPrivate(const IGstProfilerPrivate &) = delete;
+    IGstProfilerPrivate &operator=(const IGstProfilerPrivate &) = delete;
+    IGstProfilerPrivate(IGstProfilerPrivate &&) = delete;
+    IGstProfilerPrivate &operator=(IGstProfilerPrivate &&) = delete;
+
+    /**
+     * @brief Handles pad probe callback.
+     *
+     * @param[in] pad : Pad where the probe is attached.
+     * @param[in] info : Probe info.
+     *
+     * @retval The probe return code.
+     */
+    virtual GstPadProbeReturn handleProbeCb(GstPad *pad, GstPadProbeInfo *info) = 0;
+};
+} // namespace firebolt::rialto::server
+
+#endif // FIREBOLT_RIALTO_SERVER_I_GST_PROFILER_PRIVATE_H_

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -227,8 +227,7 @@ void GstGenericPlayer::initMsePipeline()
     // Set pipeline flags
     setPlaybinFlags(true);
 
-    m_context.gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper,
-                                firebolt::rialto::common::IProfilerFactory::createFactory());
+    m_context.gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper);
 
     // Set callbacks
     m_glibWrapper->gSignalConnect(m_context.pipeline, "source-setup", G_CALLBACK(&GstGenericPlayer::setupSource), this);
@@ -256,7 +255,7 @@ void GstGenericPlayer::initMsePipeline()
     }
     RIALTO_SERVER_LOG_MIL("New RialtoServer's pipeline created");
     auto recordId = m_context.gstProfiler->createRecord("Pipeline Created");
-    if(recordId)
+    if (recordId)
         m_context.gstProfiler->logRecord(recordId.value());
 }
 
@@ -319,7 +318,7 @@ void GstGenericPlayer::termPipeline()
 
     RIALTO_SERVER_LOG_MIL("RialtoServer's pipeline terminated");
     auto recordId = m_context.gstProfiler->createRecord("Pipeline Terminated");
-    if(recordId)
+    if (recordId)
         m_context.gstProfiler->logRecord(recordId.value());
 }
 
@@ -1503,7 +1502,7 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
                               typeStr.c_str(), GST_TIME_ARGS(segment->start), GST_TIME_ARGS(segment->stop),
                               segment->rate, segment->applied_rate, resetTime);
         auto recordId = m_context.gstProfiler->createRecord("First Segment Received", typeStr);
-        if(recordId)
+        if (recordId)
             m_context.gstProfiler->logRecord(recordId.value());
 
         GstCaps *currentCaps = m_gstWrapper->gstAppSrcGetCaps(GST_APP_SRC(source));

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -227,7 +227,7 @@ void GstGenericPlayer::initMsePipeline()
     // Set pipeline flags
     setPlaybinFlags(true);
 
-    m_context.m_gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper,
+    m_context.gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper,
                                 firebolt::rialto::common::IProfilerFactory::createFactory());
 
     // Set callbacks
@@ -255,9 +255,9 @@ void GstGenericPlayer::initMsePipeline()
         GST_WARNING("Failed to set pipeline to READY state");
     }
     RIALTO_SERVER_LOG_MIL("New RialtoServer's pipeline created");
-    auto recordId = m_context.m_gstProfiler->createRecord("Pipeline Created");
+    auto recordId = m_context.gstProfiler->createRecord("Pipeline Created");
     if(recordId)
-        m_context.m_gstProfiler->logRecord(recordId.value());
+        m_context.gstProfiler->logRecord(recordId.value());
 }
 
 void GstGenericPlayer::resetWorkerThread()
@@ -318,9 +318,9 @@ void GstGenericPlayer::termPipeline()
     m_gstWrapper->gstObjectUnref(m_context.pipeline);
 
     RIALTO_SERVER_LOG_MIL("RialtoServer's pipeline terminated");
-    auto recordId = m_context.m_gstProfiler->createRecord("Pipeline Terminated");
+    auto recordId = m_context.gstProfiler->createRecord("Pipeline Terminated");
     if(recordId)
-        m_context.m_gstProfiler->logRecord(recordId.value());
+        m_context.gstProfiler->logRecord(recordId.value());
 }
 
 unsigned GstGenericPlayer::getGstPlayFlag(const char *nick)
@@ -1502,9 +1502,9 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
                               "], rate: %f, appliedRate %f, reset_time: %d\n",
                               typeStr.c_str(), GST_TIME_ARGS(segment->start), GST_TIME_ARGS(segment->stop),
                               segment->rate, segment->applied_rate, resetTime);
-        auto recordId = m_context.m_gstProfiler->createRecord("First Segment Received", typeStr);
+        auto recordId = m_context.gstProfiler->createRecord("First Segment Received", typeStr);
         if(recordId)
-            m_context.m_gstProfiler->logRecord(recordId.value());
+            m_context.gstProfiler->logRecord(recordId.value());
 
         GstCaps *currentCaps = m_gstWrapper->gstAppSrcGetCaps(GST_APP_SRC(source));
         // We can't pass buffer in GstSample, because implementation of gst_app_src_push_sample

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -254,7 +254,9 @@ void GstGenericPlayer::initMsePipeline()
         GST_WARNING("Failed to set pipeline to READY state");
     }
     RIALTO_SERVER_LOG_MIL("New RialtoServer's pipeline created");
-    m_context.m_gstProfiler->createRecord("Pipeline Created");
+    auto recordId = m_context.m_gstProfiler->createRecord("Pipeline Created");
+    if(recordId)
+        m_context.m_gstProfiler->logRecord(recordId.value());
 }
 
 void GstGenericPlayer::resetWorkerThread()
@@ -315,7 +317,9 @@ void GstGenericPlayer::termPipeline()
     m_gstWrapper->gstObjectUnref(m_context.pipeline);
 
     RIALTO_SERVER_LOG_MIL("RialtoServer's pipeline terminated");
-    m_context.m_gstProfiler->createRecord("Pipeline Terminated");
+    auto recordId = m_context.m_gstProfiler->createRecord("Pipeline Terminated");
+    if(recordId)
+        m_context.m_gstProfiler->logRecord(recordId.value());
 }
 
 unsigned GstGenericPlayer::getGstPlayFlag(const char *nick)
@@ -1497,7 +1501,9 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
                               "], rate: %f, appliedRate %f, reset_time: %d\n",
                               typeStr.c_str(), GST_TIME_ARGS(segment->start), GST_TIME_ARGS(segment->stop),
                               segment->rate, segment->applied_rate, resetTime);
-        m_context.m_gstProfiler->createRecord(std::string("First ") + typeStr.c_str() + "Segment Received");
+        auto recordId = m_context.m_gstProfiler->createRecord("First Segment Received", typeStr);
+        if(recordId)
+            m_context.m_gstProfiler->logRecord(recordId.value());
 
         GstCaps *currentCaps = m_gstWrapper->gstAppSrcGetCaps(GST_APP_SRC(source));
         // We can't pass buffer in GstSample, because implementation of gst_app_src_push_sample

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -328,6 +328,7 @@ void GstGenericPlayer::termPipeline()
     auto recordId = m_context.gstProfiler->createRecord("Pipeline Terminated");
     if (recordId)
         m_context.gstProfiler->logRecord(recordId.value());
+    m_context.gstProfiler->dumpToFile();
 
     // Delete the pipeline
     m_gstWrapper->gstObjectUnref(m_context.pipeline);

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -106,10 +106,12 @@ std::unique_ptr<IGstGenericPlayer> GstGenericPlayerFactory::createGstGenericPlay
         {
             throw std::runtime_error("Cannot create RdkGstreamerUtilsWrapper");
         }
+
         gstPlayer = std::make_unique<
             GstGenericPlayer>(client, decryptionService, type, videoRequirements, isLive, gstWrapper, glibWrapper,
                               rdkGstreamerUtilsWrapper, IGstInitialiser::instance(), std::make_unique<FlushWatcher>(),
-                              IGstSrcFactory::getFactory(), common::ITimerFactory::getFactory(),
+                              IGstSrcFactory::getFactory(), IGstProfilerFactory::getFactory(),
+                              common::ITimerFactory::getFactory(),
                               std::make_unique<GenericPlayerTaskFactory>(client, gstWrapper, glibWrapper,
                                                                          rdkGstreamerUtilsWrapper,
                                                                          IGstTextTrackSinkFactory::createFactory()),
@@ -131,13 +133,14 @@ GstGenericPlayer::GstGenericPlayer(
     const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
     const std::shared_ptr<firebolt::rialto::wrappers::IRdkGstreamerUtilsWrapper> &rdkGstreamerUtilsWrapper,
     const IGstInitialiser &gstInitialiser, std::unique_ptr<IFlushWatcher> &&flushWatcher,
-    const std::shared_ptr<IGstSrcFactory> &gstSrcFactory, std::shared_ptr<common::ITimerFactory> timerFactory,
+    const std::shared_ptr<IGstSrcFactory> &gstSrcFactory,
+    const std::shared_ptr<IGstProfilerFactory> &gstProfilerFactory, std::shared_ptr<common::ITimerFactory> timerFactory,
     std::unique_ptr<IGenericPlayerTaskFactory> taskFactory, std::unique_ptr<IWorkerThreadFactory> workerThreadFactory,
     std::unique_ptr<IGstDispatcherThreadFactory> gstDispatcherThreadFactory,
     std::shared_ptr<IGstProtectionMetadataHelperFactory> gstProtectionMetadataFactory)
     : m_gstPlayerClient(client), m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper},
-      m_rdkGstreamerUtilsWrapper{rdkGstreamerUtilsWrapper}, m_timerFactory{timerFactory},
-      m_taskFactory{std::move(taskFactory)}, m_flushWatcher{std::move(flushWatcher)}
+      m_rdkGstreamerUtilsWrapper{rdkGstreamerUtilsWrapper}, m_gstProfilerFactory{gstProfilerFactory},
+      m_timerFactory{timerFactory}, m_taskFactory{std::move(taskFactory)}, m_flushWatcher{std::move(flushWatcher)}
 {
     RIALTO_SERVER_LOG_DEBUG("GstGenericPlayer is constructed.");
 
@@ -149,6 +152,10 @@ GstGenericPlayer::GstGenericPlayer(
     if ((!gstSrcFactory) || (!(m_context.gstSrc = gstSrcFactory->getGstSrc())))
     {
         throw std::runtime_error("Cannot create GstSrc");
+    }
+    if (!m_gstProfilerFactory)
+    {
+        throw std::runtime_error("No gst profiler factory provided");
     }
 
     if (!timerFactory)
@@ -228,7 +235,11 @@ void GstGenericPlayer::initMsePipeline()
     // Set pipeline flags
     setPlaybinFlags(true);
 
-    m_context.gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper);
+    m_context.gstProfiler = m_gstProfilerFactory->createGstProfiler(m_context.pipeline, m_gstWrapper, m_glibWrapper);
+    if (!m_context.gstProfiler)
+    {
+        throw std::runtime_error("Cannot create GstProfiler");
+    }
 
     // Set callbacks
     m_glibWrapper->gSignalConnect(m_context.pipeline, "source-setup", G_CALLBACK(&GstGenericPlayer::setupSource), this);

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -227,7 +227,8 @@ void GstGenericPlayer::initMsePipeline()
     // Set pipeline flags
     setPlaybinFlags(true);
 
-    m_context.m_gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper);
+    m_context.m_gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper,
+                                firebolt::rialto::common::IProfilerFactory::createFactory());
 
     // Set callbacks
     m_glibWrapper->gSignalConnect(m_context.pipeline, "source-setup", G_CALLBACK(&GstGenericPlayer::setupSource), this);

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -26,6 +26,7 @@
 #include "FlushWatcher.h"
 #include "GstDispatcherThread.h"
 #include "GstGenericPlayer.h"
+#include "GstProfiler.h"
 #include "GstProtectionMetadata.h"
 #include "IGstTextTrackSinkFactory.h"
 #include "IMediaPipeline.h"
@@ -313,13 +314,14 @@ void GstGenericPlayer::termPipeline()
         m_context.playbackGroup.m_curAudioPlaysinkBin = nullptr;
     }
 
+    auto recordId = m_context.gstProfiler->createRecord("Pipeline Terminated");
+    if (recordId)
+        m_context.gstProfiler->logRecord(recordId.value());
+
     // Delete the pipeline
     m_gstWrapper->gstObjectUnref(m_context.pipeline);
 
     RIALTO_SERVER_LOG_MIL("RialtoServer's pipeline terminated");
-    auto recordId = m_context.gstProfiler->createRecord("Pipeline Terminated");
-    if (recordId)
-        m_context.gstProfiler->logRecord(recordId.value());
 }
 
 unsigned GstGenericPlayer::getGstPlayFlag(const char *nick)

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -227,6 +227,8 @@ void GstGenericPlayer::initMsePipeline()
     // Set pipeline flags
     setPlaybinFlags(true);
 
+    m_context.m_gstProfiler = std::make_unique<GstProfiler>(m_context.pipeline, m_gstWrapper, m_glibWrapper);
+
     // Set callbacks
     m_glibWrapper->gSignalConnect(m_context.pipeline, "source-setup", G_CALLBACK(&GstGenericPlayer::setupSource), this);
     m_glibWrapper->gSignalConnect(m_context.pipeline, "element-setup", G_CALLBACK(&GstGenericPlayer::setupElement), this);
@@ -252,6 +254,7 @@ void GstGenericPlayer::initMsePipeline()
         GST_WARNING("Failed to set pipeline to READY state");
     }
     RIALTO_SERVER_LOG_MIL("New RialtoServer's pipeline created");
+    m_context.m_gstProfiler->createRecord("Pipeline Created");
 }
 
 void GstGenericPlayer::resetWorkerThread()
@@ -312,6 +315,7 @@ void GstGenericPlayer::termPipeline()
     m_gstWrapper->gstObjectUnref(m_context.pipeline);
 
     RIALTO_SERVER_LOG_MIL("RialtoServer's pipeline terminated");
+    m_context.m_gstProfiler->createRecord("Pipeline Terminated");
 }
 
 unsigned GstGenericPlayer::getGstPlayFlag(const char *nick)
@@ -1493,6 +1497,7 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
                               "], rate: %f, appliedRate %f, reset_time: %d\n",
                               typeStr.c_str(), GST_TIME_ARGS(segment->start), GST_TIME_ARGS(segment->stop),
                               segment->rate, segment->applied_rate, resetTime);
+        m_context.m_gstProfiler->createRecord(std::string("First ") + typeStr.c_str() + "Segment Received");
 
         GstCaps *currentCaps = m_gstWrapper->gstAppSrcGetCaps(GST_APP_SRC(source));
         // We can't pass buffer in GstSample, because implementation of gst_app_src_push_sample

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -1,0 +1,116 @@
+#include "GstProfiler.h"
+
+#include <mutex>
+#include <string>
+
+#include <gst/gst.h>
+#include <glib.h>
+
+namespace firebolt::rialto::server
+{
+inline constexpr std::array kKlassTokens
+{
+    std::string_view{"Source"},
+    std::string_view{"Decryptor"},
+    std::string_view{"Decoder"},
+};
+
+GstProfiler::GstProfiler(GstElement* pipeline,
+                        const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
+                        const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper)
+    :   m_pipeline{pipeline},
+        m_id{generateId()},
+        m_profiler{k_module, m_id},
+        m_gstWrapper{gstWrapper},
+        m_glibWrapper{glibWrapper}
+{
+    if (m_pipeline)
+        m_gstWrapper->gstObjectRef(m_pipeline);
+}
+
+
+GstProfiler::~GstProfiler()
+{
+    if (m_pipeline)
+        m_gstWrapper->gstObjectUnref(m_pipeline);
+}
+
+uint64_t GstProfiler::generateId()
+{
+    using namespace std::chrono;
+
+    return duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+}
+
+void GstProfiler::createRecord(std::string stage)
+{
+    m_profiler.record(stage);
+}
+
+void GstProfiler::scheduleGstElementRecord(GstElement* element)
+{
+    if (!element)
+        return;
+
+    if(!checkElement(element))
+        return;
+
+    GstPad* pad = m_gstWrapper->gstElementGetStaticPad(element, "src");
+    if (!pad)
+        return;
+
+    auto* probeCtx = new ProbeCtx{this, std::string(m_gstWrapper->gstElementGetName(element))};
+
+    gst_pad_add_probe(pad,
+                    GST_PAD_PROBE_TYPE_BUFFER,
+                    &GstProfiler::probeCb,
+                    probeCtx,
+                    &GstProfiler::probeCtxDestroy);
+
+    m_gstWrapper->gstObjectUnref(pad);
+}
+
+GstPadProbeReturn GstProfiler::probeCb(GstPad* pad, GstPadProbeInfo* info, gpointer user_data)
+{
+    auto* probeCtx = static_cast<ProbeCtx*>(user_data);
+    GstProfiler* self = probeCtx->self;
+    GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+
+    if (!(info->type & GST_PAD_PROBE_TYPE_BUFFER))
+      return GST_PAD_PROBE_OK;
+
+    if (!buffer)
+      return GST_PAD_PROBE_OK;
+
+    self->m_profiler.record(probeCtx->stage);
+
+    return GST_PAD_PROBE_REMOVE;
+}
+
+void GstProfiler::probeCtxDestroy(gpointer data)
+{
+    delete static_cast<ProbeCtx*>(data);
+}
+
+bool GstProfiler::checkElement(GstElement* element)
+{
+    GstElementFactory* factory = m_gstWrapper->gstElementGetFactory(element);
+    if (!factory)
+        return false;
+
+    const gchar* klass = gst_element_factory_get_klass(factory);
+    if (!klass)
+        return false;
+
+    for (auto token : kKlassTokens)
+    {
+        if (g_strrstr(klass, token.data()) != nullptr)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -128,7 +128,7 @@ std::optional<std::string> GstProfiler::checkElement(GstElement* element)
     {
         if (g_strrstr(klass, token.data()) != nullptr)
         {
-            return std::string(token.data());
+            return std::string(token.data()) + " FB Exit";
         }
     }
 

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -1,107 +1,130 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "GstProfiler.h"
 #include "RialtoCommonLogging.h"
 
 #include <mutex>
 #include <string>
 
-#include <gst/gst.h>
 #include <glib.h>
+#include <gst/gst.h>
 
 namespace firebolt::rialto::server
 {
-inline constexpr std::array kKlassTokens
-{
+inline constexpr std::array kKlassTokens{
     std::string_view{"Source"},
     std::string_view{"Decryptor"},
     std::string_view{"Decoder"},
 };
 
-GstProfiler::GstProfiler(GstElement* pipeline,
-                        const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
-                        const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
-                        std::shared_ptr<IProfilerFactory> profilerFactory)
-    :   m_pipeline{pipeline},
-        m_gstWrapper{gstWrapper},
-        m_glibWrapper{glibWrapper},
-        m_profilerFactory{profilerFactory}
+GstProfiler::GstProfiler(GstElement *pipeline, const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
+                         const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper)
+    : m_pipeline{pipeline}, m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}
 {
-    if (m_pipeline)
+    auto profilerFactory = firebolt::rialto::common::IProfilerFactory::createFactory();
+    m_profiler = profilerFactory ? profilerFactory->createProfiler(std::string{k_module}) : nullptr;
+    m_enabled = (m_profiler != nullptr) && m_profiler->enabled();
+
+    if (m_enabled && m_pipeline)
         m_gstWrapper->gstObjectRef(m_pipeline);
-
-    if (m_profilerFactory)
-        m_profiler = m_profilerFactory->createProfiler(std::string{k_module});
-
-    if (m_profiler)
-        m_enabled = m_profiler->enabled();
 }
-
 
 GstProfiler::~GstProfiler()
 {
-    if (m_pipeline)
+    if (m_enabled && m_pipeline)
         m_gstWrapper->gstObjectUnref(m_pipeline);
 }
 
 std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage)
 {
-    if (!m_enabled) return std::nullopt;
+    if (!m_enabled || !m_profiler)
+        return std::nullopt;
 
-    return m_profiler->record(stage);
+    auto id = m_profiler->record(std::move(stage));
+    if (!id)
+        return std::nullopt;
+
+    return static_cast<GstProfiler::RecordId>(*id);
 }
 
 std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage, std::string info)
 {
-    if (!m_enabled) return std::nullopt;
+    if (!m_enabled || !m_profiler)
+        return std::nullopt;
 
-    return m_profiler->record(stage, info);
+    auto id = m_profiler->record(std::move(stage), std::move(info));
+    if (!id)
+        return std::nullopt;
+
+    return static_cast<GstProfiler::RecordId>(*id);
 }
 
-void GstProfiler::scheduleGstElementRecord(GstElement* element)
+void GstProfiler::scheduleGstElementRecord(GstElement *element)
 {
-    if (!m_enabled) return;
+    if (!m_enabled || !m_profiler)
+        return;
 
     if (!element)
         return;
 
     auto stage = checkElement(element);
-    if(!stage)
+    if (!stage)
         return;
 
-    GstPad* pad = m_gstWrapper->gstElementGetStaticPad(element, "src");
+    GstPad *pad = m_gstWrapper->gstElementGetStaticPad(element, "src");
     if (!pad)
         return;
 
-    auto* probeCtx = new ProbeCtx{this, stage.value_or(""), std::string(m_gstWrapper->gstElementGetName(element))};
-    gst_pad_add_probe(pad,
-                    GST_PAD_PROBE_TYPE_BUFFER,
-                    &GstProfiler::probeCb,
-                    probeCtx,
-                    &GstProfiler::probeCtxDestroy);
+    gchar *rawName = m_gstWrapper->gstElementGetName(element);
+    std::string elementName = rawName ? rawName : "<null>";
+    if (rawName)
+        m_glibWrapper->gFree(rawName);
+
+    auto *probeCtx = new ProbeCtx{this, stage.value(), std::move(elementName)};
+    gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb, probeCtx, &GstProfiler::probeCtxDestroy);
 
     m_gstWrapper->gstObjectUnref(pad);
 }
 
 void GstProfiler::logRecord(GstProfiler::RecordId id)
 {
-    if (!m_enabled) return;
+    if (!m_enabled || !m_profiler)
+        return;
 
-    m_profiler->log(id);
+    m_profiler->log(static_cast<firebolt::rialto::common::IProfiler::RecordId>(id));
 }
 
-GstPadProbeReturn GstProfiler::probeCb(GstPad* pad, GstPadProbeInfo* info, gpointer user_data)
+GstPadProbeReturn GstProfiler::probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data)
 {
-    auto* probeCtx = static_cast<ProbeCtx*>(user_data);
-    GstProfiler* self = probeCtx->self;
-    GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+    auto *probeCtx = static_cast<ProbeCtx *>(user_data);
+    GstProfiler *self = probeCtx->self;
+    GstBuffer *buffer = GST_PAD_PROBE_INFO_BUFFER(info);
 
     if (!(info->type & GST_PAD_PROBE_TYPE_BUFFER))
-      return GST_PAD_PROBE_OK;
+        return GST_PAD_PROBE_OK;
 
     if (!buffer)
-      return GST_PAD_PROBE_OK;
+        return GST_PAD_PROBE_OK;
 
     const auto id = self->m_profiler->record(probeCtx->stage, probeCtx->info);
-    if(id)
+    if (id)
     {
         self->m_profiler->log(id.value());
     }
@@ -111,16 +134,16 @@ GstPadProbeReturn GstProfiler::probeCb(GstPad* pad, GstPadProbeInfo* info, gpoin
 
 void GstProfiler::probeCtxDestroy(gpointer data)
 {
-    delete static_cast<ProbeCtx*>(data);
+    delete static_cast<ProbeCtx *>(data);
 }
 
-std::optional<std::string> GstProfiler::checkElement(GstElement* element)
+std::optional<std::string> GstProfiler::checkElement(GstElement *element)
 {
-    GstElementFactory* factory = m_gstWrapper->gstElementGetFactory(element);
+    GstElementFactory *factory = m_gstWrapper->gstElementGetFactory(element);
     if (!factory)
         return std::nullopt;
 
-    const gchar* klass = gst_element_factory_get_klass(factory);
+    const gchar *klass = gst_element_factory_get_klass(factory);
     if (!klass)
         return std::nullopt;
 

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -30,6 +30,9 @@ GstProfiler::GstProfiler(GstElement* pipeline,
 
     if (m_profilerFactory)
         m_profiler = m_profilerFactory->createProfiler(std::string{k_module});
+
+    if (m_profiler)
+        m_enabled = m_profiler->enabled();
 }
 
 
@@ -41,16 +44,22 @@ GstProfiler::~GstProfiler()
 
 std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage)
 {
+    if (!m_enabled) return std::nullopt;
+
     return m_profiler->record(stage);
 }
 
 std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage, std::string info)
 {
+    if (!m_enabled) return std::nullopt;
+
     return m_profiler->record(stage, info);
 }
 
 void GstProfiler::scheduleGstElementRecord(GstElement* element)
 {
+    if (!m_enabled) return;
+
     if (!element)
         return;
 
@@ -74,6 +83,8 @@ void GstProfiler::scheduleGstElementRecord(GstElement* element)
 
 void GstProfiler::logRecord(GstProfiler::RecordId id)
 {
+    if (!m_enabled) return;
+
     m_profiler->log(id);
 }
 

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -139,11 +139,7 @@ void GstProfiler::probeCtxDestroy(gpointer data)
 
 std::optional<std::string> GstProfiler::checkElement(GstElement *element)
 {
-    GstElementFactory *factory = m_gstWrapper->gstElementGetFactory(element);
-    if (!factory)
-        return std::nullopt;
-
-    const gchar *klass = gst_element_factory_get_klass(factory);
+    const gchar* klass = getElementClass(element);
     if (!klass)
         return std::nullopt;
 
@@ -156,6 +152,21 @@ std::optional<std::string> GstProfiler::checkElement(GstElement *element)
     }
 
     return std::nullopt;
+}
+
+const gchar* GstProfiler::getElementClass(GstElement *element)
+{
+    GstElementFactory *factory = m_gstWrapper->gstElementGetFactory(element);
+    if (factory)
+    {
+        return gst_element_factory_get_klass(factory);
+    }
+    else
+    {
+        return m_gstWrapper->gstElementClassGetMetadata(GST_ELEMENT_CLASS(G_OBJECT_GET_CLASS(element)), GST_ELEMENT_METADATA_KLASS);
+    }
+
+    return NULL;
 }
 
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -97,7 +97,7 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
     if (rawName)
         m_glibWrapper->gFree(rawName);
 
-    auto *probeCtx = new ProbeCtx{this, stage.value(), std::move(elementName)};
+    auto *probeCtx = new ProbeCtx{this, stage.value(), processElementName(std::move(elementName))};
     gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb, probeCtx, &GstProfiler::probeCtxDestroy);
 
     m_gstWrapper->gstObjectUnref(pad);
@@ -109,6 +109,28 @@ void GstProfiler::logRecord(GstProfiler::RecordId id)
         return;
 
     m_profiler->log(static_cast<firebolt::rialto::common::IProfiler::RecordId>(id));
+}
+
+void GstProfiler::logPipeline() const
+{
+    const auto metrics = calculateMetrics();
+    if(metrics)
+    {
+        RIALTO_COMMON_LOG_MIL("PROFILER | TUNETIME: %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld",
+                              metrics->preparation ? static_cast<long long>(*metrics->preparation) : -1,
+                              metrics->videoDownload ? static_cast<long long>(*metrics->videoDownload) : -1,
+                              metrics->audioDownload ? static_cast<long long>(*metrics->audioDownload) : -1,
+                              metrics->videoSource ? static_cast<long long>(*metrics->videoSource) : -1,
+                              metrics->audioSource ? static_cast<long long>(*metrics->audioSource) : -1,
+                              metrics->videoDecryption ? static_cast<long long>(*metrics->videoDecryption) : -1,
+                              metrics->audioDecryption ? static_cast<long long>(*metrics->audioDecryption) : -1,
+                              metrics->videoDecode ? static_cast<long long>(*metrics->videoDecode) : -1,
+                              metrics->audioDecode ? static_cast<long long>(*metrics->audioDecode) : -1,
+                              metrics->preRoll ? static_cast<long long>(*metrics->preRoll) : -1,
+                              metrics->play ? static_cast<long long>(*metrics->play) : -1,
+                              metrics->total ? static_cast<long long>(*metrics->total) : -1,
+                              metrics->totalWithoutApp ? static_cast<long long>(*metrics->totalWithoutApp) : -1);
+    }
 }
 
 GstPadProbeReturn GstProfiler::probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data)
@@ -167,6 +189,137 @@ const gchar* GstProfiler::getElementClass(GstElement *element)
     }
 
     return NULL;
+}
+
+std::string GstProfiler::processElementName(std::string name)
+{
+    std::string lower = name;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    if (lower.find("vid") != std::string::npos ||
+        lower.find("h264") != std::string::npos ||
+        lower.find("h265") != std::string::npos ||
+        lower.find("hevc") != std::string::npos ||
+        lower.find("avc") != std::string::npos ||
+        lower.find("av1") != std::string::npos ||
+        lower.find("vp9") != std::string::npos ||
+        lower.find("video") != std::string::npos)
+    {
+        return "Video";
+    }
+
+    if (lower.find("aud") != std::string::npos ||
+        lower.find("eac3") != std::string::npos ||
+        lower.find("ac3") != std::string::npos ||
+        lower.find("aac") != std::string::npos ||
+        lower.find("opus") != std::string::npos ||
+        lower.find("audio") != std::string::npos)
+    {
+        return "Audio";
+    }
+
+    return name;
+}
+
+std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() const
+{
+    const auto& records = m_profiler->getRecords();
+
+    PipelineStageTimestamps timestamps;
+
+    for (const auto& record : records)
+    {
+        const auto& stage = record.stage;
+        const auto& info = record.info;
+
+        if (!timestamps.pipelineCreated && stage == "Pipeline Created")
+            timestamps.pipelineCreated = record.time;
+        else if (!timestamps.allSourcesAttached && stage == "All Sources Attached")
+            timestamps.allSourcesAttached = record.time;
+        else if (!timestamps.firstSegmentReceivedVideo && stage == "First Segment Received" && info == "Video")
+            timestamps.firstSegmentReceivedVideo = record.time;
+        else if (!timestamps.firstSegmentReceivedAudio && stage == "First Segment Received" && info == "Audio")
+            timestamps.firstSegmentReceivedAudio = record.time;
+        else if (!timestamps.sourceFbExitVideo && stage == "Source FB Exit" && info == "Video")
+            timestamps.sourceFbExitVideo = record.time;
+        else if (!timestamps.sourceFbExitAudio && stage == "Source FB Exit" && info == "Audio")
+            timestamps.sourceFbExitAudio = record.time;
+        else if (!timestamps.decryptorFbExitVideo && stage == "Decryptor FB Exit" && info == "Video")
+            timestamps.decryptorFbExitVideo = record.time;
+        else if (!timestamps.decryptorFbExitAudio && stage == "Decryptor FB Exit" && info == "Audio")
+            timestamps.decryptorFbExitAudio = record.time;
+        else if (!timestamps.decoderFbExitVideo && stage == "Decoder FB Exit" && info == "Video")
+            timestamps.decoderFbExitVideo = record.time;
+        else if (!timestamps.decoderFbExitAudio && stage == "Decoder FB Exit" && info == "Audio")
+            timestamps.decoderFbExitAudio = record.time;
+        else if (!timestamps.pipelinePaused && stage == "Pipeline State Changed" && info == "PAUSED")
+            timestamps.pipelinePaused = record.time;
+        else if (!timestamps.pipelinePlaying && stage == "Pipeline State Changed" && info == "PLAYING")
+            timestamps.pipelinePlaying = record.time;
+    }
+
+    if(!timestamps.pipelineCreated || !timestamps.allSourcesAttached || !timestamps.firstSegmentReceivedVideo
+        || !timestamps.firstSegmentReceivedAudio || !timestamps.sourceFbExitVideo
+        || !timestamps.sourceFbExitAudio || !timestamps.decoderFbExitVideo
+        || !timestamps.decoderFbExitAudio || !timestamps.pipelinePaused
+        || !timestamps.pipelinePlaying)
+    {
+        // TODO Warning message
+        return std::nullopt;
+    }
+
+    PipelineMetrics metrics;
+
+    metrics.preparation      = diffMs(timestamps.allSourcesAttached,        timestamps.pipelineCreated);
+    metrics.videoDownload    = diffMs(timestamps.firstSegmentReceivedVideo, timestamps.allSourcesAttached);
+    metrics.audioDownload    = diffMs(timestamps.firstSegmentReceivedAudio, timestamps.allSourcesAttached);
+    metrics.videoSource      = diffMs(timestamps.sourceFbExitVideo,         timestamps.firstSegmentReceivedVideo);
+    metrics.audioSource      = diffMs(timestamps.sourceFbExitAudio,         timestamps.firstSegmentReceivedAudio);
+
+    if(timestamps.decryptorFbExitVideo && timestamps.decryptorFbExitAudio)
+    {
+        metrics.videoDecryption  = diffMs(timestamps.decryptorFbExitVideo,      timestamps.sourceFbExitVideo);
+        metrics.audioDecryption  = diffMs(timestamps.decryptorFbExitAudio,      timestamps.sourceFbExitAudio);
+        metrics.videoDecode      = diffMs(timestamps.decoderFbExitVideo,        timestamps.decryptorFbExitVideo);
+        metrics.audioDecode      = diffMs(timestamps.decoderFbExitAudio,        timestamps.decryptorFbExitAudio);
+    }
+    else
+    {
+        metrics.videoDecode = diffMs(timestamps.decoderFbExitVideo, timestamps.sourceFbExitVideo);
+        metrics.audioDecode = diffMs(timestamps.decoderFbExitAudio, timestamps.sourceFbExitAudio);
+    }
+
+    const auto firstMediaReady = maxTime(timestamps.firstSegmentReceivedVideo,
+                                         timestamps.firstSegmentReceivedAudio);
+
+    metrics.preRoll         = diffMs(timestamps.pipelinePaused,  firstMediaReady);
+    metrics.play            = diffMs(timestamps.pipelinePlaying, timestamps.pipelinePaused);
+    metrics.total           = diffMs(timestamps.pipelinePlaying, timestamps.pipelineCreated);
+    metrics.totalWithoutApp = diffMs(timestamps.pipelinePlaying, firstMediaReady);
+
+    return metrics;
+}
+
+std::optional<int64_t> GstProfiler::diffMs(const std::optional<Clock::time_point>& end,
+                                     const std::optional<Clock::time_point>& start)
+{
+    if (!end || !start)
+        return std::nullopt;
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(*end - *start).count();
+}
+
+std::optional<GstProfiler::Clock::time_point> GstProfiler::maxTime(const std::optional<Clock::time_point>& a,
+                                                const std::optional<Clock::time_point>& b)
+{
+    if (a && b)
+        return std::max(*a, *b);
+    if (a)
+        return a;
+    if (b)
+        return b;
+    return std::nullopt;
 }
 
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -31,6 +31,36 @@
 
 namespace firebolt::rialto::server
 {
+std::weak_ptr<IGstProfilerFactory> GstProfilerFactory::m_factory;
+
+std::shared_ptr<IGstProfilerFactory> IGstProfilerFactory::getFactory()
+{
+    std::shared_ptr<IGstProfilerFactory> factory = GstProfilerFactory::m_factory.lock();
+
+    if (!factory)
+    {
+        try
+        {
+            factory = std::make_shared<GstProfilerFactory>();
+        }
+        catch (const std::exception &e)
+        {
+            RIALTO_COMMON_LOG_ERROR("Failed to create the gst profiler factory, reason: %s", e.what());
+        }
+
+        GstProfilerFactory::m_factory = factory;
+    }
+
+    return factory;
+}
+
+std::unique_ptr<IGstProfiler> GstProfilerFactory::createGstProfiler(GstElement *pipeline,
+                                                                    const std::shared_ptr<IGstWrapper> &gstWrapper,
+                                                                    const std::shared_ptr<IGlibWrapper> &glibWrapper) const
+{
+    return std::make_unique<GstProfiler>(pipeline, gstWrapper, glibWrapper);
+}
+
 inline constexpr std::array kKlassTokens{
     std::string_view{"Source"},
     std::string_view{"Decryptor"},
@@ -55,33 +85,9 @@ GstProfiler::~GstProfiler()
         m_gstWrapper->gstObjectUnref(m_pipeline);
 }
 
-void GstProfiler::enable()
-{
-    if (!m_profiler || m_enabled)
-        return;
-
-    m_profiler->enable();
-    m_enabled = m_profiler->isEnabled();
-
-    if (m_enabled && m_pipeline)
-        m_gstWrapper->gstObjectRef(m_pipeline);
-}
-
-void GstProfiler::disable()
-{
-    if (!m_profiler || !m_enabled)
-        return;
-
-    if (m_pipeline)
-        m_gstWrapper->gstObjectUnref(m_pipeline);
-
-    m_profiler->disable();
-    m_enabled = false;
-}
-
 bool GstProfiler::isEnabled() const
 {
-    return m_profiler && m_profiler->isEnabled();
+    return m_enabled;
 }
 
 std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage)

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -19,6 +19,7 @@
 
 #include "GstProfiler.h"
 #include "RialtoCommonLogging.h"
+#include "Utils.h"
 
 #include <algorithm>
 #include <array>
@@ -130,12 +131,24 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
     if (!pad)
         return;
 
-    gchar *rawName = m_gstWrapper->gstElementGetName(element);
-    std::string elementName = rawName ? rawName : "<null>";
-    if (rawName)
-        m_glibWrapper->gFree(rawName);
+    std::string elementInfo;
+    if (isVideo(*m_gstWrapper, element))
+    {
+        elementInfo = "Video";
+    }
+    else if (isAudio(*m_gstWrapper, element))
+    {
+        elementInfo = "Audio";
+    }
+    else
+    {
+        gchar *rawName = m_gstWrapper->gstElementGetName(element);
+        elementInfo = rawName ? rawName : "<null>";
+        if (rawName)
+            m_glibWrapper->gFree(rawName);
+    }
 
-    auto *probeCtx = new ProbeCtx{this, stage.value(), processElementName(std::move(elementName))};
+    auto *probeCtx = new ProbeCtx{this, stage.value(), std::move(elementInfo)};
     m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb, probeCtx,
                                  &GstProfiler::probeCtxDestroy);
 
@@ -233,29 +246,6 @@ const gchar *GstProfiler::getElementClass(GstElement *element)
     }
 
     return NULL;
-}
-
-std::string GstProfiler::processElementName(std::string name)
-{
-    std::string lower = name;
-    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
-
-    if (lower.find("vid") != std::string::npos || lower.find("h264") != std::string::npos ||
-        lower.find("h265") != std::string::npos || lower.find("hevc") != std::string::npos ||
-        lower.find("avc") != std::string::npos || lower.find("av1") != std::string::npos ||
-        lower.find("vp9") != std::string::npos || lower.find("video") != std::string::npos)
-    {
-        return "Video";
-    }
-
-    if (lower.find("aud") != std::string::npos || lower.find("eac3") != std::string::npos ||
-        lower.find("ac3") != std::string::npos || lower.find("aac") != std::string::npos ||
-        lower.find("opus") != std::string::npos || lower.find("audio") != std::string::npos)
-    {
-        return "Audio";
-    }
-
-    return name;
 }
 
 std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() const

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -40,7 +40,7 @@ GstProfiler::GstProfiler(GstElement *pipeline, const std::shared_ptr<firebolt::r
 {
     auto profilerFactory = firebolt::rialto::common::IProfilerFactory::createFactory();
     m_profiler = profilerFactory ? profilerFactory->createProfiler(std::string{k_module}) : nullptr;
-    m_enabled = (m_profiler != nullptr) && m_profiler->enabled();
+    m_enabled = (m_profiler != nullptr) && m_profiler->isEnabled();
 
     if (m_enabled && m_pipeline)
         m_gstWrapper->gstObjectRef(m_pipeline);
@@ -114,22 +114,23 @@ void GstProfiler::logRecord(GstProfiler::RecordId id)
 void GstProfiler::logPipeline() const
 {
     const auto metrics = calculateMetrics();
-    if(metrics)
+    if (metrics)
     {
-        RIALTO_COMMON_LOG_MIL("PROFILER | TUNETIME: %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld",
-                              metrics->preparation ? static_cast<long long>(*metrics->preparation) : -1,
-                              metrics->videoDownload ? static_cast<long long>(*metrics->videoDownload) : -1,
-                              metrics->audioDownload ? static_cast<long long>(*metrics->audioDownload) : -1,
-                              metrics->videoSource ? static_cast<long long>(*metrics->videoSource) : -1,
-                              metrics->audioSource ? static_cast<long long>(*metrics->audioSource) : -1,
-                              metrics->videoDecryption ? static_cast<long long>(*metrics->videoDecryption) : -1,
-                              metrics->audioDecryption ? static_cast<long long>(*metrics->audioDecryption) : -1,
-                              metrics->videoDecode ? static_cast<long long>(*metrics->videoDecode) : -1,
-                              metrics->audioDecode ? static_cast<long long>(*metrics->audioDecode) : -1,
-                              metrics->preRoll ? static_cast<long long>(*metrics->preRoll) : -1,
-                              metrics->play ? static_cast<long long>(*metrics->play) : -1,
-                              metrics->total ? static_cast<long long>(*metrics->total) : -1,
-                              metrics->totalWithoutApp ? static_cast<long long>(*metrics->totalWithoutApp) : -1);
+        RIALTO_COMMON_LOG_MIL("PROFILER | TUNETIME: %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  "
+                              "%lld,  %lld,  %lld,  %lld",
+                              metrics->preparation ? static_cast<long long>(*metrics->preparation) : -1,     // NOLINT
+                              metrics->videoDownload ? static_cast<long long>(*metrics->videoDownload) : -1, // NOLINT
+                              metrics->audioDownload ? static_cast<long long>(*metrics->audioDownload) : -1, // NOLINT
+                              metrics->videoSource ? static_cast<long long>(*metrics->videoSource) : -1,     // NOLINT
+                              metrics->audioSource ? static_cast<long long>(*metrics->audioSource) : -1,     // NOLINT
+                              metrics->videoDecryption ? static_cast<long long>(*metrics->videoDecryption) : -1, // NOLINT
+                              metrics->audioDecryption ? static_cast<long long>(*metrics->audioDecryption) : -1, // NOLINT
+                              metrics->videoDecode ? static_cast<long long>(*metrics->videoDecode) : -1, // NOLINT
+                              metrics->audioDecode ? static_cast<long long>(*metrics->audioDecode) : -1, // NOLINT
+                              metrics->preRoll ? static_cast<long long>(*metrics->preRoll) : -1,         // NOLINT
+                              metrics->play ? static_cast<long long>(*metrics->play) : -1,               // NOLINT
+                              metrics->total ? static_cast<long long>(*metrics->total) : -1,             // NOLINT
+                              metrics->totalWithoutApp ? static_cast<long long>(*metrics->totalWithoutApp) : -1); // NOLINT
     }
 }
 
@@ -161,7 +162,7 @@ void GstProfiler::probeCtxDestroy(gpointer data)
 
 std::optional<std::string> GstProfiler::checkElement(GstElement *element)
 {
-    const gchar* klass = getElementClass(element);
+    const gchar *klass = getElementClass(element);
     if (!klass)
         return std::nullopt;
 
@@ -176,7 +177,7 @@ std::optional<std::string> GstProfiler::checkElement(GstElement *element)
     return std::nullopt;
 }
 
-const gchar* GstProfiler::getElementClass(GstElement *element)
+const gchar *GstProfiler::getElementClass(GstElement *element)
 {
     GstElementFactory *factory = m_gstWrapper->gstElementGetFactory(element);
     if (factory)
@@ -185,7 +186,8 @@ const gchar* GstProfiler::getElementClass(GstElement *element)
     }
     else
     {
-        return m_gstWrapper->gstElementClassGetMetadata(GST_ELEMENT_CLASS(G_OBJECT_GET_CLASS(element)), GST_ELEMENT_METADATA_KLASS);
+        return m_gstWrapper->gstElementClassGetMetadata(GST_ELEMENT_CLASS(G_OBJECT_GET_CLASS(element)),
+                                                        GST_ELEMENT_METADATA_KLASS);
     }
 
     return NULL;
@@ -194,27 +196,19 @@ const gchar* GstProfiler::getElementClass(GstElement *element)
 std::string GstProfiler::processElementName(std::string name)
 {
     std::string lower = name;
-    std::transform(lower.begin(), lower.end(), lower.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
 
-    if (lower.find("vid") != std::string::npos ||
-        lower.find("h264") != std::string::npos ||
-        lower.find("h265") != std::string::npos ||
-        lower.find("hevc") != std::string::npos ||
-        lower.find("avc") != std::string::npos ||
-        lower.find("av1") != std::string::npos ||
-        lower.find("vp9") != std::string::npos ||
-        lower.find("video") != std::string::npos)
+    if (lower.find("vid") != std::string::npos || lower.find("h264") != std::string::npos ||
+        lower.find("h265") != std::string::npos || lower.find("hevc") != std::string::npos ||
+        lower.find("avc") != std::string::npos || lower.find("av1") != std::string::npos ||
+        lower.find("vp9") != std::string::npos || lower.find("video") != std::string::npos)
     {
         return "Video";
     }
 
-    if (lower.find("aud") != std::string::npos ||
-        lower.find("eac3") != std::string::npos ||
-        lower.find("ac3") != std::string::npos ||
-        lower.find("aac") != std::string::npos ||
-        lower.find("opus") != std::string::npos ||
-        lower.find("audio") != std::string::npos)
+    if (lower.find("aud") != std::string::npos || lower.find("eac3") != std::string::npos ||
+        lower.find("ac3") != std::string::npos || lower.find("aac") != std::string::npos ||
+        lower.find("opus") != std::string::npos || lower.find("audio") != std::string::npos)
     {
         return "Audio";
     }
@@ -224,14 +218,14 @@ std::string GstProfiler::processElementName(std::string name)
 
 std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() const
 {
-    const auto& records = m_profiler->getRecords();
+    const auto &records = m_profiler->getRecords();
 
     PipelineStageTimestamps timestamps;
 
-    for (const auto& record : records)
+    for (const auto &record : records)
     {
-        const auto& stage = record.stage;
-        const auto& info = record.info;
+        const auto &stage = record.stage;
+        const auto &info = record.info;
 
         if (!timestamps.pipelineCreated && stage == "Pipeline Created")
             timestamps.pipelineCreated = record.time;
@@ -259,30 +253,28 @@ std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() cons
             timestamps.pipelinePlaying = record.time;
     }
 
-    if(!timestamps.pipelineCreated || !timestamps.allSourcesAttached || !timestamps.firstSegmentReceivedVideo
-        || !timestamps.firstSegmentReceivedAudio || !timestamps.sourceFbExitVideo
-        || !timestamps.sourceFbExitAudio || !timestamps.decoderFbExitVideo
-        || !timestamps.decoderFbExitAudio || !timestamps.pipelinePaused
-        || !timestamps.pipelinePlaying)
+    if (!timestamps.pipelineCreated || !timestamps.allSourcesAttached || !timestamps.firstSegmentReceivedVideo ||
+        !timestamps.firstSegmentReceivedAudio || !timestamps.sourceFbExitVideo || !timestamps.sourceFbExitAudio ||
+        !timestamps.decoderFbExitVideo || !timestamps.decoderFbExitAudio || !timestamps.pipelinePaused ||
+        !timestamps.pipelinePlaying)
     {
-        // TODO Warning message
         return std::nullopt;
     }
 
     PipelineMetrics metrics;
 
-    metrics.preparation      = diffMs(timestamps.allSourcesAttached,        timestamps.pipelineCreated);
-    metrics.videoDownload    = diffMs(timestamps.firstSegmentReceivedVideo, timestamps.allSourcesAttached);
-    metrics.audioDownload    = diffMs(timestamps.firstSegmentReceivedAudio, timestamps.allSourcesAttached);
-    metrics.videoSource      = diffMs(timestamps.sourceFbExitVideo,         timestamps.firstSegmentReceivedVideo);
-    metrics.audioSource      = diffMs(timestamps.sourceFbExitAudio,         timestamps.firstSegmentReceivedAudio);
+    metrics.preparation = diffMs(timestamps.allSourcesAttached, timestamps.pipelineCreated);
+    metrics.videoDownload = diffMs(timestamps.firstSegmentReceivedVideo, timestamps.allSourcesAttached);
+    metrics.audioDownload = diffMs(timestamps.firstSegmentReceivedAudio, timestamps.allSourcesAttached);
+    metrics.videoSource = diffMs(timestamps.sourceFbExitVideo, timestamps.firstSegmentReceivedVideo);
+    metrics.audioSource = diffMs(timestamps.sourceFbExitAudio, timestamps.firstSegmentReceivedAudio);
 
-    if(timestamps.decryptorFbExitVideo && timestamps.decryptorFbExitAudio)
+    if (timestamps.decryptorFbExitVideo && timestamps.decryptorFbExitAudio)
     {
-        metrics.videoDecryption  = diffMs(timestamps.decryptorFbExitVideo,      timestamps.sourceFbExitVideo);
-        metrics.audioDecryption  = diffMs(timestamps.decryptorFbExitAudio,      timestamps.sourceFbExitAudio);
-        metrics.videoDecode      = diffMs(timestamps.decoderFbExitVideo,        timestamps.decryptorFbExitVideo);
-        metrics.audioDecode      = diffMs(timestamps.decoderFbExitAudio,        timestamps.decryptorFbExitAudio);
+        metrics.videoDecryption = diffMs(timestamps.decryptorFbExitVideo, timestamps.sourceFbExitVideo);
+        metrics.audioDecryption = diffMs(timestamps.decryptorFbExitAudio, timestamps.sourceFbExitAudio);
+        metrics.videoDecode = diffMs(timestamps.decoderFbExitVideo, timestamps.decryptorFbExitVideo);
+        metrics.audioDecode = diffMs(timestamps.decoderFbExitAudio, timestamps.decryptorFbExitAudio);
     }
     else
     {
@@ -290,19 +282,18 @@ std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() cons
         metrics.audioDecode = diffMs(timestamps.decoderFbExitAudio, timestamps.sourceFbExitAudio);
     }
 
-    const auto firstMediaReady = maxTime(timestamps.firstSegmentReceivedVideo,
-                                         timestamps.firstSegmentReceivedAudio);
+    const auto firstMediaReady = maxTime(timestamps.firstSegmentReceivedVideo, timestamps.firstSegmentReceivedAudio);
 
-    metrics.preRoll         = diffMs(timestamps.pipelinePaused,  firstMediaReady);
-    metrics.play            = diffMs(timestamps.pipelinePlaying, timestamps.pipelinePaused);
-    metrics.total           = diffMs(timestamps.pipelinePlaying, timestamps.pipelineCreated);
+    metrics.preRoll = diffMs(timestamps.pipelinePaused, firstMediaReady);
+    metrics.play = diffMs(timestamps.pipelinePlaying, timestamps.pipelinePaused);
+    metrics.total = diffMs(timestamps.pipelinePlaying, timestamps.pipelineCreated);
     metrics.totalWithoutApp = diffMs(timestamps.pipelinePlaying, firstMediaReady);
 
     return metrics;
 }
 
-std::optional<int64_t> GstProfiler::diffMs(const std::optional<Clock::time_point>& end,
-                                     const std::optional<Clock::time_point>& start)
+std::optional<int64_t> GstProfiler::diffMs(const std::optional<Clock::time_point> &end,
+                                           const std::optional<Clock::time_point> &start)
 {
     if (!end || !start)
         return std::nullopt;
@@ -310,8 +301,8 @@ std::optional<int64_t> GstProfiler::diffMs(const std::optional<Clock::time_point
     return std::chrono::duration_cast<std::chrono::milliseconds>(*end - *start).count();
 }
 
-std::optional<GstProfiler::Clock::time_point> GstProfiler::maxTime(const std::optional<Clock::time_point>& a,
-                                                const std::optional<Clock::time_point>& b)
+std::optional<GstProfiler::Clock::time_point> GstProfiler::maxTime(const std::optional<Clock::time_point> &a,
+                                                                   const std::optional<Clock::time_point> &b)
 {
     if (a && b)
         return std::max(*a, *b);

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -143,7 +143,7 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
     else
     {
         gchar *rawName = m_gstWrapper->gstElementGetName(element);
-        elementInfo = rawName ? rawName : "<null>";
+        elementInfo = classifyElementName(rawName ? rawName : "<null>");
         if (rawName)
             m_glibWrapper->gFree(rawName);
     }
@@ -254,6 +254,24 @@ const gchar *GstProfiler::getElementClass(GstElement *element)
     }
 
     return NULL;
+}
+
+std::string GstProfiler::classifyElementName(std::string name) const
+{
+    std::string lower = name;
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+
+    if (lower.find("vid") != std::string::npos || lower.find("video") != std::string::npos)
+    {
+        return "Video";
+    }
+
+    if (lower.find("aud") != std::string::npos || lower.find("audio") != std::string::npos)
+    {
+        return "Audio";
+    }
+
+    return name;
 }
 
 std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() const

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -20,8 +20,11 @@
 #include "GstProfiler.h"
 #include "RialtoCommonLogging.h"
 
-#include <mutex>
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <string>
+#include <string_view>
 
 #include <glib.h>
 #include <gst/gst.h>
@@ -50,6 +53,35 @@ GstProfiler::~GstProfiler()
 {
     if (m_enabled && m_pipeline)
         m_gstWrapper->gstObjectUnref(m_pipeline);
+}
+
+void GstProfiler::enable()
+{
+    if (!m_profiler || m_enabled)
+        return;
+
+    m_profiler->enable();
+    m_enabled = m_profiler->isEnabled();
+
+    if (m_enabled && m_pipeline)
+        m_gstWrapper->gstObjectRef(m_pipeline);
+}
+
+void GstProfiler::disable()
+{
+    if (!m_profiler || !m_enabled)
+        return;
+
+    if (m_pipeline)
+        m_gstWrapper->gstObjectUnref(m_pipeline);
+
+    m_profiler->disable();
+    m_enabled = false;
+}
+
+bool GstProfiler::isEnabled() const
+{
+    return m_profiler && m_profiler->isEnabled();
 }
 
 std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage)
@@ -98,7 +130,8 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
         m_glibWrapper->gFree(rawName);
 
     auto *probeCtx = new ProbeCtx{this, stage.value(), processElementName(std::move(elementName))};
-    gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb, probeCtx, &GstProfiler::probeCtxDestroy);
+    m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb, probeCtx,
+                                 &GstProfiler::probeCtxDestroy);
 
     m_gstWrapper->gstObjectUnref(pad);
 }
@@ -113,6 +146,9 @@ void GstProfiler::logRecord(GstProfiler::RecordId id)
 
 void GstProfiler::logPipeline() const
 {
+    if (!m_enabled || !m_profiler)
+        return;
+
     const auto metrics = calculateMetrics();
     if (metrics)
     {
@@ -168,7 +204,7 @@ std::optional<std::string> GstProfiler::checkElement(GstElement *element)
 
     for (auto token : kKlassTokens)
     {
-        if (g_strrstr(klass, token.data()) != nullptr)
+        if (m_glibWrapper->gStrrstr(klass, token.data()) != nullptr)
         {
             return std::string(token.data()) + " FB Exit";
         }

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -163,6 +163,14 @@ void GstProfiler::logRecord(GstProfiler::RecordId id)
     m_profiler->log(static_cast<firebolt::rialto::common::IProfiler::RecordId>(id));
 }
 
+void GstProfiler::dumpToFile() const
+{
+    if (!m_enabled || !m_profiler)
+        return;
+
+    (void)m_profiler->dumpToFile();
+}
+
 void GstProfiler::logPipeline() const
 {
     if (!m_enabled || !m_profiler)

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -62,18 +62,79 @@ std::unique_ptr<IGstProfiler> GstProfilerFactory::createGstProfiler(GstElement *
     return std::make_unique<GstProfiler>(pipeline, gstWrapper, glibWrapper);
 }
 
+namespace
+{
 inline constexpr std::array kKlassTokens{
     std::string_view{"Source"},
     std::string_view{"Decryptor"},
     std::string_view{"Decoder"},
 };
+inline constexpr std::string_view kModuleName{"GstProfiler"};
+
+using Clock = std::chrono::system_clock;
+using IProfiler = firebolt::rialto::common::IProfiler;
+
+struct ProbeCtx
+{
+    std::shared_ptr<IProfiler> profiler;
+    std::string stage;
+    std::string info;
+};
+
+GstPadProbeReturn probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer userData)
+{
+    auto *probeCtx = static_cast<ProbeCtx *>(userData);
+
+    if (!(info->type & GST_PAD_PROBE_TYPE_BUFFER))
+        return GST_PAD_PROBE_OK;
+
+    if (!GST_PAD_PROBE_INFO_BUFFER(info))
+        return GST_PAD_PROBE_OK;
+
+    if (!probeCtx->profiler)
+        return GST_PAD_PROBE_REMOVE;
+
+    const auto id = probeCtx->profiler->record(probeCtx->stage, probeCtx->info);
+    if (id)
+    {
+        probeCtx->profiler->log(id.value());
+    }
+
+    return GST_PAD_PROBE_REMOVE;
+}
+
+void probeCtxDestroy(gpointer data)
+{
+    delete static_cast<ProbeCtx *>(data);
+}
+
+std::optional<int64_t> diffMs(const std::optional<Clock::time_point> &end, const std::optional<Clock::time_point> &start)
+{
+    if (!end || !start)
+        return std::nullopt;
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(*end - *start).count();
+}
+
+std::optional<Clock::time_point> maxTime(const std::optional<Clock::time_point> &a,
+                                         const std::optional<Clock::time_point> &b)
+{
+    if (a && b)
+        return std::max(*a, *b);
+    if (a)
+        return a;
+    if (b)
+        return b;
+    return std::nullopt;
+}
+} // namespace
 
 GstProfiler::GstProfiler(GstElement *pipeline, const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                          const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper)
     : m_pipeline{pipeline}, m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}
 {
     auto profilerFactory = firebolt::rialto::common::IProfilerFactory::createFactory();
-    m_profiler = profilerFactory ? std::shared_ptr<IProfiler>{profilerFactory->createProfiler(std::string{k_module})}
+    m_profiler = profilerFactory ? std::shared_ptr<IProfiler>{profilerFactory->createProfiler(std::string{kModuleName})}
                                  : nullptr;
     m_enabled = (m_profiler != nullptr) && m_profiler->isEnabled();
 
@@ -92,24 +153,24 @@ bool GstProfiler::isEnabled() const
     return m_enabled;
 }
 
-std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage)
+std::optional<GstProfiler::RecordId> GstProfiler::createRecord(const std::string &stage)
 {
     if (!m_enabled || !m_profiler)
         return std::nullopt;
 
-    auto id = m_profiler->record(std::move(stage));
+    auto id = m_profiler->record(stage);
     if (!id)
         return std::nullopt;
 
     return static_cast<GstProfiler::RecordId>(*id);
 }
 
-std::optional<GstProfiler::RecordId> GstProfiler::createRecord(std::string stage, std::string info)
+std::optional<GstProfiler::RecordId> GstProfiler::createRecord(const std::string &stage, const std::string &info)
 {
     if (!m_enabled || !m_profiler)
         return std::nullopt;
 
-    auto id = m_profiler->record(std::move(stage), std::move(info));
+    auto id = m_profiler->record(stage, info);
     if (!id)
         return std::nullopt;
 
@@ -124,7 +185,7 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
     if (!element)
         return;
 
-    auto stage = checkElement(element);
+    auto stage = getFirstBufferExitStage(element);
     if (!stage)
         return;
 
@@ -144,19 +205,17 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
     else
     {
         gchar *rawName = m_gstWrapper->gstElementGetName(element);
-        elementInfo = classifyElementName(rawName ? rawName : "<null>");
+        elementInfo = deriveElementInfoFromName(rawName ? rawName : "<null>");
         if (rawName)
             m_glibWrapper->gFree(rawName);
     }
 
-    auto probeCtx = std::make_unique<ProbeCtx>(ProbeCtx{m_profiler, stage.value(), std::move(elementInfo)});
-    const auto probeId = m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb,
-                                                      probeCtx.get(), &GstProfiler::probeCtxDestroy);
-    if (probeId != 0)
+    auto *probeCtx = new ProbeCtx{m_profiler, stage.value(), std::move(elementInfo)};
+    const auto probeId =
+        m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &probeCb, probeCtx, &probeCtxDestroy);
+    if (probeId == 0)
     {
-        // Ownership transfers to GStreamer on successful installation and probeCtxDestroy()
-        // deletes the context when the probe is removed.
-        probeCtx.release();
+        delete probeCtx;
     }
 
     m_gstWrapper->gstObjectUnref(pad);
@@ -188,7 +247,7 @@ void GstProfiler::dumpToFile() const
     (void)m_profiler->dumpToFile();
 }
 
-void GstProfiler::logPipeline() const
+void GstProfiler::logPipelineSummary() const
 {
     if (!m_enabled || !m_profiler)
         return;
@@ -214,37 +273,9 @@ void GstProfiler::logPipeline() const
     }
 }
 
-GstPadProbeReturn GstProfiler::probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data)
+std::optional<std::string> GstProfiler::getFirstBufferExitStage(GstElement *element)
 {
-    auto *probeCtx = static_cast<ProbeCtx *>(user_data);
-    GstBuffer *buffer = GST_PAD_PROBE_INFO_BUFFER(info);
-
-    if (!(info->type & GST_PAD_PROBE_TYPE_BUFFER))
-        return GST_PAD_PROBE_OK;
-
-    if (!buffer)
-        return GST_PAD_PROBE_OK;
-
-    if (!probeCtx->profiler)
-        return GST_PAD_PROBE_REMOVE;
-
-    const auto id = probeCtx->profiler->record(probeCtx->stage, probeCtx->info);
-    if (id)
-    {
-        probeCtx->profiler->log(id.value());
-    }
-
-    return GST_PAD_PROBE_REMOVE;
-}
-
-void GstProfiler::probeCtxDestroy(gpointer data)
-{
-    delete static_cast<ProbeCtx *>(data);
-}
-
-std::optional<std::string> GstProfiler::checkElement(GstElement *element)
-{
-    const gchar *klass = getElementClass(element);
+    const gchar *klass = getElementClassMetadata(element);
     if (!klass)
         return std::nullopt;
 
@@ -259,13 +290,13 @@ std::optional<std::string> GstProfiler::checkElement(GstElement *element)
     return std::nullopt;
 }
 
-const gchar *GstProfiler::getElementClass(GstElement *element)
+const gchar *GstProfiler::getElementClassMetadata(GstElement *element)
 {
     return m_gstWrapper->gstElementClassGetMetadata(GST_ELEMENT_CLASS(G_OBJECT_GET_CLASS(element)),
                                                     GST_ELEMENT_METADATA_KLASS);
 }
 
-std::string GstProfiler::classifyElementName(std::string name) const
+std::string GstProfiler::deriveElementInfoFromName(const std::string &name) const
 {
     std::string lower = name;
     std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -357,27 +388,6 @@ std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() cons
     metrics.totalWithoutApp = diffMs(timestamps.pipelinePlaying, firstMediaReady);
 
     return metrics;
-}
-
-std::optional<int64_t> GstProfiler::diffMs(const std::optional<Clock::time_point> &end,
-                                           const std::optional<Clock::time_point> &start)
-{
-    if (!end || !start)
-        return std::nullopt;
-
-    return std::chrono::duration_cast<std::chrono::milliseconds>(*end - *start).count();
-}
-
-std::optional<GstProfiler::Clock::time_point> GstProfiler::maxTime(const std::optional<Clock::time_point> &a,
-                                                                   const std::optional<Clock::time_point> &b)
-{
-    if (a && b)
-        return std::max(*a, *b);
-    if (a)
-        return a;
-    if (b)
-        return b;
-    return std::nullopt;
 }
 
 } // namespace firebolt::rialto::server

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -73,7 +73,8 @@ GstProfiler::GstProfiler(GstElement *pipeline, const std::shared_ptr<firebolt::r
     : m_pipeline{pipeline}, m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}
 {
     auto profilerFactory = firebolt::rialto::common::IProfilerFactory::createFactory();
-    m_profiler = profilerFactory ? profilerFactory->createProfiler(std::string{k_module}) : nullptr;
+    m_profiler = profilerFactory ? std::shared_ptr<IProfiler>{profilerFactory->createProfiler(std::string{k_module})}
+                                 : nullptr;
     m_enabled = (m_profiler != nullptr) && m_profiler->isEnabled();
 
     if (m_enabled && m_pipeline)
@@ -148,11 +149,27 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
             m_glibWrapper->gFree(rawName);
     }
 
-    auto *probeCtx = new ProbeCtx{this, stage.value(), std::move(elementInfo)};
-    m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb, probeCtx,
-                                 &GstProfiler::probeCtxDestroy);
+    auto probeCtx = std::make_unique<ProbeCtx>(ProbeCtx{m_profiler, stage.value(), std::move(elementInfo)});
+    const auto probeId = m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &GstProfiler::probeCb,
+                                                      probeCtx.get(), &GstProfiler::probeCtxDestroy);
+    if (probeId != 0)
+    {
+        // Ownership transfers to GStreamer on successful installation and probeCtxDestroy()
+        // deletes the context when the probe is removed.
+        probeCtx.release();
+    }
 
     m_gstWrapper->gstObjectUnref(pad);
+}
+
+const std::vector<IGstProfiler::Record> &GstProfiler::getRecords() const
+{
+    static const std::vector<Record> kEmptyRecords{};
+
+    if (!m_profiler)
+        return kEmptyRecords;
+
+    return m_profiler->getRecords();
 }
 
 void GstProfiler::logRecord(GstProfiler::RecordId id)
@@ -200,7 +217,6 @@ void GstProfiler::logPipeline() const
 GstPadProbeReturn GstProfiler::probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data)
 {
     auto *probeCtx = static_cast<ProbeCtx *>(user_data);
-    GstProfiler *self = probeCtx->self;
     GstBuffer *buffer = GST_PAD_PROBE_INFO_BUFFER(info);
 
     if (!(info->type & GST_PAD_PROBE_TYPE_BUFFER))
@@ -209,10 +225,13 @@ GstPadProbeReturn GstProfiler::probeCb(GstPad *pad, GstPadProbeInfo *info, gpoin
     if (!buffer)
         return GST_PAD_PROBE_OK;
 
-    const auto id = self->m_profiler->record(probeCtx->stage, probeCtx->info);
+    if (!probeCtx->profiler)
+        return GST_PAD_PROBE_REMOVE;
+
+    const auto id = probeCtx->profiler->record(probeCtx->stage, probeCtx->info);
     if (id)
     {
-        self->m_profiler->log(id.value());
+        probeCtx->profiler->log(id.value());
     }
 
     return GST_PAD_PROBE_REMOVE;
@@ -242,18 +261,8 @@ std::optional<std::string> GstProfiler::checkElement(GstElement *element)
 
 const gchar *GstProfiler::getElementClass(GstElement *element)
 {
-    GstElementFactory *factory = m_gstWrapper->gstElementGetFactory(element);
-    if (factory)
-    {
-        return gst_element_factory_get_klass(factory);
-    }
-    else
-    {
-        return m_gstWrapper->gstElementClassGetMetadata(GST_ELEMENT_CLASS(G_OBJECT_GET_CLASS(element)),
-                                                        GST_ELEMENT_METADATA_KLASS);
-    }
-
-    return NULL;
+    return m_gstWrapper->gstElementClassGetMetadata(GST_ELEMENT_CLASS(G_OBJECT_GET_CLASS(element)),
+                                                    GST_ELEMENT_METADATA_KLASS);
 }
 
 std::string GstProfiler::classifyElementName(std::string name) const

--- a/media/server/gstplayer/source/GstProfiler.cpp
+++ b/media/server/gstplayer/source/GstProfiler.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "GstProfiler.h"
-#include "RialtoCommonLogging.h"
+#include "RialtoServerLogging.h"
 #include "Utils.h"
 
 #include <algorithm>
@@ -46,7 +46,7 @@ std::shared_ptr<IGstProfilerFactory> IGstProfilerFactory::getFactory()
         }
         catch (const std::exception &e)
         {
-            RIALTO_COMMON_LOG_ERROR("Failed to create the gst profiler factory, reason: %s", e.what());
+            RIALTO_SERVER_LOG_ERROR("Failed to create the gst profiler factory, reason: %s", e.what());
         }
 
         GstProfilerFactory::m_factory = factory;
@@ -74,38 +74,11 @@ inline constexpr std::string_view kModuleName{"GstProfiler"};
 using Clock = std::chrono::system_clock;
 using IProfiler = firebolt::rialto::common::IProfiler;
 
-struct ProbeCtx
-{
-    std::shared_ptr<IProfiler> profiler;
-    std::string stage;
-    std::string info;
-};
-
 GstPadProbeReturn probeCb(GstPad *pad, GstPadProbeInfo *info, gpointer userData)
 {
-    auto *probeCtx = static_cast<ProbeCtx *>(userData);
-
-    if (!(info->type & GST_PAD_PROBE_TYPE_BUFFER))
-        return GST_PAD_PROBE_OK;
-
-    if (!GST_PAD_PROBE_INFO_BUFFER(info))
-        return GST_PAD_PROBE_OK;
-
-    if (!probeCtx->profiler)
-        return GST_PAD_PROBE_REMOVE;
-
-    const auto id = probeCtx->profiler->record(probeCtx->stage, probeCtx->info);
-    if (id)
-    {
-        probeCtx->profiler->log(id.value());
-    }
-
-    return GST_PAD_PROBE_REMOVE;
-}
-
-void probeCtxDestroy(gpointer data)
-{
-    delete static_cast<ProbeCtx *>(data);
+    firebolt::rialto::server::IGstProfilerPrivate *self =
+        static_cast<firebolt::rialto::server::IGstProfilerPrivate *>(userData);
+    return self->handleProbeCb(pad, info);
 }
 
 std::optional<int64_t> diffMs(const std::optional<Clock::time_point> &end, const std::optional<Clock::time_point> &start)
@@ -144,13 +117,19 @@ GstProfiler::GstProfiler(GstElement *pipeline, const std::shared_ptr<firebolt::r
 
 GstProfiler::~GstProfiler()
 {
+    while (!m_probeCtxs.empty())
+    {
+        auto &probeCtx = m_probeCtxs.back();
+        if (probeCtx.id != 0)
+        {
+            m_gstWrapper->gstPadRemoveProbe(probeCtx.pad, probeCtx.id);
+        }
+        m_gstWrapper->gstObjectUnref(probeCtx.pad);
+        m_probeCtxs.pop_back();
+    }
+
     if (m_enabled && m_pipeline)
         m_gstWrapper->gstObjectUnref(m_pipeline);
-}
-
-bool GstProfiler::isEnabled() const
-{
-    return m_enabled;
 }
 
 std::optional<GstProfiler::RecordId> GstProfiler::createRecord(const std::string &stage)
@@ -210,23 +189,21 @@ void GstProfiler::scheduleGstElementRecord(GstElement *element)
             m_glibWrapper->gFree(rawName);
     }
 
-    auto *probeCtx = new ProbeCtx{m_profiler, stage.value(), std::move(elementInfo)};
-    const auto probeId =
-        m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &probeCb, probeCtx, &probeCtxDestroy);
+    const auto probeId = m_gstWrapper->gstPadAddProbe(pad, GST_PAD_PROBE_TYPE_BUFFER, &probeCb,
+                                                      static_cast<IGstProfilerPrivate *>(this), nullptr);
     if (probeId == 0)
     {
-        delete probeCtx;
+        m_gstWrapper->gstObjectUnref(pad);
+        return;
     }
 
-    m_gstWrapper->gstObjectUnref(pad);
+    m_probeCtxs.emplace_back(ProbeCtx{m_profiler, stage.value(), std::move(elementInfo), pad, probeId});
 }
 
-const std::vector<IGstProfiler::Record> &GstProfiler::getRecords() const
+std::vector<IGstProfiler::Record> GstProfiler::getRecords() const
 {
-    static const std::vector<Record> kEmptyRecords{};
-
     if (!m_profiler)
-        return kEmptyRecords;
+        return {};
 
     return m_profiler->getRecords();
 }
@@ -244,7 +221,10 @@ void GstProfiler::dumpToFile() const
     if (!m_enabled || !m_profiler)
         return;
 
-    (void)m_profiler->dumpToFile();
+    if (!m_profiler->dumpToFile())
+    {
+        RIALTO_SERVER_LOG_WARN("Failed to dump profiler records to file");
+    }
 }
 
 void GstProfiler::logPipelineSummary() const
@@ -255,7 +235,7 @@ void GstProfiler::logPipelineSummary() const
     const auto metrics = calculateMetrics();
     if (metrics)
     {
-        RIALTO_COMMON_LOG_MIL("PROFILER | TUNETIME: %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  "
+        RIALTO_SERVER_LOG_MIL("PROFILER | TUNETIME: %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  %lld,  "
                               "%lld,  %lld,  %lld,  %lld",
                               metrics->preparation ? static_cast<long long>(*metrics->preparation) : -1,     // NOLINT
                               metrics->videoDownload ? static_cast<long long>(*metrics->videoDownload) : -1, // NOLINT
@@ -271,6 +251,32 @@ void GstProfiler::logPipelineSummary() const
                               metrics->total ? static_cast<long long>(*metrics->total) : -1,             // NOLINT
                               metrics->totalWithoutApp ? static_cast<long long>(*metrics->totalWithoutApp) : -1); // NOLINT
     }
+}
+
+GstPadProbeReturn GstProfiler::handleProbeCb(GstPad *pad, GstPadProbeInfo *info)
+{
+    if (!(info->type & GST_PAD_PROBE_TYPE_BUFFER))
+        return GST_PAD_PROBE_OK;
+
+    if (!GST_PAD_PROBE_INFO_BUFFER(info))
+        return GST_PAD_PROBE_OK;
+
+    const auto probeCtx =
+        std::find_if(m_probeCtxs.begin(), m_probeCtxs.end(), [pad](const auto &ctx) { return ctx.pad == pad; });
+    if (probeCtx == m_probeCtxs.end())
+        return GST_PAD_PROBE_REMOVE;
+
+    if (probeCtx->profiler)
+    {
+        const auto id = probeCtx->profiler->record(probeCtx->stage, probeCtx->info);
+        if (id)
+        {
+            probeCtx->profiler->log(id.value());
+        }
+    }
+
+    removeProbeCtx(pad);
+    return GST_PAD_PROBE_REMOVE;
 }
 
 std::optional<std::string> GstProfiler::getFirstBufferExitStage(GstElement *element)
@@ -314,9 +320,20 @@ std::string GstProfiler::deriveElementInfoFromName(const std::string &name) cons
     return name;
 }
 
+void GstProfiler::removeProbeCtx(GstPad *pad)
+{
+    const auto probeCtx =
+        std::find_if(m_probeCtxs.begin(), m_probeCtxs.end(), [pad](const auto &ctx) { return ctx.pad == pad; });
+    if (probeCtx == m_probeCtxs.end())
+        return;
+
+    m_gstWrapper->gstObjectUnref(probeCtx->pad);
+    m_probeCtxs.erase(probeCtx);
+}
+
 std::optional<GstProfiler::PipelineMetrics> GstProfiler::calculateMetrics() const
 {
-    const auto &records = m_profiler->getRecords();
+    const auto records = m_profiler->getRecords();
 
     PipelineStageTimestamps timestamps;
 

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -102,6 +102,11 @@ void AttachSource::addSource() const
             m_glibWrapper->gObjectSet(m_context.pipeline, "text-sink", elem, nullptr);
         }
     }
+    if (appSrc)
+    {
+        m_context.m_gstProfiler->createRecord(std::string("Created AppSrc element -> ") + m_gstWrapper->gstElementGetName(appSrc));
+    }
+
     m_glibWrapper->gFree(capsStr);
 
     m_gstWrapper->gstAppSrcSetCaps(GST_APP_SRC(appSrc), caps);

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -77,22 +77,26 @@ void AttachSource::addSource() const
         RIALTO_SERVER_LOG_ERROR("Failed to create caps from media source");
         return;
     }
+    std::string profileriInfo;
     gchar *capsStr = m_gstWrapper->gstCapsToString(caps);
     GstElement *appSrc = nullptr;
     if (m_attachedSource->getType() == MediaSourceType::AUDIO)
     {
         RIALTO_SERVER_LOG_MIL("Adding Audio appsrc with caps %s", capsStr);
         appSrc = m_gstWrapper->gstElementFactoryMake("appsrc", "audsrc");
+        profileriInfo = "audsrc";
     }
     else if (m_attachedSource->getType() == MediaSourceType::VIDEO)
     {
         RIALTO_SERVER_LOG_MIL("Adding Video appsrc with caps %s", capsStr);
         appSrc = m_gstWrapper->gstElementFactoryMake("appsrc", "vidsrc");
+        profileriInfo = "vidsrc";
     }
     else if (m_attachedSource->getType() == MediaSourceType::SUBTITLE)
     {
         RIALTO_SERVER_LOG_MIL("Adding Subtitle appsrc with caps %s", capsStr);
         appSrc = m_gstWrapper->gstElementFactoryMake("appsrc", "subsrc");
+        profileriInfo = "subsrc";
 
         if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(m_context.pipeline), "text-sink"))
         {
@@ -104,8 +108,8 @@ void AttachSource::addSource() const
     }
     if (appSrc)
     {
-        auto recordId = m_context.gstProfiler->createRecord("Created AppSrc Element", m_gstWrapper->gstElementGetName(appSrc));
-        if(recordId)
+        auto recordId = m_context.gstProfiler->createRecord("Created AppSrc Element", std::move(profileriInfo));
+        if (recordId)
             m_context.gstProfiler->logRecord(recordId.value());
     }
 

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -104,7 +104,9 @@ void AttachSource::addSource() const
     }
     if (appSrc)
     {
-        m_context.m_gstProfiler->createRecord(std::string("Created AppSrc element -> ") + m_gstWrapper->gstElementGetName(appSrc));
+        auto recordId = m_context.m_gstProfiler->createRecord("Created AppSrc Element", m_gstWrapper->gstElementGetName(appSrc));
+        if(recordId)
+            m_context.m_gstProfiler->logRecord(recordId.value());
     }
 
     m_glibWrapper->gFree(capsStr);

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -104,9 +104,9 @@ void AttachSource::addSource() const
     }
     if (appSrc)
     {
-        auto recordId = m_context.m_gstProfiler->createRecord("Created AppSrc Element", m_gstWrapper->gstElementGetName(appSrc));
+        auto recordId = m_context.gstProfiler->createRecord("Created AppSrc Element", m_gstWrapper->gstElementGetName(appSrc));
         if(recordId)
-            m_context.m_gstProfiler->logRecord(recordId.value());
+            m_context.gstProfiler->logRecord(recordId.value());
     }
 
     m_glibWrapper->gFree(capsStr);

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -77,26 +77,26 @@ void AttachSource::addSource() const
         RIALTO_SERVER_LOG_ERROR("Failed to create caps from media source");
         return;
     }
-    std::string profileriInfo;
+    std::string profilerInfo;
     gchar *capsStr = m_gstWrapper->gstCapsToString(caps);
     GstElement *appSrc = nullptr;
     if (m_attachedSource->getType() == MediaSourceType::AUDIO)
     {
         RIALTO_SERVER_LOG_MIL("Adding Audio appsrc with caps %s", capsStr);
         appSrc = m_gstWrapper->gstElementFactoryMake("appsrc", "audsrc");
-        profileriInfo = "audsrc";
+        profilerInfo = "audsrc";
     }
     else if (m_attachedSource->getType() == MediaSourceType::VIDEO)
     {
         RIALTO_SERVER_LOG_MIL("Adding Video appsrc with caps %s", capsStr);
         appSrc = m_gstWrapper->gstElementFactoryMake("appsrc", "vidsrc");
-        profileriInfo = "vidsrc";
+        profilerInfo = "vidsrc";
     }
     else if (m_attachedSource->getType() == MediaSourceType::SUBTITLE)
     {
         RIALTO_SERVER_LOG_MIL("Adding Subtitle appsrc with caps %s", capsStr);
         appSrc = m_gstWrapper->gstElementFactoryMake("appsrc", "subsrc");
-        profileriInfo = "subsrc";
+        profilerInfo = "subsrc";
 
         if (m_glibWrapper->gObjectClassFindProperty(G_OBJECT_GET_CLASS(m_context.pipeline), "text-sink"))
         {
@@ -108,7 +108,7 @@ void AttachSource::addSource() const
     }
     if (appSrc)
     {
-        auto recordId = m_context.gstProfiler->createRecord("Created AppSrc Element", std::move(profileriInfo));
+        auto recordId = m_context.gstProfiler->createRecord("Created AppSrc Element", std::move(profilerInfo));
         if (recordId)
             m_context.gstProfiler->logRecord(recordId.value());
     }

--- a/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/AttachSource.cpp
@@ -108,7 +108,7 @@ void AttachSource::addSource() const
     }
     if (appSrc)
     {
-        auto recordId = m_context.gstProfiler->createRecord("Created AppSrc Element", std::move(profilerInfo));
+        auto recordId = m_context.gstProfiler->createRecord("Created AppSrc Element", profilerInfo);
         if (recordId)
             m_context.gstProfiler->logRecord(recordId.value());
     }

--- a/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
+++ b/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
@@ -56,7 +56,7 @@ DeepElementAdded::DeepElementAdded(GenericPlayerContext &context, IGstGenericPla
             }
         }
 
-        m_context.m_gstProfiler->scheduleGstElementRecord(m_element);
+        m_context.gstProfiler->scheduleGstElementRecord(m_element);
     }
 }
 

--- a/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
+++ b/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
@@ -55,6 +55,8 @@ DeepElementAdded::DeepElementAdded(GenericPlayerContext &context, IGstGenericPla
                 m_callbackRegistered = true;
             }
         }
+
+        m_context.m_gstProfiler->scheduleGstElementRecord(m_element);
     }
 }
 

--- a/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
+++ b/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
@@ -54,9 +54,9 @@ DeepElementAdded::DeepElementAdded(GenericPlayerContext &context, IGstGenericPla
                 m_glibWrapper->gSignalConnect(G_OBJECT(m_element), "have-type", G_CALLBACK(onHaveType), &m_player);
                 m_callbackRegistered = true;
             }
-        }
 
-        m_context.gstProfiler->scheduleGstElementRecord(m_element);
+            m_context.gstProfiler->scheduleGstElementRecord(m_element);
+        }
     }
 }
 

--- a/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
@@ -124,5 +124,6 @@ void FinishSetupSource::execute() const
     m_context.setupSourceFinished = true;
 
     RIALTO_SERVER_LOG_MIL("All sources attached.");
+    m_context.m_gstProfiler->createRecord("All Sources Attached");
 }
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
@@ -124,8 +124,8 @@ void FinishSetupSource::execute() const
     m_context.setupSourceFinished = true;
 
     RIALTO_SERVER_LOG_MIL("All sources attached.");
-    auto recordId = m_context.m_gstProfiler->createRecord("All Sources Attached");
+    auto recordId = m_context.gstProfiler->createRecord("All Sources Attached");
     if(recordId)
-        m_context.m_gstProfiler->logRecord(recordId.value());
+        m_context.gstProfiler->logRecord(recordId.value());
 }
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
@@ -124,6 +124,8 @@ void FinishSetupSource::execute() const
     m_context.setupSourceFinished = true;
 
     RIALTO_SERVER_LOG_MIL("All sources attached.");
-    m_context.m_gstProfiler->createRecord("All Sources Attached");
+    auto recordId = m_context.m_gstProfiler->createRecord("All Sources Attached");
+    if(recordId)
+        m_context.m_gstProfiler->logRecord(recordId.value());
 }
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
@@ -125,7 +125,7 @@ void FinishSetupSource::execute() const
 
     RIALTO_SERVER_LOG_MIL("All sources attached.");
     auto recordId = m_context.gstProfiler->createRecord("All Sources Attached");
-    if(recordId)
+    if (recordId)
         m_context.gstProfiler->logRecord(recordId.value());
 }
 } // namespace firebolt::rialto::server::tasks::generic

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -58,6 +58,7 @@ void HandleBusMessage::execute() const
                                   m_gstWrapper->gstElementStateGetName(oldState),
                                   m_gstWrapper->gstElementStateGetName(newState),
                                   m_gstWrapper->gstElementStateGetName(pending));
+            m_context.m_gstProfiler->createRecord(std::string("Pipeline State Changed -> ") + m_gstWrapper->gstElementStateGetName(newState));
 
             std::string filename = std::string(m_gstWrapper->gstElementStateGetName(oldState)) + "-" +
                                    std::string(m_gstWrapper->gstElementStateGetName(newState));

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -58,8 +58,9 @@ void HandleBusMessage::execute() const
                                   m_gstWrapper->gstElementStateGetName(oldState),
                                   m_gstWrapper->gstElementStateGetName(newState),
                                   m_gstWrapper->gstElementStateGetName(pending));
-            auto recordId = m_context.gstProfiler->createRecord("Pipeline State Changed", m_gstWrapper->gstElementStateGetName(newState));
-            if(recordId)
+            auto recordId = m_context.gstProfiler->createRecord("Pipeline State Changed",
+                                                                m_gstWrapper->gstElementStateGetName(newState));
+            if (recordId)
                 m_context.gstProfiler->logRecord(recordId.value());
 
             std::string filename = std::string(m_gstWrapper->gstElementStateGetName(oldState)) + "-" +

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -58,9 +58,9 @@ void HandleBusMessage::execute() const
                                   m_gstWrapper->gstElementStateGetName(oldState),
                                   m_gstWrapper->gstElementStateGetName(newState),
                                   m_gstWrapper->gstElementStateGetName(pending));
-            auto recordId = m_context.m_gstProfiler->createRecord("Pipeline State Changed", m_gstWrapper->gstElementStateGetName(newState));
+            auto recordId = m_context.gstProfiler->createRecord("Pipeline State Changed", m_gstWrapper->gstElementStateGetName(newState));
             if(recordId)
-                m_context.m_gstProfiler->logRecord(recordId.value());
+                m_context.gstProfiler->logRecord(recordId.value());
 
             std::string filename = std::string(m_gstWrapper->gstElementStateGetName(oldState)) + "-" +
                                    std::string(m_gstWrapper->gstElementStateGetName(newState));

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -58,7 +58,9 @@ void HandleBusMessage::execute() const
                                   m_gstWrapper->gstElementStateGetName(oldState),
                                   m_gstWrapper->gstElementStateGetName(newState),
                                   m_gstWrapper->gstElementStateGetName(pending));
-            m_context.m_gstProfiler->createRecord(std::string("Pipeline State Changed -> ") + m_gstWrapper->gstElementStateGetName(newState));
+            auto recordId = m_context.m_gstProfiler->createRecord("Pipeline State Changed", m_gstWrapper->gstElementStateGetName(newState));
+            if(recordId)
+                m_context.m_gstProfiler->logRecord(recordId.value());
 
             std::string filename = std::string(m_gstWrapper->gstElementStateGetName(oldState)) + "-" +
                                    std::string(m_gstWrapper->gstElementStateGetName(newState));

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -62,6 +62,8 @@ void HandleBusMessage::execute() const
                                                                 m_gstWrapper->gstElementStateGetName(newState));
             if (recordId)
                 m_context.gstProfiler->logRecord(recordId.value());
+            if(newState == GST_STATE_PLAYING)
+                m_context.gstProfiler->logPipeline();
 
             std::string filename = std::string(m_gstWrapper->gstElementStateGetName(oldState)) + "-" +
                                    std::string(m_gstWrapper->gstElementStateGetName(newState));

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -62,7 +62,7 @@ void HandleBusMessage::execute() const
                                                                 m_gstWrapper->gstElementStateGetName(newState));
             if (recordId)
                 m_context.gstProfiler->logRecord(recordId.value());
-            if(newState == GST_STATE_PLAYING)
+            if (newState == GST_STATE_PLAYING)
                 m_context.gstProfiler->logPipeline();
 
             std::string filename = std::string(m_gstWrapper->gstElementStateGetName(oldState)) + "-" +

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -54,19 +54,18 @@ void HandleBusMessage::execute() const
         {
             GstState oldState, newState, pending;
             m_gstWrapper->gstMessageParseStateChanged(m_message, &oldState, &newState, &pending);
-            RIALTO_SERVER_LOG_MIL("State changed (old: %s, new: %s, pending: %s)",
-                                  m_gstWrapper->gstElementStateGetName(oldState),
-                                  m_gstWrapper->gstElementStateGetName(newState),
-                                  m_gstWrapper->gstElementStateGetName(pending));
-            auto recordId = m_context.gstProfiler->createRecord("Pipeline State Changed",
-                                                                m_gstWrapper->gstElementStateGetName(newState));
+            const char *oldStateName = m_gstWrapper->gstElementStateGetName(oldState);
+            const char *newStateName = m_gstWrapper->gstElementStateGetName(newState);
+            const char *pendingStateName = m_gstWrapper->gstElementStateGetName(pending);
+            RIALTO_SERVER_LOG_MIL("State changed (old: %s, new: %s, pending: %s)", oldStateName, newStateName,
+                                  pendingStateName);
+            auto recordId = m_context.gstProfiler->createRecord("Pipeline State Changed", newStateName);
             if (recordId)
                 m_context.gstProfiler->logRecord(recordId.value());
             if (newState == GST_STATE_PLAYING)
                 m_context.gstProfiler->logPipeline();
 
-            std::string filename = std::string(m_gstWrapper->gstElementStateGetName(oldState)) + "-" +
-                                   std::string(m_gstWrapper->gstElementStateGetName(newState));
+            std::string filename = std::string(oldStateName) + "-" + std::string(newStateName);
             m_gstWrapper->gstDebugBinToDotFileWithTs(GST_BIN(m_context.pipeline), GST_DEBUG_GRAPH_SHOW_ALL,
                                                      filename.c_str());
             if (!m_gstPlayerClient)

--- a/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
+++ b/media/server/gstplayer/source/tasks/generic/HandleBusMessage.cpp
@@ -63,7 +63,7 @@ void HandleBusMessage::execute() const
             if (recordId)
                 m_context.gstProfiler->logRecord(recordId.value());
             if (newState == GST_STATE_PLAYING)
-                m_context.gstProfiler->logPipeline();
+                m_context.gstProfiler->logPipelineSummary();
 
             std::string filename = std::string(oldStateName) + "-" + std::string(newStateName);
             m_gstWrapper->gstDebugBinToDotFileWithTs(GST_BIN(m_context.pipeline), GST_DEBUG_GRAPH_SHOW_ALL,

--- a/scripts/gtest/build_and_run_tests.py
+++ b/scripts/gtest/build_and_run_tests.py
@@ -128,6 +128,9 @@ def runTests (suites, doListTests, gtestFilter, outputDir, resultsFile, xmlFile,
 
     for key in suites:
         executeCmd = []
+        cmdEnv = os.environ.copy()
+        cmdEnv.setdefault("PROFILER_ENABLED", "false")
+        cmdEnv.update(suites[key].get("env", {}))
 
         # Valgrind command must come before the test executable
         if valgrind == True:
@@ -147,9 +150,10 @@ def runTests (suites, doListTests, gtestFilter, outputDir, resultsFile, xmlFile,
 
         # Run the command
         if resultsFile != None:
-            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, stdout=resultsFile, stderr=subprocess.STDOUT)
+            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, env=cmdEnv, stdout=resultsFile,
+                            stderr=subprocess.STDOUT)
         else:
-            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, stderr=subprocess.STDOUT)
+            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, env=cmdEnv, stderr=subprocess.STDOUT)
 
         # Check for error code
         if status.returncode == getvalgrindErrorCode():

--- a/scripts/gtest/build_and_run_tests.py
+++ b/scripts/gtest/build_and_run_tests.py
@@ -73,8 +73,8 @@ def buildAndRunGTests(args, f, buildDefines, suitesToRun):
     os.environ["RIALTO_CONSOLE_LOG"] = "1"
     # Set env variable to enable debug prints
     os.environ["RIALTO_DEBUG"] = "5"
-    # Disable profiler by default. Suites can override this via their env settings.
-    os.environ["PROFILER_ENABLED"] = "false"
+    # Enable profiler for all test suites.
+    os.environ["PROFILER_ENABLED"] = "true"
 
     # Clean if required
     if args['clean'] == True:
@@ -130,8 +130,6 @@ def runTests (suites, doListTests, gtestFilter, outputDir, resultsFile, xmlFile,
 
     for key in suites:
         executeCmd = []
-        cmdEnv = os.environ.copy()
-        cmdEnv.update(suites[key].get("env", {}))
 
         # Valgrind command must come before the test executable
         if valgrind == True:
@@ -151,10 +149,10 @@ def runTests (suites, doListTests, gtestFilter, outputDir, resultsFile, xmlFile,
 
         # Run the command
         if resultsFile != None:
-            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, env=cmdEnv, stdout=resultsFile,
+            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, stdout=resultsFile,
                             stderr=subprocess.STDOUT)
         else:
-            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, env=cmdEnv, stderr=subprocess.STDOUT)
+            status = runcmd(executeCmd, cwd=os.getcwd() + '/' + outputDir, stderr=subprocess.STDOUT)
 
         # Check for error code
         if status.returncode == getvalgrindErrorCode():

--- a/scripts/gtest/build_and_run_tests.py
+++ b/scripts/gtest/build_and_run_tests.py
@@ -129,7 +129,7 @@ def runTests (suites, doListTests, gtestFilter, outputDir, resultsFile, xmlFile,
     for key in suites:
         executeCmd = []
         cmdEnv = os.environ.copy()
-        cmdEnv.setdefault("PROFILER_ENABLED", "false")
+        cmdEnv["PROFILER_ENABLED"] = "false"
         cmdEnv.update(suites[key].get("env", {}))
 
         # Valgrind command must come before the test executable

--- a/scripts/gtest/build_and_run_tests.py
+++ b/scripts/gtest/build_and_run_tests.py
@@ -73,6 +73,8 @@ def buildAndRunGTests(args, f, buildDefines, suitesToRun):
     os.environ["RIALTO_CONSOLE_LOG"] = "1"
     # Set env variable to enable debug prints
     os.environ["RIALTO_DEBUG"] = "5"
+    # Disable profiler by default. Suites can override this via their env settings.
+    os.environ["PROFILER_ENABLED"] = "false"
 
     # Clean if required
     if args['clean'] == True:
@@ -129,7 +131,6 @@ def runTests (suites, doListTests, gtestFilter, outputDir, resultsFile, xmlFile,
     for key in suites:
         executeCmd = []
         cmdEnv = os.environ.copy()
-        cmdEnv["PROFILER_ENABLED"] = "false"
         cmdEnv.update(suites[key].get("env", {}))
 
         # Valgrind command must come before the test executable

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -228,6 +228,10 @@ public:
     MOCK_METHOD(GstPadLinkReturn, gstPadLink, (GstPad * srcpad, GstPad *sinkpad), (override));
     MOCK_METHOD(gboolean, gstBinRemove, (GstBin * bin, GstElement *element), (override));
     MOCK_METHOD(GstObject *, gstPadGetParent, (GstPad * pad), (override));
+    MOCK_METHOD(gulong, gstPadAddProbe,
+                (GstPad * pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
+                 GDestroyNotify destroyData),
+                (override));
 
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -232,6 +232,7 @@ public:
                 (GstPad * pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
                  GDestroyNotify destroyData),
                 (override));
+    MOCK_METHOD(void, gstPadRemoveProbe, (GstPad * pad, gulong id), (override));
 
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {

--- a/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
+++ b/tests/componenttests/server/fixtures/MediaPipelineTest.cpp
@@ -35,6 +35,7 @@
 
 using testing::_;
 using testing::AtLeast;
+using testing::AtMost;
 using testing::DoAll;
 using testing::Invoke;
 using testing::Return;
@@ -92,6 +93,7 @@ void MediaPipelineTest::gstPlayerWillBeCreated()
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_playsink));
     EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&m_pipeline, GST_STATE_READY))
         .WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&m_pipeline)).Times(AtMost(1));
 
     // In case of longer testruns, GstPlayer may request to query position and volume
     EXPECT_CALL(*m_gstWrapperMock, gstStateLock(_)).Times(AtLeast(0));
@@ -129,7 +131,7 @@ void MediaPipelineTest::gstPlayerWillBeDestructed()
     EXPECT_CALL(*m_gstWrapperMock, gstPipelineGetBus(GST_PIPELINE(&m_pipeline))).WillOnce(Return(&m_bus));
     EXPECT_CALL(*m_gstWrapperMock, gstBusSetSyncHandler(&m_bus, nullptr, nullptr, nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_bus));
-    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pipeline));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pipeline)).Times(testing::Between(1, 2));
 }
 
 void MediaPipelineTest::audioSourceWillBeAttached()

--- a/tests/componenttests/server/tests/mediaPipeline/DualVideoPlaybackTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/DualVideoPlaybackTest.cpp
@@ -42,6 +42,7 @@ const std::string kDummyStateName{"dummy"};
 
 using testing::_;
 using testing::AtLeast;
+using testing::AtMost;
 using testing::DoAll;
 using testing::Invoke;
 using testing::Return;
@@ -98,6 +99,7 @@ public:
         EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_secondaryPlaysink));
         EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&m_secondaryPipeline, GST_STATE_READY))
             .WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+        EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&m_secondaryPipeline)).Times(AtMost(1));
 
         // In case of longer testruns, GstPlayer may request to query position
         EXPECT_CALL(*m_gstWrapperMock, gstElementQueryPosition(&m_secondaryPipeline, GST_FORMAT_TIME, _))
@@ -279,7 +281,7 @@ public:
             .WillOnce(Return(&m_secondaryBus));
         EXPECT_CALL(*m_gstWrapperMock, gstBusSetSyncHandler(&m_secondaryBus, nullptr, nullptr, nullptr));
         EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_secondaryBus));
-        EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_secondaryPipeline));
+        EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_secondaryPipeline)).Times(testing::Between(1, 2));
     }
 
     void createSecondaryFullSession()

--- a/tests/unittests/common/mocks/ProfilerFactoryMock.h
+++ b/tests/unittests/common/mocks/ProfilerFactoryMock.h
@@ -1,0 +1,16 @@
+#include "IProfiler.h"
+#include <gmock/gmock.h>
+#include <memory>
+#include <string>
+
+namespace firebolt::rialto::common
+{
+class ProfilerFactoryMock : public IProfilerFactory
+{
+public:
+    ProfilerFactoryMock() = default;
+    virtual ~ProfilerFactoryMock() = default;
+
+    MOCK_METHOD(std::unique_ptr<IProfiler>, createProfiler, (std::string moduleName), (const, override));
+};
+} // namespace firebolt::rialto::common

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -1,0 +1,26 @@
+#include "IProfiler.h"
+#include <gmock/gmock.h>
+#include <optional>
+#include <string>
+
+namespace firebolt::rialto::common
+{
+class ProfilerMock : public IProfiler
+{
+public:
+    ProfilerMock() = default;
+    virtual ~ProfilerMock() = default;
+
+    MOCK_METHOD(bool, enabled, (), (const, noexcept, override));
+
+    MOCK_METHOD(std::optional<RecordId>, record, (std::string stage), (override));
+    MOCK_METHOD(std::optional<RecordId>, record, (std::string stage, std::string info), (override));
+
+    MOCK_METHOD(std::optional<RecordId>, find, (std::string stage), (override));
+    MOCK_METHOD(std::optional<RecordId>, find, (std::string stage, std::string info), (override));
+
+    MOCK_METHOD(void, log, (RecordId id), (override));
+
+    MOCK_METHOD(bool, dump, (const std::string &path), (const, override));
+};
+} // namespace firebolt::rialto::common

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -1,3 +1,25 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBOLT_RIALTO_COMMON_PROFILER_MOCK_H_
+#define FIREBOLT_RIALTO_COMMON_PROFILER_MOCK_H_
+
 #include "IProfiler.h"
 #include <gmock/gmock.h>
 #include <optional>
@@ -24,3 +46,5 @@ public:
     MOCK_METHOD(bool, dump, (const std::string &path), (const, override));
 };
 } // namespace firebolt::rialto::common
+
+#endif // FIREBOLT_RIALTO_COMMON_PROFILER_MOCK_H_

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -40,9 +40,6 @@ public:
     MOCK_METHOD(std::optional<RecordId>, record, (std::string stage), (override));
     MOCK_METHOD(std::optional<RecordId>, record, (std::string stage, std::string info), (override));
 
-    MOCK_METHOD(std::optional<RecordId>, find, (std::string stage), (override));
-    MOCK_METHOD(std::optional<RecordId>, find, (std::string stage, std::string info), (override));
-
     MOCK_METHOD(void, log, (RecordId id), (override));
 
     MOCK_METHOD(bool, dump, (const std::string &path), (const, override));

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -21,9 +21,11 @@
 #define FIREBOLT_RIALTO_COMMON_PROFILER_MOCK_H_
 
 #include "IProfiler.h"
+
 #include <gmock/gmock.h>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace firebolt::rialto::common
 {
@@ -31,9 +33,12 @@ class ProfilerMock : public IProfiler
 {
 public:
     ProfilerMock() = default;
-    virtual ~ProfilerMock() = default;
+    ~ProfilerMock() override = default;
 
-    MOCK_METHOD(bool, enabled, (), (const, noexcept, override));
+    MOCK_METHOD(void, enable, (), (noexcept, override));
+    MOCK_METHOD(void, disable, (), (noexcept, override));
+
+    MOCK_METHOD(bool, isEnabled, (), (const, noexcept, override));
 
     MOCK_METHOD(std::optional<RecordId>, record, (std::string stage), (override));
     MOCK_METHOD(std::optional<RecordId>, record, (std::string stage, std::string info), (override));
@@ -44,6 +49,8 @@ public:
     MOCK_METHOD(void, log, (RecordId id), (override));
 
     MOCK_METHOD(bool, dump, (const std::string &path), (const, override));
+
+    MOCK_METHOD(const std::vector<Record> &, getRecords, (), (const, override));
 };
 } // namespace firebolt::rialto::common
 

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -42,7 +42,7 @@ public:
 
     MOCK_METHOD(void, log, (RecordId id), (override));
 
-    MOCK_METHOD(bool, dump, (const std::string &path), (const, override));
+    MOCK_METHOD(bool, dumpToFile, (), (const, override));
 
     MOCK_METHOD(const std::vector<Record> &, getRecords, (), (const, override));
 };

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -35,9 +35,6 @@ public:
     ProfilerMock() = default;
     ~ProfilerMock() override = default;
 
-    MOCK_METHOD(void, enable, (), (noexcept, override));
-    MOCK_METHOD(void, disable, (), (noexcept, override));
-
     MOCK_METHOD(bool, isEnabled, (), (const, noexcept, override));
 
     MOCK_METHOD(std::optional<RecordId>, record, (std::string stage), (override));

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -44,7 +44,7 @@ public:
 
     MOCK_METHOD(bool, dumpToFile, (), (const, override));
 
-    MOCK_METHOD(const std::vector<Record> &, getRecords, (), (const, override));
+    MOCK_METHOD(std::vector<Record>, getRecords, (), (const, override));
 };
 } // namespace firebolt::rialto::common
 

--- a/tests/unittests/common/mocks/ProfilerMock.h
+++ b/tests/unittests/common/mocks/ProfilerMock.h
@@ -37,8 +37,8 @@ public:
 
     MOCK_METHOD(bool, isEnabled, (), (const, noexcept, override));
 
-    MOCK_METHOD(std::optional<RecordId>, record, (std::string stage), (override));
-    MOCK_METHOD(std::optional<RecordId>, record, (std::string stage, std::string info), (override));
+    MOCK_METHOD(std::optional<RecordId>, record, (const std::string &stage), (override));
+    MOCK_METHOD(std::optional<RecordId>, record, (const std::string &stage, const std::string &info), (override));
 
     MOCK_METHOD(void, log, (RecordId id), (override));
 

--- a/tests/unittests/common/unittests/CMakeLists.txt
+++ b/tests/unittests/common/unittests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_gtests (
         # gtest code
         TimerTests.cpp
         EventThreadTests.cpp
+        ProfilerTests.cpp
         )
 
 target_include_directories(

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -1,7 +1,27 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "IProfiler.h"
 
-#include <gtest/gtest.h>
 #include <fstream>
+#include <gtest/gtest.h>
+#include <random>
 #include <string>
 
 using namespace firebolt::rialto::common;
@@ -55,7 +75,8 @@ TEST_F(ProfilerTests, DumpCreatesFile)
 
     (void)profiler->record("StageDump", "InfoDump");
 
-    const std::string path = "/tmp/rialto_profiler_ut_dump.txt";
+    const auto suffix = std::to_string(std::random_device{}());
+    const std::string path = std::string{"/tmp/rialto_profiler_ut_dump_"} + suffix + ".txt";
     ASSERT_TRUE(profiler->dump(path));
 
     std::ifstream in(path);

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -1,0 +1,67 @@
+#include "IProfiler.h"
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include <string>
+
+using namespace firebolt::rialto::common;
+
+class ProfilerTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        factory = IProfilerFactory::createFactory();
+        ASSERT_TRUE(factory);
+
+        profiler = factory->createProfiler("UnitTestModule");
+        ASSERT_TRUE(profiler);
+    }
+
+    std::shared_ptr<IProfilerFactory> factory;
+    std::unique_ptr<IProfiler> profiler;
+};
+
+TEST_F(ProfilerTests, RecordAndFindByStage)
+{
+    if (!profiler->enabled())
+        GTEST_SKIP() << "Profiler disabled in current configuration";
+
+    auto id = profiler->record("Stage1");
+    ASSERT_TRUE(id.has_value());
+
+    auto found = profiler->find("Stage1");
+    ASSERT_TRUE(found.has_value());
+
+    EXPECT_EQ(found.value(), id.value());
+}
+
+TEST_F(ProfilerTests, RecordAndFindByStageAndInfo)
+{
+    if (!profiler->enabled())
+        GTEST_SKIP() << "Profiler disabled in current configuration";
+
+    auto id = profiler->record("Stage1", "InfoA");
+    ASSERT_TRUE(id.has_value());
+
+    EXPECT_TRUE(profiler->find("Stage1", "InfoA").has_value());
+    EXPECT_FALSE(profiler->find("Stage1", "InfoB").has_value());
+}
+
+TEST_F(ProfilerTests, DumpCreatesFile)
+{
+    if (!profiler->enabled())
+        GTEST_SKIP() << "Profiler disabled in current configuration";
+
+    (void)profiler->record("StageDump", "InfoDump");
+
+    const std::string path = "/tmp/rialto_profiler_ut_dump.txt";
+    ASSERT_TRUE(profiler->dump(path));
+
+    std::ifstream in(path);
+    ASSERT_TRUE(in.good());
+
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_FALSE(content.empty());
+    EXPECT_NE(content.find("StageDump"), std::string::npos);
+}

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -36,6 +36,9 @@ protected:
 
         profiler = factory->createProfiler("UnitTestModule");
         ASSERT_TRUE(profiler);
+
+        profiler->enable();
+        ASSERT_TRUE(profiler->isEnabled());
     }
 
     std::shared_ptr<IProfilerFactory> factory;
@@ -44,13 +47,10 @@ protected:
 
 TEST_F(ProfilerTests, RecordAndFindByStage)
 {
-    if (!profiler->enabled())
-        GTEST_SKIP() << "Profiler disabled in current configuration";
-
-    auto id = profiler->record("Stage1");
+    const auto id = profiler->record("Stage1");
     ASSERT_TRUE(id.has_value());
 
-    auto found = profiler->find("Stage1");
+    const auto found = profiler->find("Stage1");
     ASSERT_TRUE(found.has_value());
 
     EXPECT_EQ(found.value(), id.value());
@@ -58,31 +58,53 @@ TEST_F(ProfilerTests, RecordAndFindByStage)
 
 TEST_F(ProfilerTests, RecordAndFindByStageAndInfo)
 {
-    if (!profiler->enabled())
-        GTEST_SKIP() << "Profiler disabled in current configuration";
-
-    auto id = profiler->record("Stage1", "InfoA");
+    const auto id = profiler->record("Stage1", "InfoA");
     ASSERT_TRUE(id.has_value());
 
-    EXPECT_TRUE(profiler->find("Stage1", "InfoA").has_value());
+    const auto found = profiler->find("Stage1", "InfoA");
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(found.value(), id.value());
+
     EXPECT_FALSE(profiler->find("Stage1", "InfoB").has_value());
+}
+
+TEST_F(ProfilerTests, GetRecordsReturnsRecordedEntries)
+{
+    const auto id1 = profiler->record("Stage1");
+    ASSERT_TRUE(id1.has_value());
+
+    const auto id2 = profiler->record("Stage2", "Info2");
+    ASSERT_TRUE(id2.has_value());
+
+    const auto &records = profiler->getRecords();
+    ASSERT_GE(records.size(), 2U);
+
+    const auto &record1 = records[records.size() - 2];
+    EXPECT_EQ(record1.module, "UnitTestModule");
+    EXPECT_EQ(record1.id, id1.value());
+    EXPECT_EQ(record1.stage, "Stage1");
+    EXPECT_TRUE(record1.info.empty());
+
+    const auto &record2 = records[records.size() - 1];
+    EXPECT_EQ(record2.module, "UnitTestModule");
+    EXPECT_EQ(record2.id, id2.value());
+    EXPECT_EQ(record2.stage, "Stage2");
+    EXPECT_EQ(record2.info, "Info2");
 }
 
 TEST_F(ProfilerTests, DumpCreatesFile)
 {
-    if (!profiler->enabled())
-        GTEST_SKIP() << "Profiler disabled in current configuration";
-
     (void)profiler->record("StageDump", "InfoDump");
 
     const auto suffix = std::to_string(std::random_device{}());
     const std::string path = std::string{"/tmp/rialto_profiler_ut_dump_"} + suffix + ".txt";
+
     ASSERT_TRUE(profiler->dump(path));
 
     std::ifstream in(path);
     ASSERT_TRUE(in.good());
 
-    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     EXPECT_FALSE(content.empty());
     EXPECT_NE(content.find("StageDump"), std::string::npos);
 }

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -19,6 +19,7 @@
 
 #include "IProfiler.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -27,6 +28,18 @@
 #include <string>
 
 using namespace firebolt::rialto::common;
+
+namespace
+{
+const IProfiler::Record *findRecord(const std::vector<IProfiler::Record> &records, const std::string &stage,
+                                    const std::optional<std::string> &info = std::nullopt)
+{
+    const auto it = std::find_if(records.begin(), records.end(), [&](const auto &record)
+                                 { return record.stage == stage && (!info.has_value() || record.info == info.value()); });
+
+    return it != records.end() ? &(*it) : nullptr;
+}
+} // namespace
 
 class ProfilerTests : public ::testing::Test
 {
@@ -65,10 +78,10 @@ TEST_F(ProfilerTests, RecordAndFindByStage)
     const auto id = profiler->record("Stage1");
     ASSERT_TRUE(id.has_value());
 
-    const auto found = profiler->find("Stage1");
-    ASSERT_TRUE(found.has_value());
+    const auto *found = findRecord(profiler->getRecords(), "Stage1");
+    ASSERT_NE(found, nullptr);
 
-    EXPECT_EQ(found.value(), id.value());
+    EXPECT_EQ(found->id, id.value());
 }
 
 TEST_F(ProfilerTests, RecordAndFindByStageAndInfo)
@@ -76,11 +89,11 @@ TEST_F(ProfilerTests, RecordAndFindByStageAndInfo)
     const auto id = profiler->record("Stage1", "InfoA");
     ASSERT_TRUE(id.has_value());
 
-    const auto found = profiler->find("Stage1", "InfoA");
-    ASSERT_TRUE(found.has_value());
-    EXPECT_EQ(found.value(), id.value());
+    const auto *found = findRecord(profiler->getRecords(), "Stage1", "InfoA");
+    ASSERT_NE(found, nullptr);
+    EXPECT_EQ(found->id, id.value());
 
-    EXPECT_FALSE(profiler->find("Stage1", "InfoB").has_value());
+    EXPECT_EQ(findRecord(profiler->getRecords(), "Stage1", "InfoB"), nullptr);
 }
 
 TEST_F(ProfilerTests, GetRecordsReturnsRecordedEntries)
@@ -156,11 +169,11 @@ TEST_F(ProfilerTests, StartsDisabledWhenEnvFalse)
     EXPECT_FALSE(envProfiler->isEnabled());
 }
 
-TEST_F(ProfilerTests, FindByStageReturnsNulloptWhenMissing)
+TEST_F(ProfilerTests, GetRecordsDoesNotContainMissingStage)
 {
     ASSERT_TRUE(profiler->record("Stage1").has_value());
 
-    EXPECT_EQ(profiler->find("MissingStage"), std::nullopt);
+    EXPECT_EQ(findRecord(profiler->getRecords(), "MissingStage"), nullptr);
 }
 
 TEST_F(ProfilerTests, DumpReturnsFalseForInvalidPath)

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -46,11 +46,8 @@ class ProfilerTests : public ::testing::Test
 protected:
     void SetUp() override
     {
-        const char *envValue = std::getenv("PROFILER_ENABLED");
-        if (envValue)
-            m_originalProfilerEnabled = envValue;
-        else
-            m_originalProfilerEnabled = std::nullopt;
+        saveEnv("PROFILER_ENABLED", m_originalProfilerEnabled);
+        saveEnv("PROFILER_DUMP_FILE_NAME", m_originalProfilerDumpFileName);
 
         factory = IProfilerFactory::createFactory();
         ASSERT_TRUE(factory);
@@ -62,15 +59,31 @@ protected:
 
     void TearDown() override
     {
-        if (m_originalProfilerEnabled)
-            setenv("PROFILER_ENABLED", m_originalProfilerEnabled->c_str(), 1);
+        restoreEnv("PROFILER_ENABLED", m_originalProfilerEnabled);
+        restoreEnv("PROFILER_DUMP_FILE_NAME", m_originalProfilerDumpFileName);
+    }
+
+    static void saveEnv(const char *name, std::optional<std::string> &value)
+    {
+        const char *envValue = std::getenv(name);
+        if (envValue)
+            value = envValue;
         else
-            unsetenv("PROFILER_ENABLED");
+            value = std::nullopt;
+    }
+
+    static void restoreEnv(const char *name, const std::optional<std::string> &value)
+    {
+        if (value)
+            setenv(name, value->c_str(), 1);
+        else
+            unsetenv(name);
     }
 
     std::shared_ptr<IProfilerFactory> factory;
     std::unique_ptr<IProfiler> profiler;
     std::optional<std::string> m_originalProfilerEnabled;
+    std::optional<std::string> m_originalProfilerDumpFileName;
 };
 
 TEST_F(ProfilerTests, RecordAndFindByStage)
@@ -123,11 +136,14 @@ TEST_F(ProfilerTests, GetRecordsReturnsRecordedEntries)
 TEST_F(ProfilerTests, DumpCreatesFile)
 {
     (void)profiler->record("StageDump", "InfoDump");
-
     const auto suffix = std::to_string(std::random_device{}());
     const std::string path = std::string{"/tmp/rialto_profiler_ut_dump_"} + suffix + ".txt";
+    setenv("PROFILER_DUMP_FILE_NAME", path.c_str(), 1);
 
-    ASSERT_TRUE(profiler->dump(path));
+    auto dumpProfiler = factory->createProfiler("UnitTestModule");
+    ASSERT_TRUE(dumpProfiler);
+    ASSERT_TRUE(dumpProfiler->record("StageDump", "InfoDump").has_value());
+    ASSERT_TRUE(dumpProfiler->dumpToFile());
 
     std::ifstream in(path);
     ASSERT_TRUE(in.good());
@@ -135,6 +151,56 @@ TEST_F(ProfilerTests, DumpCreatesFile)
     const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     EXPECT_FALSE(content.empty());
     EXPECT_NE(content.find("StageDump"), std::string::npos);
+
+    std::remove(path.c_str());
+}
+
+TEST_F(ProfilerTests, DumpAppendsToExistingFile)
+{
+    const auto suffix = std::to_string(std::random_device{}());
+    const std::string path = std::string{"/tmp/rialto_profiler_ut_append_"} + suffix + ".txt";
+    setenv("PROFILER_DUMP_FILE_NAME", path.c_str(), 1);
+
+    auto dumpProfiler = factory->createProfiler("UnitTestModule");
+    ASSERT_TRUE(dumpProfiler);
+    ASSERT_TRUE(dumpProfiler->record("Stage1").has_value());
+    ASSERT_TRUE(dumpProfiler->dumpToFile());
+
+    ASSERT_TRUE(dumpProfiler->record("Stage2").has_value());
+    ASSERT_TRUE(dumpProfiler->dumpToFile());
+
+    std::ifstream in(path);
+    ASSERT_TRUE(in.good());
+
+    const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("Stage1"), std::string::npos);
+    EXPECT_NE(content.find("Stage2"), std::string::npos);
+    EXPECT_LT(content.find("Stage1"), content.rfind("Stage2"));
+
+    std::remove(path.c_str());
+}
+
+TEST_F(ProfilerTests, DumpToFileUsesCachedEnvValue)
+{
+    const auto suffix = std::to_string(std::random_device{}());
+    const std::string path = std::string{"/tmp/rialto_profiler_ut_configured_"} + suffix + ".txt";
+    setenv("PROFILER_DUMP_FILE_NAME", path.c_str(), 1);
+
+    auto configuredProfiler = factory->createProfiler("UnitTestModule");
+    ASSERT_TRUE(configuredProfiler);
+    ASSERT_TRUE(configuredProfiler->record("StageConfigured").has_value());
+    ASSERT_TRUE(configuredProfiler->dumpToFile());
+
+    unsetenv("PROFILER_DUMP_FILE_NAME");
+    ASSERT_TRUE(configuredProfiler->record("StageConfiguredCached").has_value());
+    ASSERT_TRUE(configuredProfiler->dumpToFile());
+
+    std::ifstream in(path);
+    ASSERT_TRUE(in.good());
+
+    const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("StageConfigured"), std::string::npos);
+    EXPECT_NE(content.find("StageConfiguredCached"), std::string::npos);
 
     std::remove(path.c_str());
 }
@@ -176,7 +242,15 @@ TEST_F(ProfilerTests, GetRecordsDoesNotContainMissingStage)
     EXPECT_EQ(findRecord(profiler->getRecords(), "MissingStage"), nullptr);
 }
 
-TEST_F(ProfilerTests, DumpReturnsFalseForInvalidPath)
+TEST_F(ProfilerTests, DumpToFileReturnsFalseForInvalidPath)
 {
-    EXPECT_FALSE(profiler->dump("/proc/rialto_profiler_ut_dump.txt"));
+    setenv("PROFILER_DUMP_FILE_NAME", "/proc/rialto_profiler_ut_dump.txt", 1);
+    auto dumpProfiler = factory->createProfiler("UnitTestModule");
+    ASSERT_TRUE(dumpProfiler);
+    EXPECT_FALSE(dumpProfiler->dumpToFile());
+}
+
+TEST_F(ProfilerTests, DumpToFileSucceedsWhenEnvMissing)
+{
+    EXPECT_TRUE(profiler->dumpToFile());
 }

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -19,8 +19,10 @@
 
 #include "IProfiler.h"
 
+#include <cstdlib>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <optional>
 #include <random>
 #include <string>
 
@@ -31,6 +33,12 @@ class ProfilerTests : public ::testing::Test
 protected:
     void SetUp() override
     {
+        const char *envValue = std::getenv("PROFILER_ENABLED");
+        if (envValue)
+            m_originalProfilerEnabled = envValue;
+        else
+            m_originalProfilerEnabled = std::nullopt;
+
         factory = IProfilerFactory::createFactory();
         ASSERT_TRUE(factory);
 
@@ -41,8 +49,17 @@ protected:
         ASSERT_TRUE(profiler->isEnabled());
     }
 
+    void TearDown() override
+    {
+        if (m_originalProfilerEnabled)
+            setenv("PROFILER_ENABLED", m_originalProfilerEnabled->c_str(), 1);
+        else
+            unsetenv("PROFILER_ENABLED");
+    }
+
     std::shared_ptr<IProfilerFactory> factory;
     std::unique_ptr<IProfiler> profiler;
+    std::optional<std::string> m_originalProfilerEnabled;
 };
 
 TEST_F(ProfilerTests, RecordAndFindByStage)
@@ -107,4 +124,38 @@ TEST_F(ProfilerTests, DumpCreatesFile)
     const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     EXPECT_FALSE(content.empty());
     EXPECT_NE(content.find("StageDump"), std::string::npos);
+
+    std::remove(path.c_str());
+}
+
+TEST_F(ProfilerTests, StartsEnabledWhenEnvTrue)
+{
+    setenv("PROFILER_ENABLED", "true", 1);
+
+    auto envProfiler = factory->createProfiler("UnitTestModule");
+
+    ASSERT_TRUE(envProfiler);
+    EXPECT_TRUE(envProfiler->isEnabled());
+}
+
+TEST_F(ProfilerTests, StartsDisabledWhenEnvValueInvalid)
+{
+    setenv("PROFILER_ENABLED", "definitely-not-a-bool", 1);
+
+    auto envProfiler = factory->createProfiler("UnitTestModule");
+
+    ASSERT_TRUE(envProfiler);
+    EXPECT_FALSE(envProfiler->isEnabled());
+}
+
+TEST_F(ProfilerTests, FindByStageReturnsNulloptWhenMissing)
+{
+    ASSERT_TRUE(profiler->record("Stage1").has_value());
+
+    EXPECT_EQ(profiler->find("MissingStage"), std::nullopt);
+}
+
+TEST_F(ProfilerTests, DumpReturnsFalseForInvalidPath)
+{
+    EXPECT_FALSE(profiler->dump("/proc/rialto_profiler_ut_dump.txt"));
 }

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -44,8 +44,6 @@ protected:
 
         profiler = factory->createProfiler("UnitTestModule");
         ASSERT_TRUE(profiler);
-
-        profiler->enable();
         ASSERT_TRUE(profiler->isEnabled());
     }
 
@@ -141,6 +139,16 @@ TEST_F(ProfilerTests, StartsEnabledWhenEnvTrue)
 TEST_F(ProfilerTests, StartsDisabledWhenEnvValueInvalid)
 {
     setenv("PROFILER_ENABLED", "definitely-not-a-bool", 1);
+
+    auto envProfiler = factory->createProfiler("UnitTestModule");
+
+    ASSERT_TRUE(envProfiler);
+    EXPECT_FALSE(envProfiler->isEnabled());
+}
+
+TEST_F(ProfilerTests, StartsDisabledWhenEnvFalse)
+{
+    setenv("PROFILER_ENABLED", "false", 1);
 
     auto envProfiler = factory->createProfiler("UnitTestModule");
 

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -48,6 +48,7 @@ protected:
     {
         saveEnv("PROFILER_ENABLED", m_originalProfilerEnabled);
         saveEnv("PROFILER_DUMP_FILE_NAME", m_originalProfilerDumpFileName);
+        setenv("PROFILER_ENABLED", "true", 1);
 
         factory = IProfilerFactory::createFactory();
         ASSERT_TRUE(factory);

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -31,13 +31,17 @@ using namespace firebolt::rialto::common;
 
 namespace
 {
-const IProfiler::Record *findRecord(const std::vector<IProfiler::Record> &records, const std::string &stage,
-                                    const std::optional<std::string> &info = std::nullopt)
+std::optional<IProfiler::Record> findRecord(const std::vector<IProfiler::Record> &records, const std::string &stage,
+                                            const std::optional<std::string> &info = std::nullopt)
 {
     const auto it = std::find_if(records.begin(), records.end(), [&](const auto &record)
                                  { return record.stage == stage && (!info.has_value() || record.info == info.value()); });
 
-    return it != records.end() ? &(*it) : nullptr;
+    if (it != records.end())
+    {
+        return *it;
+    }
+    return std::nullopt;
 }
 } // namespace
 
@@ -92,8 +96,8 @@ TEST_F(ProfilerTests, RecordAndFindByStage)
     const auto id = profiler->record("Stage1");
     ASSERT_TRUE(id.has_value());
 
-    const auto *found = findRecord(profiler->getRecords(), "Stage1");
-    ASSERT_NE(found, nullptr);
+    const auto found = findRecord(profiler->getRecords(), "Stage1");
+    ASSERT_TRUE(found.has_value());
 
     EXPECT_EQ(found->id, id.value());
 }
@@ -103,11 +107,11 @@ TEST_F(ProfilerTests, RecordAndFindByStageAndInfo)
     const auto id = profiler->record("Stage1", "InfoA");
     ASSERT_TRUE(id.has_value());
 
-    const auto *found = findRecord(profiler->getRecords(), "Stage1", "InfoA");
-    ASSERT_NE(found, nullptr);
+    const auto found = findRecord(profiler->getRecords(), "Stage1", "InfoA");
+    ASSERT_TRUE(found.has_value());
     EXPECT_EQ(found->id, id.value());
 
-    EXPECT_EQ(findRecord(profiler->getRecords(), "Stage1", "InfoB"), nullptr);
+    EXPECT_FALSE(findRecord(profiler->getRecords(), "Stage1", "InfoB").has_value());
 }
 
 TEST_F(ProfilerTests, GetRecordsReturnsRecordedEntries)
@@ -118,7 +122,7 @@ TEST_F(ProfilerTests, GetRecordsReturnsRecordedEntries)
     const auto id2 = profiler->record("Stage2", "Info2");
     ASSERT_TRUE(id2.has_value());
 
-    const auto &records = profiler->getRecords();
+    const auto records = profiler->getRecords();
     ASSERT_GE(records.size(), 2U);
 
     const auto &record1 = records[records.size() - 2];
@@ -240,7 +244,7 @@ TEST_F(ProfilerTests, GetRecordsDoesNotContainMissingStage)
 {
     ASSERT_TRUE(profiler->record("Stage1").has_value());
 
-    EXPECT_EQ(findRecord(profiler->getRecords(), "MissingStage"), nullptr);
+    EXPECT_FALSE(findRecord(profiler->getRecords(), "MissingStage").has_value());
 }
 
 TEST_F(ProfilerTests, DumpToFileReturnsFalseForInvalidPath)

--- a/tests/unittests/common/unittests/ProfilerTests.cpp
+++ b/tests/unittests/common/unittests/ProfilerTests.cpp
@@ -122,13 +122,13 @@ TEST_F(ProfilerTests, GetRecordsReturnsRecordedEntries)
     ASSERT_GE(records.size(), 2U);
 
     const auto &record1 = records[records.size() - 2];
-    EXPECT_EQ(record1.module, "UnitTestModule");
+    EXPECT_EQ(record1.moduleName, "UnitTestModule");
     EXPECT_EQ(record1.id, id1.value());
     EXPECT_EQ(record1.stage, "Stage1");
     EXPECT_TRUE(record1.info.empty());
 
     const auto &record2 = records[records.size() - 1];
-    EXPECT_EQ(record2.module, "UnitTestModule");
+    EXPECT_EQ(record2.moduleName, "UnitTestModule");
     EXPECT_EQ(record2.id, id2.value());
     EXPECT_EQ(record2.stage, "Stage2");
     EXPECT_EQ(record2.info, "Info2");
@@ -251,7 +251,7 @@ TEST_F(ProfilerTests, DumpToFileReturnsFalseForInvalidPath)
     EXPECT_FALSE(dumpProfiler->dumpToFile());
 }
 
-TEST_F(ProfilerTests, DumpToFileSucceedsWhenEnvMissing)
+TEST_F(ProfilerTests, DumpToFileReturnsFalseWhenEnvMissing)
 {
-    EXPECT_TRUE(profiler->dumpToFile());
+    EXPECT_FALSE(profiler->dumpToFile());
 }

--- a/tests/unittests/media/server/gstplayer/CMakeLists.txt
+++ b/tests/unittests/media/server/gstplayer/CMakeLists.txt
@@ -121,6 +121,9 @@ add_gtests(RialtoServerGstPlayerUnitTests
     #FlushWatcher unittests
     flushWatcher/FlushWatcherTests.cpp
 
+    #GstProfiler unittests
+    profiler/GstProfilerTests.cpp
+
 )
 
 target_include_directories(RialtoServerGstPlayerUnitTests

--- a/tests/unittests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -83,8 +83,8 @@ protected:
                                                              m_videoReq, m_kIsLive, m_gstWrapperMock, m_glibWrapperMock,
                                                              m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
                                                              std::move(m_flushWatcher), m_gstSrcFactoryMock,
-                                                             m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
-                                                             std::move(workerThreadFactory),
+                                                             m_gstProfilerFactoryMock, m_timerFactoryMock,
+                                                             std::move(m_taskFactory), std::move(workerThreadFactory),
                                                              std::move(gstDispatcherThreadFactory),
                                                              m_gstProtectionMetadataFactoryMock));
         EXPECT_NE(m_gstPlayer, nullptr);
@@ -154,6 +154,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, FactoryCreatesObject)
     expectCheckPlaySink();
     EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&m_pipeline, GST_STATE_READY))
         .WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&m_pipeline)).WillOnce(Return(&m_pipeline));
 
     std::shared_ptr<firebolt::rialto::server::IGstGenericPlayerFactory> factory =
         firebolt::rialto::server::IGstGenericPlayerFactory::getFactory();
@@ -165,7 +166,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, FactoryCreatesObject)
     // Destroy expectations
     EXPECT_CALL(*m_gstWrapperMock, gstBusSetSyncHandler(nullptr, nullptr, nullptr, nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(_, GST_STATE_NULL)).WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
-    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(_)).Times(2);
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(_)).Times(3);
     player.reset();
 
     // Cleanup
@@ -348,8 +349,9 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateWesterossinkFailsCreateCont
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
-                                                                  std::move(m_taskFactory), std::move(workerThreadFactory),
+                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock,
+                                                                  m_timerFactoryMock, std::move(m_taskFactory),
+                                                                  std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
                  std::runtime_error);
@@ -366,8 +368,8 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, GstSrcFactoryNull)
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  nullptr, m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
-                                                                  std::move(workerThreadFactory),
+                                                                  nullptr, m_gstProfilerFactoryMock, m_timerFactoryMock,
+                                                                  std::move(m_taskFactory), std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
                  std::runtime_error);
@@ -386,7 +388,8 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, TimerFactoryFails)
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock, nullptr, std::move(m_taskFactory),
+                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock,
+                                                                  nullptr, std::move(m_taskFactory),
                                                                   std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
@@ -406,8 +409,9 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, GstSrcFactoryFails)
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
-                                                                  std::move(m_taskFactory), std::move(workerThreadFactory),
+                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock,
+                                                                  m_timerFactoryMock, std::move(m_taskFactory),
+                                                                  std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
                  std::runtime_error);
@@ -428,15 +432,15 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, UnknownMediaType)
     EXPECT_CALL(*m_gstProtectionMetadataFactoryMock, createProtectionMetadataWrapper(_))
         .WillOnce(Return(ByMove(std::move(m_gstProtectionMetadataWrapper))));
 
-    EXPECT_THROW(m_gstPlayer = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock,
-                                                                  MediaType::UNKNOWN, m_videoReq, m_kIsLive,
-                                                                  m_gstWrapperMock, m_glibWrapperMock,
-                                                                  m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
-                                                                  std::move(m_flushWatcher), m_gstSrcFactoryMock,
-                                                                  m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
-                                                                  std::move(workerThreadFactory),
-                                                                  std::move(gstDispatcherThreadFactory),
-                                                                  m_gstProtectionMetadataFactoryMock),
+    EXPECT_THROW(m_gstPlayer =
+                     std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, MediaType::UNKNOWN,
+                                                        m_videoReq, m_kIsLive, m_gstWrapperMock, m_glibWrapperMock,
+                                                        m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
+                                                        std::move(m_flushWatcher), m_gstSrcFactoryMock,
+                                                        m_gstProfilerFactoryMock, m_timerFactoryMock,
+                                                        std::move(m_taskFactory), std::move(workerThreadFactory),
+                                                        std::move(gstDispatcherThreadFactory),
+                                                        m_gstProtectionMetadataFactoryMock),
                  std::runtime_error);
     EXPECT_EQ(m_gstPlayer, nullptr);
 }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/CreateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/CreateTest.cpp
@@ -51,6 +51,12 @@ protected:
     GParamSpec m_rectangleSpec{};
     const bool m_kIsLive{false};
 
+    void expectCreateProfiler()
+    {
+        EXPECT_CALL(*m_gstProfilerFactoryMock, createGstProfiler(&m_pipeline, _, _))
+            .WillOnce(Return(ByMove(std::move(m_gstProfiler))));
+    }
+
     void expectCreatePipeline()
     {
         EXPECT_CALL(m_gstInitialiserMock, waitForInitialisation());
@@ -60,6 +66,7 @@ protected:
         expectSetSignalCallbacks();
         expectSetUri();
         expectCheckPlaySink();
+        expectCreateProfiler();
 
         EXPECT_CALL(*m_gstSrcMock, initSrc());
         EXPECT_CALL(m_workerThreadFactoryMock, createWorkerThread()).WillOnce(Return(ByMove(std::move(workerThread))));
@@ -76,7 +83,7 @@ protected:
                                                              m_videoReq, m_kIsLive, m_gstWrapperMock, m_glibWrapperMock,
                                                              m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
                                                              std::move(m_flushWatcher), m_gstSrcFactoryMock,
-                                                             m_timerFactoryMock, std::move(m_taskFactory),
+                                                             m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
                                                              std::move(workerThreadFactory),
                                                              std::move(gstDispatcherThreadFactory),
                                                              m_gstProtectionMetadataFactoryMock));
@@ -341,7 +348,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, CreateWesterossinkFailsCreateCont
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  m_gstSrcFactoryMock, m_timerFactoryMock,
+                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
                                                                   std::move(m_taskFactory), std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
@@ -359,7 +366,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, GstSrcFactoryNull)
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  nullptr, m_timerFactoryMock, std::move(m_taskFactory),
+                                                                  nullptr, m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
                                                                   std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
@@ -379,7 +386,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, TimerFactoryFails)
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  m_gstSrcFactoryMock, nullptr, std::move(m_taskFactory),
+                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock, nullptr, std::move(m_taskFactory),
                                                                   std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
@@ -399,7 +406,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, GstSrcFactoryFails)
                                                                   m_videoReq, m_kIsLive, m_gstWrapperMock,
                                                                   m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                                   m_gstInitialiserMock, std::move(m_flushWatcher),
-                                                                  m_gstSrcFactoryMock, m_timerFactoryMock,
+                                                                  m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
                                                                   std::move(m_taskFactory), std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
@@ -426,7 +433,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, UnknownMediaType)
                                                                   m_gstWrapperMock, m_glibWrapperMock,
                                                                   m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
                                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock,
-                                                                  m_timerFactoryMock, std::move(m_taskFactory),
+                                                                  m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
                                                                   std::move(workerThreadFactory),
                                                                   std::move(gstDispatcherThreadFactory),
                                                                   m_gstProtectionMetadataFactoryMock),
@@ -448,6 +455,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, PlaysinkNotFound)
     expectSetUri();
 
     expectSetMessageCallback();
+    expectCreateProfiler();
 
     EXPECT_CALL(*m_gstSrcMock, initSrc());
     EXPECT_CALL(m_workerThreadFactoryMock, createWorkerThread()).WillOnce(Return(ByMove(std::move(workerThread))));
@@ -463,7 +471,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, PlaysinkNotFound)
             std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, m_type, m_videoReq, m_kIsLive,
                                                m_gstWrapperMock, m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                m_gstInitialiserMock, std::move(m_flushWatcher), m_gstSrcFactoryMock,
-                                               m_timerFactoryMock, std::move(m_taskFactory),
+                                               m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
                                                std::move(workerThreadFactory), std::move(gstDispatcherThreadFactory),
                                                m_gstProtectionMetadataFactoryMock));
     EXPECT_NE(m_gstPlayer, nullptr);
@@ -486,6 +494,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, SetNativeAudioForBrcmAudioSink)
     expectSetUri();
     expectCheckPlaySink();
     expectSetMessageCallback();
+    expectCreateProfiler();
 
     EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&m_pipeline, GST_STATE_READY))
         .WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
@@ -499,7 +508,7 @@ TEST_F(RialtoServerCreateGstGenericPlayerTest, SetNativeAudioForBrcmAudioSink)
             std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, m_type, m_videoReq, m_kIsLive,
                                                m_gstWrapperMock, m_glibWrapperMock, m_rdkGstreamerUtilsWrapperMock,
                                                m_gstInitialiserMock, std::move(m_flushWatcher), m_gstSrcFactoryMock,
-                                               m_timerFactoryMock, std::move(m_taskFactory),
+                                               m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
                                                std::move(workerThreadFactory), std::move(gstDispatcherThreadFactory),
                                                m_gstProtectionMetadataFactoryMock));
     EXPECT_NE(m_gstPlayer, nullptr);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstDispatcherThreadClientTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstDispatcherThreadClientTest.cpp
@@ -41,7 +41,7 @@ protected:
         m_sut = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, MediaType::MSE,
                                                    m_videoReq, m_kIsLive, m_gstWrapperMock, m_glibWrapperMock,
                                                    m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
-                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_timerFactoryMock,
+                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
                                                    std::move(m_taskFactory), std::move(workerThreadFactory),
                                                    std::move(gstDispatcherThreadFactory),
                                                    m_gstProtectionMetadataFactoryMock);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstDispatcherThreadClientTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstDispatcherThreadClientTest.cpp
@@ -41,9 +41,9 @@ protected:
         m_sut = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, MediaType::MSE,
                                                    m_videoReq, m_kIsLive, m_gstWrapperMock, m_glibWrapperMock,
                                                    m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
-                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
-                                                   std::move(m_taskFactory), std::move(workerThreadFactory),
-                                                   std::move(gstDispatcherThreadFactory),
+                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock,
+                                                   m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
+                                                   std::move(workerThreadFactory), std::move(gstDispatcherThreadFactory),
                                                    m_gstProtectionMetadataFactoryMock);
     }
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -121,9 +121,9 @@ protected:
         m_sut = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, MediaType::MSE,
                                                    m_videoReq, kIsLive, m_gstWrapperMock, m_glibWrapperMock,
                                                    m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
-                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
-                                                   std::move(m_taskFactory), std::move(workerThreadFactory),
-                                                   std::move(gstDispatcherThreadFactory),
+                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock,
+                                                   m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
+                                                   std::move(workerThreadFactory), std::move(gstDispatcherThreadFactory),
                                                    m_gstProtectionMetadataFactoryMock);
         m_realElement = initRealElement();
     }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -121,7 +121,7 @@ protected:
         m_sut = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, MediaType::MSE,
                                                    m_videoReq, kIsLive, m_gstWrapperMock, m_glibWrapperMock,
                                                    m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
-                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_timerFactoryMock,
+                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
                                                    std::move(m_taskFactory), std::move(workerThreadFactory),
                                                    std::move(gstDispatcherThreadFactory),
                                                    m_gstProtectionMetadataFactoryMock);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -55,9 +55,9 @@ protected:
         m_sut = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, MediaType::MSE,
                                                    m_videoReq, m_isLive, m_gstWrapperMock, m_glibWrapperMock,
                                                    m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
-                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
-                                                   std::move(m_taskFactory), std::move(workerThreadFactory),
-                                                   std::move(gstDispatcherThreadFactory),
+                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock,
+                                                   m_gstProfilerFactoryMock, m_timerFactoryMock, std::move(m_taskFactory),
+                                                   std::move(workerThreadFactory), std::move(gstDispatcherThreadFactory),
                                                    m_gstProtectionMetadataFactoryMock);
         m_element = fakeElement();
     }

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -55,7 +55,7 @@ protected:
         m_sut = std::make_unique<GstGenericPlayer>(&m_gstPlayerClient, m_decryptionServiceMock, MediaType::MSE,
                                                    m_videoReq, m_isLive, m_gstWrapperMock, m_glibWrapperMock,
                                                    m_rdkGstreamerUtilsWrapperMock, m_gstInitialiserMock,
-                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_timerFactoryMock,
+                                                   std::move(m_flushWatcher), m_gstSrcFactoryMock, m_gstProfilerFactoryMock, m_timerFactoryMock,
                                                    std::move(m_taskFactory), std::move(workerThreadFactory),
                                                    std::move(gstDispatcherThreadFactory),
                                                    m_gstProtectionMetadataFactoryMock);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -270,6 +270,7 @@ GenericTasksTestsBase::GenericTasksTestsBase()
     testContext->m_context.gstSrc = testContext->m_gstSrc;
     testContext->m_context.source = testContext->m_element;
     testContext->m_context.decryptionService = testContext->m_decryptionServiceMock.get();
+    testContext->m_context.gstProfiler = std::move(testContext->m_gstProfilerMock);
 }
 
 GenericTasksTestsBase::~GenericTasksTestsBase()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsContext.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsContext.h
@@ -26,6 +26,7 @@
 #include "GlibWrapperMock.h"
 #include "GstGenericPlayerClientMock.h"
 #include "GstGenericPlayerPrivateMock.h"
+#include "GstProfilerMock.h"
 #include "GstSrcMock.h"
 #include "GstTextTrackSinkFactoryMock.h"
 #include "GstWrapperMock.h"
@@ -61,6 +62,8 @@ public:
         std::make_shared<StrictMock<firebolt::rialto::server::DataReaderMock>>()};
     std::shared_ptr<firebolt::rialto::server::GstTextTrackSinkFactoryMock> m_gstTextTrackSinkFactoryMock{
         std::make_shared<StrictMock<firebolt::rialto::server::GstTextTrackSinkFactoryMock>>()};
+    std::unique_ptr<::testing::NiceMock<firebolt::rialto::server::GstProfilerMock>> m_gstProfilerMock{
+        std::make_unique<::testing::NiceMock<firebolt::rialto::server::GstProfilerMock>>()};
 
     // Gstreamer members
     GstElement *m_element{};

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -44,6 +44,8 @@ void GstGenericPlayerTestCommon::gstPlayerWillBeCreated()
     EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&m_pipeline, GST_STATE_READY))
         .WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
     EXPECT_CALL(*m_gstSrcMock, initSrc());
+    EXPECT_CALL(*m_gstProfilerFactoryMock, createGstProfiler(&m_pipeline, _, _))
+        .WillOnce(Return(ByMove(std::move(m_gstProfiler))));
     EXPECT_CALL(m_workerThreadFactoryMock, createWorkerThread()).WillOnce(Return(ByMove(std::move(workerThread))));
     EXPECT_CALL(*m_gstProtectionMetadataFactoryMock, createProtectionMetadataWrapper(_))
         .WillOnce(Return(ByMove(std::move(m_gstProtectionMetadataWrapper))));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.h
@@ -29,6 +29,8 @@
 #include "GstGenericPlayer.h"
 #include "GstGenericPlayerClientMock.h"
 #include "GstInitialiserMock.h"
+#include "GstProfilerFactoryMock.h"
+#include "GstProfilerMock.h"
 #include "GstProtectionMetadataHelperFactoryMock.h"
 #include "GstProtectionMetadataHelperMock.h"
 #include "GstSrcFactoryMock.h"
@@ -47,6 +49,7 @@ using namespace firebolt::rialto;
 using namespace firebolt::rialto::server;
 using namespace firebolt::rialto::wrappers;
 
+using ::testing::NiceMock;
 using ::testing::StrictMock;
 
 namespace
@@ -75,6 +78,10 @@ public:
         std::make_shared<StrictMock<RdkGstreamerUtilsWrapperMock>>()};
     std::shared_ptr<StrictMock<GstSrcFactoryMock>> m_gstSrcFactoryMock{std::make_shared<StrictMock<GstSrcFactoryMock>>()};
     std::shared_ptr<StrictMock<GstSrcMock>> m_gstSrcMock{std::make_shared<StrictMock<GstSrcMock>>()};
+    std::shared_ptr<StrictMock<GstProfilerFactoryMock>> m_gstProfilerFactoryMock{
+        std::make_shared<StrictMock<GstProfilerFactoryMock>>()};
+    std::unique_ptr<NiceMock<GstProfilerMock>> m_gstProfiler{std::make_unique<NiceMock<GstProfilerMock>>()};
+    NiceMock<GstProfilerMock> *m_gstProfilerMock{m_gstProfiler.get()};
     std::shared_ptr<StrictMock<TimerFactoryMock>> m_timerFactoryMock{std::make_shared<StrictMock<TimerFactoryMock>>()};
     std::unique_ptr<IGenericPlayerTaskFactory> m_taskFactory{std::make_unique<StrictMock<GenericPlayerTaskFactoryMock>>()};
     StrictMock<GenericPlayerTaskFactoryMock> &m_taskFactoryMock{

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/HandleBusMessageTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/HandleBusMessageTest.cpp
@@ -231,8 +231,8 @@ TEST_F(HandleBusMessageTest, shouldNotHandleStateChangedMessageWhenGstPlayerClie
 
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Null"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Null"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(*m_gstWrapper, gstMessageUnref(&m_message));
@@ -254,8 +254,8 @@ TEST_F(HandleBusMessageTest, shouldHandleStateChangedToNullMessage)
 
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Null"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Null"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayerClient, notifyPlaybackState(firebolt::rialto::PlaybackState::STOPPED));
@@ -280,8 +280,8 @@ TEST_F(HandleBusMessageTest, shouldHandleStateChangedToPausedMessage)
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
     EXPECT_CALL(m_gstPlayer, hasSourceType(firebolt::rialto::MediaSourceType::SUBTITLE)).WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Paused"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Paused"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayerClient, notifyPlaybackState(firebolt::rialto::PlaybackState::PAUSED));
@@ -310,8 +310,8 @@ TEST_F(HandleBusMessageTest, shouldHandleStateChangedToPausedMessageWhenSyncFlus
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
     EXPECT_CALL(m_gstPlayer, hasSourceType(firebolt::rialto::MediaSourceType::SUBTITLE)).WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Paused"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Paused"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayerClient, notifyPlaybackState(firebolt::rialto::PlaybackState::PAUSED));
@@ -339,8 +339,8 @@ TEST_F(HandleBusMessageTest, shouldSkipHandlingStateChangedToPausedMessageWhenAs
 
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Paused"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Paused"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayer, stopPositionReportingAndCheckAudioUnderflowTimer());
@@ -367,8 +367,8 @@ TEST_F(HandleBusMessageTest, shouldSkipHandlingStateChangedToPausedMessageWhenAs
 
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Paused"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Paused"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayer, stopPositionReportingAndCheckAudioUnderflowTimer());
@@ -420,8 +420,8 @@ TEST_F(HandleBusMessageTest, shouldHandleStateChangedToPlayingMessage)
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
     EXPECT_CALL(m_gstPlayer, hasSourceType(firebolt::rialto::MediaSourceType::SUBTITLE)).WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Playing"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Playing"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayer, startPositionReportingAndCheckAudioUnderflowTimer());
@@ -452,8 +452,8 @@ TEST_F(HandleBusMessageTest, shouldHandleStateChangedToPlayingMessageWhenSyncFlu
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
     EXPECT_CALL(m_gstPlayer, hasSourceType(firebolt::rialto::MediaSourceType::SUBTITLE)).WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Playing"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Playing"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayer, startPositionReportingAndCheckAudioUnderflowTimer());
@@ -483,8 +483,8 @@ TEST_F(HandleBusMessageTest, shouldSkipHandlingStateChangedToPlayingMessageWhenA
 
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Playing"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Playing"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(*m_gstWrapper, gstMessageUnref(&m_message));
@@ -510,8 +510,8 @@ TEST_F(HandleBusMessageTest, shouldSkipHandlingStateChangedToPlayingMessageWhenA
 
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Playing"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Playing"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(*m_gstWrapper, gstMessageUnref(&m_message));
@@ -536,8 +536,8 @@ TEST_F(HandleBusMessageTest, shouldHandleStateChangedToPlayingMessageAndSetPendi
     EXPECT_CALL(*m_gstWrapper, gstMessageParseStateChanged(&m_message, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(oldState), SetArgPointee<2>(newState), SetArgPointee<3>(pending)));
     EXPECT_CALL(m_gstPlayer, hasSourceType(firebolt::rialto::MediaSourceType::SUBTITLE)).WillOnce(Return(false));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(2).WillRepeatedly(Return("Ready"));
-    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(3).WillRepeatedly(Return("Playing"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(oldState)).Times(1).WillRepeatedly(Return("Ready"));
+    EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(newState)).Times(1).WillRepeatedly(Return("Playing"));
     EXPECT_CALL(*m_gstWrapper, gstElementStateGetName(pending)).WillOnce(Return("Void"));
     EXPECT_CALL(*m_gstWrapper, gstDebugBinToDotFileWithTs(GST_BIN(&m_pipeline), _, _));
     EXPECT_CALL(m_gstPlayer, startPositionReportingAndCheckAudioUnderflowTimer());

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -21,9 +21,11 @@
 #include "GstWrapperMock.h"
 
 #include <cstdlib>
+#include <fstream>
 #include <glib.h>
 #include <gst/gst.h>
 #include <gtest/gtest.h>
+#include <random>
 #include <string_view>
 #include <thread>
 
@@ -48,6 +50,7 @@ protected:
     std::shared_ptr<StrictMock<GlibWrapperMock>> m_glibWrapperMock;
     std::unique_ptr<GstProfiler> m_gstProfiler;
     std::optional<std::string> m_profilerEnabledEnv;
+    std::optional<std::string> m_profilerDumpFileNameEnv;
     GstElement *m_realElement{nullptr};
 
     GstElement m_pipeline = {};
@@ -56,8 +59,8 @@ protected:
 
     void SetUp() override
     {
-        if (const char *env = std::getenv("PROFILER_ENABLED"))
-            m_profilerEnabledEnv = env;
+        saveEnv("PROFILER_ENABLED", m_profilerEnabledEnv);
+        saveEnv("PROFILER_DUMP_FILE_NAME", m_profilerDumpFileNameEnv);
 
         m_gstWrapperMock = std::make_shared<StrictMock<GstWrapperMock>>();
         m_glibWrapperMock = std::make_shared<StrictMock<GlibWrapperMock>>();
@@ -79,9 +82,23 @@ protected:
             setenv("PROFILER_ENABLED", m_profilerEnabledEnv->c_str(), 1);
         else
             unsetenv("PROFILER_ENABLED");
+
+        if (m_profilerDumpFileNameEnv)
+            setenv("PROFILER_DUMP_FILE_NAME", m_profilerDumpFileNameEnv->c_str(), 1);
+        else
+            unsetenv("PROFILER_DUMP_FILE_NAME");
     }
 
     void setProfilerEnabledEnv(bool enabled) { setenv("PROFILER_ENABLED", enabled ? "true" : "false", 1); }
+    void setProfilerDumpFileEnv(const std::string &path) { setenv("PROFILER_DUMP_FILE_NAME", path.c_str(), 1); }
+
+    static void saveEnv(const char *name, std::optional<std::string> &value)
+    {
+        if (const char *env = std::getenv(name))
+            value = env;
+        else
+            value = std::nullopt;
+    }
 
     void createGstProfiler(GstElement *pipeline = nullptr)
     {
@@ -171,6 +188,53 @@ TEST_F(GstProfilerTests, LogRecord)
     createGstProfiler();
 
     EXPECT_NO_THROW(m_gstProfiler->logRecord(1));
+}
+
+TEST_F(GstProfilerTests, DumpToFileCreatesAndAppendsDump)
+{
+    setProfilerEnabledEnv(true);
+    const auto suffix = std::to_string(std::random_device{}());
+    const std::string path = std::string{"/tmp/rialto_gst_profiler_ut_dump_"} + suffix + ".txt";
+    setProfilerDumpFileEnv(path);
+    createGstProfiler();
+
+    ASSERT_TRUE(m_gstProfiler->createRecord("Pipeline Created").has_value());
+    ASSERT_TRUE(m_gstProfiler->createRecord("Pipeline Terminated").has_value());
+
+    EXPECT_NO_THROW(m_gstProfiler->dumpToFile());
+    EXPECT_NO_THROW(m_gstProfiler->dumpToFile());
+
+    std::ifstream in(path);
+    ASSERT_TRUE(in.good());
+
+    const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("Pipeline Created"), std::string::npos);
+    EXPECT_NE(content.find("Pipeline Terminated"), std::string::npos);
+    EXPECT_NE(content.find("Pipeline Created"), content.rfind("Pipeline Created"));
+
+    std::remove(path.c_str());
+}
+
+TEST_F(GstProfilerTests, DumpToFileUsesCachedEnvValue)
+{
+    setProfilerEnabledEnv(true);
+    const auto suffix = std::to_string(std::random_device{}());
+    const std::string path = std::string{"/tmp/rialto_gst_profiler_cached_dump_"} + suffix + ".txt";
+    setProfilerDumpFileEnv(path);
+    createGstProfiler();
+
+    unsetenv("PROFILER_DUMP_FILE_NAME");
+    ASSERT_TRUE(m_gstProfiler->createRecord("CachedDumpStage").has_value());
+
+    EXPECT_NO_THROW(m_gstProfiler->dumpToFile());
+
+    std::ifstream in(path);
+    ASSERT_TRUE(in.good());
+
+    const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("CachedDumpStage"), std::string::npos);
+
+    std::remove(path.c_str());
 }
 
 /**

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -37,6 +37,7 @@ using namespace firebolt::rialto::wrappers;
 using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::ReturnNull;
 using ::testing::StrEq;
 using ::testing::StrictMock;
 
@@ -232,9 +233,20 @@ TEST_F(GstProfilerTests, ScheduleElementRecord)
     setProfilerEnabledEnv(true);
     createGstProfiler();
 
-    expectElementRecognizedAsSource(m_realElement);
+    auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement))
+        .WillOnce(Return(nullptr))
+        .WillOnce(Return(factory))
+        .WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
+    EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
 
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(&m_pad));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(false));
 
     gchar *rawName = g_strdup("videoDecoder");
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
@@ -265,13 +277,15 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
     setProfilerEnabledEnv(true);
     createGstProfiler();
 
-    expectElementRecognizedAsSource(m_realElement);
+    auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(nullptr)).WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
+    EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
 
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(&m_pad));
-
-    gchar *rawName = g_strdup("videoDecoder");
-    EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
-    EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(true));
 
     EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
         .WillOnce(Invoke(
@@ -303,6 +317,62 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
 }
 
 /**
+ * Test that scheduled probe falls back to raw element name when media type cannot be classified.
+ */
+TEST_F(GstProfilerTests, ScheduleElementRecordFallsBackToRawElementName)
+{
+    setProfilerEnabledEnv(true);
+    createGstProfiler();
+
+    auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement))
+        .WillOnce(Return(nullptr))
+        .WillOnce(Return(factory))
+        .WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
+    EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(&m_pad));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(false));
+
+    gchar *rawName = g_strdup("custom-element");
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
+        .WillOnce(Invoke(
+            [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
+               GDestroyNotify destroyData) -> gulong
+            {
+                GstBuffer *buffer = gst_buffer_new();
+                GstPadProbeInfo info{};
+                info.type = GST_PAD_PROBE_TYPE_BUFFER;
+                info.data = buffer;
+
+                EXPECT_EQ(callback(pad, &info, userData), GST_PAD_PROBE_REMOVE);
+
+                gst_buffer_unref(buffer);
+                if (destroyData)
+                    destroyData(userData);
+
+                return 1;
+            }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pad));
+
+    m_gstProfiler->scheduleGstElementRecord(m_realElement);
+
+    const auto &records = m_gstProfiler->m_profiler->getRecords();
+    ASSERT_FALSE(records.empty());
+    EXPECT_EQ(records.back().stage, "Source FB Exit");
+    EXPECT_EQ(records.back().info, "custom-element");
+}
+
+/**
  * Test that scheduling record handles missing src pad.
  */
 TEST_F(GstProfilerTests, ScheduleElementRecordNoPad)
@@ -326,19 +396,6 @@ TEST_F(GstProfilerTests, DestroyAfterCreateWithPipeline)
     createGstProfiler(&m_pipeline);
 
     EXPECT_NO_THROW(m_gstProfiler.reset());
-}
-
-/**
- * Test that element names are normalized to video and audio buckets.
- */
-TEST_F(GstProfilerTests, ProcessElementNameNormalizesMediaTypes)
-{
-    setProfilerEnabledEnv(true);
-    createGstProfiler();
-
-    EXPECT_EQ(m_gstProfiler->processElementName("h264parse"), "Video");
-    EXPECT_EQ(m_gstProfiler->processElementName("audsrc"), "Audio");
-    EXPECT_EQ(m_gstProfiler->processElementName("custom-element"), "custom-element");
 }
 
 /**

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -17,146 +17,397 @@
  * limitations under the License.
  */
 
-#include <gmock/gmock.h>
+#include "GlibWrapperMock.h"
+#include "GstWrapperMock.h"
+
+#include <cstdlib>
+#include <glib.h>
+#include <gst/gst.h>
 #include <gtest/gtest.h>
+#include <thread>
 
-#include <memory>
-#include <optional>
-#include <string>
-
+#define private public
 #include "GstProfiler.h"
-#include "common/interface/IProfiler.h"
-#include "common/interface/IProfilerFactory.h"
-#include "wrappers/IGlibWrapper.h"
-#include "wrappers/IGstWrapper.h"
-
-#include "common/mocks/ProfilerFactoryMock.h"
-#include "common/mocks/ProfilerMock.h"
-#include "wrappers/mocks/GlibWrapperMock.h"
-#include "wrappers/mocks/GstWrapperMock.h"
+#undef private
 
 using namespace firebolt::rialto::server;
+using namespace firebolt::rialto::wrappers;
 
 using ::testing::_;
-using ::testing::ByMove;
-using ::testing::NiceMock;
+using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::StrEq;
 using ::testing::StrictMock;
 
 class GstProfilerTests : public ::testing::Test
 {
 protected:
+    std::shared_ptr<StrictMock<GstWrapperMock>> m_gstWrapperMock;
+    std::shared_ptr<StrictMock<GlibWrapperMock>> m_glibWrapperMock;
+    std::unique_ptr<GstProfiler> m_gstProfiler;
+    std::optional<std::string> m_profilerEnabledEnv;
+    GstElement *m_realElement{nullptr};
+
+    GstElement m_pipeline = {};
+    GstElement m_element = {};
+    GstPad m_pad = {};
+
     void SetUp() override
     {
-        gstWrapper = std::make_shared<NiceMock<firebolt::rialto::wrappers::GstWrapperMock>>();
-        glibWrapper = std::make_shared<NiceMock<firebolt::rialto::wrappers::GlibWrapperMock>>();
+        if (const char *env = std::getenv("PROFILER_ENABLED"))
+            m_profilerEnabledEnv = env;
+        unsetenv("PROFILER_ENABLED");
 
-        factoryMock = std::make_shared<StrictMock<firebolt::rialto::common::ProfilerFactoryMock>>();
-        ASSERT_TRUE(factoryMock);
+        m_gstWrapperMock = std::make_shared<StrictMock<GstWrapperMock>>();
+        m_glibWrapperMock = std::make_shared<StrictMock<GlibWrapperMock>>();
+
+        gst_init(nullptr, nullptr);
+        m_realElement = gst_element_factory_make("fakesrc", "profiler-test-source");
+        ASSERT_NE(m_realElement, nullptr);
     }
 
-    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> gstWrapper;
-    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> glibWrapper;
-    std::shared_ptr<StrictMock<firebolt::rialto::common::ProfilerFactoryMock>> factoryMock;
+    void TearDown() override
+    {
+        if (m_realElement)
+        {
+            gst_object_unref(m_realElement);
+            m_realElement = nullptr;
+        }
+
+        if (m_profilerEnabledEnv)
+            setenv("PROFILER_ENABLED", m_profilerEnabledEnv->c_str(), 1);
+        else
+            unsetenv("PROFILER_ENABLED");
+    }
+
+    void createGstProfiler(GstElement *pipeline = nullptr)
+    {
+        if (pipeline)
+        {
+            EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(pipeline));
+            EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(pipeline));
+        }
+
+        EXPECT_NO_THROW(m_gstProfiler = std::make_unique<GstProfiler>(pipeline, m_gstWrapperMock, m_glibWrapperMock));
+        ASSERT_NE(m_gstProfiler, nullptr);
+
+        m_gstProfiler->enable();
+        ASSERT_TRUE(m_gstProfiler->isEnabled());
+    }
+
+    void expectElementRecognizedAsSource(GstElement *element)
+    {
+        EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(element)).WillOnce(Return(nullptr));
+
+        EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
+
+        EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
+    }
+
+    void addRecordAndWait(const std::string &stage, const std::optional<std::string> &info = std::nullopt)
+    {
+        std::optional<IGstProfiler::RecordId> id;
+
+        if (info)
+            id = m_gstProfiler->createRecord(stage, *info);
+        else
+            id = m_gstProfiler->createRecord(stage);
+
+        ASSERT_TRUE(id.has_value());
+        std::this_thread::sleep_for(std::chrono::milliseconds{2});
+    }
 };
 
-TEST_F(GstProfilerTests, DisabledProfilerDoesNotRefPipeline)
+/**
+ * Test that GstProfiler can be created with null pipeline.
+ */
+TEST_F(GstProfilerTests, CreateWithNullPipeline)
 {
-    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
-    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(false));
-
-    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
-
-    auto *pipeline = reinterpret_cast<GstElement *>(0x1234);
-
-    // Disabled profiler: no pipeline ref/unref expected.
-    GstProfiler gstProfiler{pipeline, gstWrapper, glibWrapper, factoryMock};
+    createGstProfiler();
 }
 
-TEST_F(GstProfilerTests, EnabledProfilerRefsAndUnrefsPipeline)
+/**
+ * Test that GstProfiler can be created with valid pipeline.
+ */
+TEST_F(GstProfilerTests, CreateWithPipeline)
 {
-    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
-    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
-
-    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
-
-    auto *pipeline = reinterpret_cast<GstElement *>(0x1234);
-
-    auto gstWrapperMock = std::static_pointer_cast<NiceMock<firebolt::rialto::wrappers::GstWrapperMock>>(gstWrapper);
-
-    EXPECT_CALL(*gstWrapperMock, gstObjectRef(pipeline));
-    EXPECT_CALL(*gstWrapperMock, gstObjectUnref(pipeline));
-
-    {
-        GstProfiler gstProfiler{pipeline, gstWrapper, glibWrapper, factoryMock};
-    }
+    createGstProfiler(&m_pipeline);
 }
 
-TEST_F(GstProfilerTests, CreateRecordNoOpWhenDisabled)
+/**
+ * Test that GstProfiler can create a record with stage only.
+ */
+TEST_F(GstProfilerTests, CreateRecordStageOnly)
 {
-    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
-    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(false));
+    createGstProfiler();
 
-    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
-
-    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
-
-    EXPECT_FALSE(gstProfiler.createRecord("Stage").has_value());
-    EXPECT_FALSE(gstProfiler.createRecord("Stage", "Info").has_value());
-
-    gstProfiler.logRecord(123U); // no-op when disabled
+    EXPECT_NO_THROW({ [[maybe_unused]] const auto id = m_gstProfiler->createRecord("PipelineCreated"); });
 }
 
-TEST_F(GstProfilerTests, CreateRecordForwardsWhenEnabled)
+/**
+ * Test that GstProfiler can create a record with stage and info.
+ */
+TEST_F(GstProfilerTests, CreateRecordStageAndInfo)
 {
-    constexpr firebolt::rialto::common::IProfiler::RecordId kRecordId{123U};
+    createGstProfiler();
 
-    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
-    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
-    EXPECT_CALL(*profilerMock, record(std::string{"StageOnly"}))
-        .WillOnce(Return(std::optional<firebolt::rialto::common::IProfiler::RecordId>{kRecordId}));
-    EXPECT_CALL(*profilerMock, log(kRecordId));
-
-    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
-
-    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
-
-    const auto id = gstProfiler.createRecord("StageOnly");
-    ASSERT_TRUE(id.has_value());
-    EXPECT_EQ(*id, kRecordId);
-
-    gstProfiler.logRecord(*id);
+    EXPECT_NO_THROW({ [[maybe_unused]] const auto id = m_gstProfiler->createRecord("SourceAttached", "video"); });
 }
 
-TEST_F(GstProfilerTests, CreateRecordWithInfoForwardsWhenEnabled)
+/**
+ * Test that GstProfiler can log a record.
+ */
+TEST_F(GstProfilerTests, LogRecord)
 {
-    constexpr firebolt::rialto::common::IProfiler::RecordId kRecordId{456U};
+    createGstProfiler();
 
-    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
-    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
-    EXPECT_CALL(*profilerMock, record(std::string{"StageWithInfo"}, std::string{"InfoValue"}))
-        .WillOnce(Return(std::optional<firebolt::rialto::common::IProfiler::RecordId>{kRecordId}));
-    EXPECT_CALL(*profilerMock, log(kRecordId));
-
-    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
-
-    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
-
-    const auto id = gstProfiler.createRecord("StageWithInfo", "InfoValue");
-    ASSERT_TRUE(id.has_value());
-    EXPECT_EQ(*id, kRecordId);
-
-    gstProfiler.logRecord(*id);
+    EXPECT_NO_THROW(m_gstProfiler->logRecord(1));
 }
 
-TEST_F(GstProfilerTests, ScheduleNullElementIsSafe)
+/**
+ * Test that GstProfiler can log pipeline metrics.
+ */
+TEST_F(GstProfilerTests, LogPipeline)
 {
-    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
-    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
+    createGstProfiler();
 
-    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
+    EXPECT_NO_THROW(m_gstProfiler->logPipeline());
+}
 
-    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
+/**
+ * Test that disable prevents record creation and scheduling.
+ */
+TEST_F(GstProfilerTests, DisablePreventsRecordCreationAndScheduling)
+{
+    createGstProfiler();
 
-    gstProfiler.scheduleGstElementRecord(nullptr);
+    m_gstProfiler->disable();
+    EXPECT_FALSE(m_gstProfiler->isEnabled());
+    EXPECT_FALSE(m_gstProfiler->createRecord("Pipeline Created").has_value());
+
+    EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(m_realElement));
+}
+
+/**
+ * Test that enabling allows scheduling path to proceed up to pad lookup.
+ */
+TEST_F(GstProfilerTests, EnableAllowsScheduling)
+{
+    EXPECT_NO_THROW(m_gstProfiler = std::make_unique<GstProfiler>(nullptr, m_gstWrapperMock, m_glibWrapperMock));
+    ASSERT_NE(m_gstProfiler, nullptr);
+    EXPECT_FALSE(m_gstProfiler->isEnabled());
+
+    m_gstProfiler->enable();
+    ASSERT_TRUE(m_gstProfiler->isEnabled());
+
+    expectElementRecognizedAsSource(m_realElement);
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(nullptr));
+
+    EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(m_realElement));
+}
+
+/**
+ * Test that scheduling record for null element is safe.
+ */
+TEST_F(GstProfilerTests, ScheduleNullElementRecord)
+{
+    createGstProfiler();
+
+    EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(nullptr));
+}
+
+/**
+ * Test that scheduling record for valid element is safe.
+ */
+TEST_F(GstProfilerTests, ScheduleElementRecord)
+{
+    createGstProfiler();
+
+    expectElementRecognizedAsSource(m_realElement);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(&m_pad));
+
+    gchar *rawName = g_strdup("videoDecoder");
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
+        .WillOnce(Invoke(
+            [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
+               GDestroyNotify destroyData) -> gulong
+            {
+                if (destroyData)
+                {
+                    destroyData(userData);
+                }
+                return 1;
+            }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pad));
+
+    EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(m_realElement));
+}
+
+/**
+ * Test that scheduled probe creates record with normalized video info.
+ */
+TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
+{
+    createGstProfiler();
+
+    expectElementRecognizedAsSource(m_realElement);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(&m_pad));
+
+    gchar *rawName = g_strdup("videoDecoder");
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
+        .WillOnce(Invoke(
+            [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
+               GDestroyNotify destroyData) -> gulong
+            {
+                GstBuffer *buffer = gst_buffer_new();
+                GstPadProbeInfo info{};
+                info.type = GST_PAD_PROBE_TYPE_BUFFER;
+                info.data = buffer;
+
+                EXPECT_EQ(callback(pad, &info, userData), GST_PAD_PROBE_REMOVE);
+
+                gst_buffer_unref(buffer);
+                if (destroyData)
+                    destroyData(userData);
+
+                return 1;
+            }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pad));
+
+    m_gstProfiler->scheduleGstElementRecord(m_realElement);
+
+    const auto &records = m_gstProfiler->m_profiler->getRecords();
+    ASSERT_FALSE(records.empty());
+    EXPECT_EQ(records.back().stage, "Source FB Exit");
+    EXPECT_EQ(records.back().info, "Video");
+}
+
+/**
+ * Test that scheduling record handles missing src pad.
+ */
+TEST_F(GstProfilerTests, ScheduleElementRecordNoPad)
+{
+    createGstProfiler();
+
+    expectElementRecognizedAsSource(m_realElement);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(nullptr));
+
+    EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(m_realElement));
+}
+
+/**
+ * Test that GstProfiler can be destroyed after creation with pipeline.
+ */
+TEST_F(GstProfilerTests, DestroyAfterCreateWithPipeline)
+{
+    createGstProfiler(&m_pipeline);
+
+    EXPECT_NO_THROW(m_gstProfiler.reset());
+}
+
+/**
+ * Test that element names are normalized to video and audio buckets.
+ */
+TEST_F(GstProfilerTests, ProcessElementNameNormalizesMediaTypes)
+{
+    createGstProfiler();
+
+    EXPECT_EQ(m_gstProfiler->processElementName("h264parse"), "Video");
+    EXPECT_EQ(m_gstProfiler->processElementName("audsrc"), "Audio");
+    EXPECT_EQ(m_gstProfiler->processElementName("custom-element"), "custom-element");
+}
+
+/**
+ * Test that element classes are mapped to expected stage names.
+ */
+TEST_F(GstProfilerTests, CheckElementMapsClassToExpectedStage)
+{
+    createGstProfiler();
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Decryptor"));
+    EXPECT_CALL(*m_glibWrapperMock, gStrrstr("Decryptor", StrEq("Source"))).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_glibWrapperMock, gStrrstr("Decryptor", StrEq("Decryptor")))
+        .WillOnce(Return(const_cast<gchar *>("Decryptor")));
+
+    const auto stage = m_gstProfiler->checkElement(m_realElement);
+    ASSERT_TRUE(stage.has_value());
+    EXPECT_EQ(stage.value(), "Decryptor FB Exit");
+}
+
+/**
+ * Test that metrics calculation returns null when required records are missing.
+ */
+TEST_F(GstProfilerTests, CalculateMetricsReturnsNulloptWhenRecordsMissing)
+{
+    createGstProfiler();
+
+    addRecordAndWait("Pipeline Created");
+    addRecordAndWait("All Sources Attached");
+
+    EXPECT_FALSE(m_gstProfiler->calculateMetrics().has_value());
+}
+
+/**
+ * Test that metrics calculation succeeds for a full clear pipeline path.
+ */
+TEST_F(GstProfilerTests, CalculateMetricsReturnsValuesForNonEncryptedPlayback)
+{
+    createGstProfiler();
+
+    addRecordAndWait("Pipeline Created");
+    addRecordAndWait("All Sources Attached");
+    addRecordAndWait("First Segment Received", "Video");
+    addRecordAndWait("First Segment Received", "Audio");
+    addRecordAndWait("Source FB Exit", "Video");
+    addRecordAndWait("Source FB Exit", "Audio");
+    addRecordAndWait("Decoder FB Exit", "Video");
+    addRecordAndWait("Decoder FB Exit", "Audio");
+    addRecordAndWait("Pipeline State Changed", "PAUSED");
+    addRecordAndWait("Pipeline State Changed", "PLAYING");
+
+    const auto metrics = m_gstProfiler->calculateMetrics();
+    ASSERT_TRUE(metrics.has_value());
+    EXPECT_TRUE(metrics->preparation.has_value());
+    EXPECT_TRUE(metrics->videoDownload.has_value());
+    EXPECT_TRUE(metrics->audioDownload.has_value());
+    EXPECT_TRUE(metrics->videoSource.has_value());
+    EXPECT_TRUE(metrics->audioSource.has_value());
+    EXPECT_TRUE(metrics->videoDecode.has_value());
+    EXPECT_TRUE(metrics->audioDecode.has_value());
+    EXPECT_TRUE(metrics->preRoll.has_value());
+    EXPECT_TRUE(metrics->play.has_value());
+    EXPECT_TRUE(metrics->total.has_value());
+    EXPECT_TRUE(metrics->totalWithoutApp.has_value());
+}
+
+/**
+ * Test that public API can be called multiple times.
+ */
+TEST_F(GstProfilerTests, MultipleCalls)
+{
+    createGstProfiler();
+
+    expectElementRecognizedAsSource(m_realElement);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(nullptr));
+
+    EXPECT_NO_THROW({
+        [[maybe_unused]] const auto id1 = m_gstProfiler->createRecord("PipelineCreated");
+        [[maybe_unused]] const auto id2 = m_gstProfiler->createRecord("AllSourcesAttached", "audio+video");
+        m_gstProfiler->logRecord(1);
+        m_gstProfiler->scheduleGstElementRecord(m_realElement);
+        m_gstProfiler->logPipeline();
+    });
 }

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -24,6 +24,7 @@
 #include <glib.h>
 #include <gst/gst.h>
 #include <gtest/gtest.h>
+#include <string_view>
 #include <thread>
 
 #define private public
@@ -56,7 +57,6 @@ protected:
     {
         if (const char *env = std::getenv("PROFILER_ENABLED"))
             m_profilerEnabledEnv = env;
-        unsetenv("PROFILER_ENABLED");
 
         m_gstWrapperMock = std::make_shared<StrictMock<GstWrapperMock>>();
         m_glibWrapperMock = std::make_shared<StrictMock<GlibWrapperMock>>();
@@ -80,9 +80,13 @@ protected:
             unsetenv("PROFILER_ENABLED");
     }
 
+    void setProfilerEnabledEnv(bool enabled) { setenv("PROFILER_ENABLED", enabled ? "true" : "false", 1); }
+
     void createGstProfiler(GstElement *pipeline = nullptr)
     {
-        if (pipeline)
+        const char *profilerEnabledEnv = std::getenv("PROFILER_ENABLED");
+        const bool expectPipelineRef = pipeline && profilerEnabledEnv && std::string_view{profilerEnabledEnv} == "true";
+        if (expectPipelineRef)
         {
             EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(pipeline));
             EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(pipeline));
@@ -90,9 +94,6 @@ protected:
 
         EXPECT_NO_THROW(m_gstProfiler = std::make_unique<GstProfiler>(pipeline, m_gstWrapperMock, m_glibWrapperMock));
         ASSERT_NE(m_gstProfiler, nullptr);
-
-        m_gstProfiler->enable();
-        ASSERT_TRUE(m_gstProfiler->isEnabled());
     }
 
     void expectElementRecognizedAsSource(GstElement *element)
@@ -123,7 +124,9 @@ protected:
  */
 TEST_F(GstProfilerTests, CreateWithNullPipeline)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
+    EXPECT_TRUE(m_gstProfiler->isEnabled());
 }
 
 /**
@@ -131,7 +134,9 @@ TEST_F(GstProfilerTests, CreateWithNullPipeline)
  */
 TEST_F(GstProfilerTests, CreateWithPipeline)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler(&m_pipeline);
+    EXPECT_TRUE(m_gstProfiler->isEnabled());
 }
 
 /**
@@ -139,6 +144,7 @@ TEST_F(GstProfilerTests, CreateWithPipeline)
  */
 TEST_F(GstProfilerTests, CreateRecordStageOnly)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     EXPECT_NO_THROW({ [[maybe_unused]] const auto id = m_gstProfiler->createRecord("PipelineCreated"); });
@@ -149,6 +155,7 @@ TEST_F(GstProfilerTests, CreateRecordStageOnly)
  */
 TEST_F(GstProfilerTests, CreateRecordStageAndInfo)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     EXPECT_NO_THROW({ [[maybe_unused]] const auto id = m_gstProfiler->createRecord("SourceAttached", "video"); });
@@ -159,6 +166,7 @@ TEST_F(GstProfilerTests, CreateRecordStageAndInfo)
  */
 TEST_F(GstProfilerTests, LogRecord)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     EXPECT_NO_THROW(m_gstProfiler->logRecord(1));
@@ -169,19 +177,20 @@ TEST_F(GstProfilerTests, LogRecord)
  */
 TEST_F(GstProfilerTests, LogPipeline)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     EXPECT_NO_THROW(m_gstProfiler->logPipeline());
 }
 
 /**
- * Test that disable prevents record creation and scheduling.
+ * Test that disabled profiler prevents record creation and scheduling.
  */
-TEST_F(GstProfilerTests, DisablePreventsRecordCreationAndScheduling)
+TEST_F(GstProfilerTests, DisabledProfilerPreventsRecordCreationAndScheduling)
 {
+    setProfilerEnabledEnv(false);
     createGstProfiler();
 
-    m_gstProfiler->disable();
     EXPECT_FALSE(m_gstProfiler->isEnabled());
     EXPECT_FALSE(m_gstProfiler->createRecord("Pipeline Created").has_value());
 
@@ -189,15 +198,13 @@ TEST_F(GstProfilerTests, DisablePreventsRecordCreationAndScheduling)
 }
 
 /**
- * Test that enabling allows scheduling path to proceed up to pad lookup.
+ * Test that enabled profiler allows scheduling path to proceed up to pad lookup.
  */
-TEST_F(GstProfilerTests, EnableAllowsScheduling)
+TEST_F(GstProfilerTests, EnabledProfilerAllowsScheduling)
 {
+    setProfilerEnabledEnv(true);
     EXPECT_NO_THROW(m_gstProfiler = std::make_unique<GstProfiler>(nullptr, m_gstWrapperMock, m_glibWrapperMock));
     ASSERT_NE(m_gstProfiler, nullptr);
-    EXPECT_FALSE(m_gstProfiler->isEnabled());
-
-    m_gstProfiler->enable();
     ASSERT_TRUE(m_gstProfiler->isEnabled());
 
     expectElementRecognizedAsSource(m_realElement);
@@ -211,6 +218,7 @@ TEST_F(GstProfilerTests, EnableAllowsScheduling)
  */
 TEST_F(GstProfilerTests, ScheduleNullElementRecord)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(nullptr));
@@ -221,6 +229,7 @@ TEST_F(GstProfilerTests, ScheduleNullElementRecord)
  */
 TEST_F(GstProfilerTests, ScheduleElementRecord)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     expectElementRecognizedAsSource(m_realElement);
@@ -253,6 +262,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecord)
  */
 TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     expectElementRecognizedAsSource(m_realElement);
@@ -297,6 +307,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
  */
 TEST_F(GstProfilerTests, ScheduleElementRecordNoPad)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     expectElementRecognizedAsSource(m_realElement);
@@ -311,6 +322,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordNoPad)
  */
 TEST_F(GstProfilerTests, DestroyAfterCreateWithPipeline)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler(&m_pipeline);
 
     EXPECT_NO_THROW(m_gstProfiler.reset());
@@ -321,6 +333,7 @@ TEST_F(GstProfilerTests, DestroyAfterCreateWithPipeline)
  */
 TEST_F(GstProfilerTests, ProcessElementNameNormalizesMediaTypes)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     EXPECT_EQ(m_gstProfiler->processElementName("h264parse"), "Video");
@@ -333,6 +346,7 @@ TEST_F(GstProfilerTests, ProcessElementNameNormalizesMediaTypes)
  */
 TEST_F(GstProfilerTests, CheckElementMapsClassToExpectedStage)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(nullptr));
@@ -351,6 +365,7 @@ TEST_F(GstProfilerTests, CheckElementMapsClassToExpectedStage)
  */
 TEST_F(GstProfilerTests, CalculateMetricsReturnsNulloptWhenRecordsMissing)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     addRecordAndWait("Pipeline Created");
@@ -364,6 +379,7 @@ TEST_F(GstProfilerTests, CalculateMetricsReturnsNulloptWhenRecordsMissing)
  */
 TEST_F(GstProfilerTests, CalculateMetricsReturnsValuesForNonEncryptedPlayback)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     addRecordAndWait("Pipeline Created");
@@ -397,6 +413,7 @@ TEST_F(GstProfilerTests, CalculateMetricsReturnsValuesForNonEncryptedPlayback)
  */
 TEST_F(GstProfilerTests, MultipleCalls)
 {
+    setProfilerEnabledEnv(true);
     createGstProfiler();
 
     expectElementRecognizedAsSource(m_realElement);

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -1,0 +1,162 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 Sky UK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "GstProfiler.h"
+#include "common/interface/IProfiler.h"
+#include "common/interface/IProfilerFactory.h"
+#include "wrappers/IGlibWrapper.h"
+#include "wrappers/IGstWrapper.h"
+
+#include "common/mocks/ProfilerFactoryMock.h"
+#include "common/mocks/ProfilerMock.h"
+#include "wrappers/mocks/GlibWrapperMock.h"
+#include "wrappers/mocks/GstWrapperMock.h"
+
+using namespace firebolt::rialto::server;
+
+using ::testing::_;
+using ::testing::ByMove;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::StrictMock;
+
+class GstProfilerTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        gstWrapper = std::make_shared<NiceMock<firebolt::rialto::wrappers::GstWrapperMock>>();
+        glibWrapper = std::make_shared<NiceMock<firebolt::rialto::wrappers::GlibWrapperMock>>();
+
+        factoryMock = std::make_shared<StrictMock<firebolt::rialto::common::ProfilerFactoryMock>>();
+        ASSERT_TRUE(factoryMock);
+    }
+
+    std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> gstWrapper;
+    std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> glibWrapper;
+    std::shared_ptr<StrictMock<firebolt::rialto::common::ProfilerFactoryMock>> factoryMock;
+};
+
+TEST_F(GstProfilerTests, DisabledProfilerDoesNotRefPipeline)
+{
+    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
+    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(false));
+
+    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
+
+    auto *pipeline = reinterpret_cast<GstElement *>(0x1234);
+
+    // Disabled profiler: no pipeline ref/unref expected.
+    GstProfiler gstProfiler{pipeline, gstWrapper, glibWrapper, factoryMock};
+}
+
+TEST_F(GstProfilerTests, EnabledProfilerRefsAndUnrefsPipeline)
+{
+    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
+    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
+
+    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
+
+    auto *pipeline = reinterpret_cast<GstElement *>(0x1234);
+
+    auto gstWrapperMock = std::static_pointer_cast<NiceMock<firebolt::rialto::wrappers::GstWrapperMock>>(gstWrapper);
+
+    EXPECT_CALL(*gstWrapperMock, gstObjectRef(pipeline));
+    EXPECT_CALL(*gstWrapperMock, gstObjectUnref(pipeline));
+
+    {
+        GstProfiler gstProfiler{pipeline, gstWrapper, glibWrapper, factoryMock};
+    }
+}
+
+TEST_F(GstProfilerTests, CreateRecordNoOpWhenDisabled)
+{
+    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
+    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(false));
+
+    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
+
+    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
+
+    EXPECT_FALSE(gstProfiler.createRecord("Stage").has_value());
+    EXPECT_FALSE(gstProfiler.createRecord("Stage", "Info").has_value());
+
+    gstProfiler.logRecord(123U); // no-op when disabled
+}
+
+TEST_F(GstProfilerTests, CreateRecordForwardsWhenEnabled)
+{
+    constexpr firebolt::rialto::common::IProfiler::RecordId kRecordId{123U};
+
+    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
+    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
+    EXPECT_CALL(*profilerMock, record(std::string{"StageOnly"}))
+        .WillOnce(Return(std::optional<firebolt::rialto::common::IProfiler::RecordId>{kRecordId}));
+    EXPECT_CALL(*profilerMock, log(kRecordId));
+
+    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
+
+    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
+
+    const auto id = gstProfiler.createRecord("StageOnly");
+    ASSERT_TRUE(id.has_value());
+    EXPECT_EQ(*id, kRecordId);
+
+    gstProfiler.logRecord(*id);
+}
+
+TEST_F(GstProfilerTests, CreateRecordWithInfoForwardsWhenEnabled)
+{
+    constexpr firebolt::rialto::common::IProfiler::RecordId kRecordId{456U};
+
+    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
+    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
+    EXPECT_CALL(*profilerMock, record(std::string{"StageWithInfo"}, std::string{"InfoValue"}))
+        .WillOnce(Return(std::optional<firebolt::rialto::common::IProfiler::RecordId>{kRecordId}));
+    EXPECT_CALL(*profilerMock, log(kRecordId));
+
+    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
+
+    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
+
+    const auto id = gstProfiler.createRecord("StageWithInfo", "InfoValue");
+    ASSERT_TRUE(id.has_value());
+    EXPECT_EQ(*id, kRecordId);
+
+    gstProfiler.logRecord(*id);
+}
+
+TEST_F(GstProfilerTests, ScheduleNullElementIsSafe)
+{
+    auto profilerMock = std::make_unique<StrictMock<firebolt::rialto::common::ProfilerMock>>();
+    EXPECT_CALL(*profilerMock, enabled()).WillOnce(Return(true));
+
+    EXPECT_CALL(*factoryMock, createProfiler(_)).WillOnce(Return(ByMove(std::move(profilerMock))));
+
+    GstProfiler gstProfiler{nullptr, gstWrapper, glibWrapper, factoryMock};
+
+    gstProfiler.scheduleGstElementRecord(nullptr);
+}

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -381,6 +381,62 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
 }
 
 /**
+ * Test that scheduled probe falls back to element name classification when media type helpers fail.
+ */
+TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfoFromNameFallback)
+{
+    setProfilerEnabledEnv(true);
+    createGstProfiler();
+
+    auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement))
+        .WillOnce(Return(nullptr))
+        .WillOnce(Return(factory))
+        .WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
+    EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(&m_pad));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(false));
+
+    gchar *rawName = g_strdup("videoDecoder");
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
+        .WillOnce(Invoke(
+            [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
+               GDestroyNotify destroyData) -> gulong
+            {
+                GstBuffer *buffer = gst_buffer_new();
+                GstPadProbeInfo info{};
+                info.type = GST_PAD_PROBE_TYPE_BUFFER;
+                info.data = buffer;
+
+                EXPECT_EQ(callback(pad, &info, userData), GST_PAD_PROBE_REMOVE);
+
+                gst_buffer_unref(buffer);
+                if (destroyData)
+                    destroyData(userData);
+
+                return 1;
+            }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pad));
+
+    m_gstProfiler->scheduleGstElementRecord(m_realElement);
+
+    const auto &records = m_gstProfiler->m_profiler->getRecords();
+    ASSERT_FALSE(records.empty());
+    EXPECT_EQ(records.back().stage, "Source FB Exit");
+    EXPECT_EQ(records.back().info, "Video");
+}
+
+/**
  * Test that scheduled probe falls back to raw element name when media type cannot be classified.
  */
 TEST_F(GstProfilerTests, ScheduleElementRecordFallsBackToRawElementName)

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -29,9 +29,7 @@
 #include <string_view>
 #include <thread>
 
-#define private public
 #include "GstProfiler.h"
-#undef private
 
 using namespace firebolt::rialto::server;
 using namespace firebolt::rialto::wrappers;
@@ -42,6 +40,18 @@ using ::testing::Return;
 using ::testing::ReturnNull;
 using ::testing::StrEq;
 using ::testing::StrictMock;
+
+namespace firebolt::rialto::server
+{
+class GstProfilerAccessor
+{
+public:
+    static std::optional<GstProfiler::PipelineMetrics> calculateMetrics(const GstProfiler &profiler)
+    {
+        return profiler.calculateMetrics();
+    }
+};
+} // namespace firebolt::rialto::server
 
 class GstProfilerTests : public ::testing::Test
 {
@@ -116,8 +126,6 @@ protected:
 
     void expectElementRecognizedAsSource(GstElement *element)
     {
-        EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(element)).WillOnce(Return(nullptr));
-
         EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
 
         EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
@@ -299,10 +307,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecord)
 
     auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement))
-        .WillOnce(Return(nullptr))
-        .WillOnce(Return(factory))
-        .WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(factory)).WillOnce(Return(factory));
     EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
     EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
 
@@ -343,7 +348,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
 
     auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(nullptr)).WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(factory));
     EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
     EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
 
@@ -374,7 +379,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
 
     m_gstProfiler->scheduleGstElementRecord(m_realElement);
 
-    const auto &records = m_gstProfiler->m_profiler->getRecords();
+    const auto &records = m_gstProfiler->getRecords();
     ASSERT_FALSE(records.empty());
     EXPECT_EQ(records.back().stage, "Source FB Exit");
     EXPECT_EQ(records.back().info, "Video");
@@ -390,10 +395,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfoFro
 
     auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement))
-        .WillOnce(Return(nullptr))
-        .WillOnce(Return(factory))
-        .WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(factory)).WillOnce(Return(factory));
     EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
     EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
 
@@ -430,7 +432,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfoFro
 
     m_gstProfiler->scheduleGstElementRecord(m_realElement);
 
-    const auto &records = m_gstProfiler->m_profiler->getRecords();
+    const auto &records = m_gstProfiler->getRecords();
     ASSERT_FALSE(records.empty());
     EXPECT_EQ(records.back().stage, "Source FB Exit");
     EXPECT_EQ(records.back().info, "Video");
@@ -446,10 +448,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordFallsBackToRawElementName)
 
     auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
 
-    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement))
-        .WillOnce(Return(nullptr))
-        .WillOnce(Return(factory))
-        .WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(factory)).WillOnce(Return(factory));
     EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
     EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
 
@@ -486,7 +485,7 @@ TEST_F(GstProfilerTests, ScheduleElementRecordFallsBackToRawElementName)
 
     m_gstProfiler->scheduleGstElementRecord(m_realElement);
 
-    const auto &records = m_gstProfiler->m_profiler->getRecords();
+    const auto &records = m_gstProfiler->getRecords();
     ASSERT_FALSE(records.empty());
     EXPECT_EQ(records.back().stage, "Source FB Exit");
     EXPECT_EQ(records.back().info, "custom-element");
@@ -508,6 +507,36 @@ TEST_F(GstProfilerTests, ScheduleElementRecordNoPad)
 }
 
 /**
+ * Test that scheduling record handles probe installation failure without leaking context ownership.
+ */
+TEST_F(GstProfilerTests, ScheduleElementRecordProbeAddFails)
+{
+    setProfilerEnabledEnv(true);
+    createGstProfiler();
+
+    auto *factory = reinterpret_cast<GstElementFactory *>(0x1);
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(factory)).WillOnce(Return(factory));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
+    EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(&m_pad));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(false));
+
+    gchar *rawName = g_strdup("videoDecoder");
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
+
+    EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pad));
+
+    EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(m_realElement));
+}
+
+/**
  * Test that GstProfiler can be destroyed after creation with pipeline.
  */
 TEST_F(GstProfilerTests, DestroyAfterCreateWithPipeline)
@@ -516,25 +545,6 @@ TEST_F(GstProfilerTests, DestroyAfterCreateWithPipeline)
     createGstProfiler(&m_pipeline);
 
     EXPECT_NO_THROW(m_gstProfiler.reset());
-}
-
-/**
- * Test that element classes are mapped to expected stage names.
- */
-TEST_F(GstProfilerTests, CheckElementMapsClassToExpectedStage)
-{
-    setProfilerEnabledEnv(true);
-    createGstProfiler();
-
-    EXPECT_CALL(*m_gstWrapperMock, gstElementGetFactory(m_realElement)).WillOnce(Return(nullptr));
-    EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Decryptor"));
-    EXPECT_CALL(*m_glibWrapperMock, gStrrstr("Decryptor", StrEq("Source"))).WillOnce(Return(nullptr));
-    EXPECT_CALL(*m_glibWrapperMock, gStrrstr("Decryptor", StrEq("Decryptor")))
-        .WillOnce(Return(const_cast<gchar *>("Decryptor")));
-
-    const auto stage = m_gstProfiler->checkElement(m_realElement);
-    ASSERT_TRUE(stage.has_value());
-    EXPECT_EQ(stage.value(), "Decryptor FB Exit");
 }
 
 /**
@@ -548,7 +558,7 @@ TEST_F(GstProfilerTests, CalculateMetricsReturnsNulloptWhenRecordsMissing)
     addRecordAndWait("Pipeline Created");
     addRecordAndWait("All Sources Attached");
 
-    EXPECT_FALSE(m_gstProfiler->calculateMetrics().has_value());
+    EXPECT_FALSE(GstProfilerAccessor::calculateMetrics(*m_gstProfiler).has_value());
 }
 
 /**
@@ -570,7 +580,7 @@ TEST_F(GstProfilerTests, CalculateMetricsReturnsValuesForNonEncryptedPlayback)
     addRecordAndWait("Pipeline State Changed", "PAUSED");
     addRecordAndWait("Pipeline State Changed", "PLAYING");
 
-    const auto metrics = m_gstProfiler->calculateMetrics();
+    const auto metrics = GstProfilerAccessor::calculateMetrics(*m_gstProfiler);
     ASSERT_TRUE(metrics.has_value());
     EXPECT_TRUE(metrics->preparation.has_value());
     EXPECT_TRUE(metrics->videoDownload.has_value());

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -20,14 +20,18 @@
 #include "GlibWrapperMock.h"
 #include "GstWrapperMock.h"
 
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <glib.h>
 #include <gst/gst.h>
 #include <gtest/gtest.h>
+#include <iterator>
+#include <memory>
+#include <optional>
 #include <random>
+#include <string>
 #include <string_view>
-#include <thread>
 
 #include "GstProfiler.h"
 
@@ -40,18 +44,6 @@ using ::testing::Return;
 using ::testing::ReturnNull;
 using ::testing::StrEq;
 using ::testing::StrictMock;
-
-namespace firebolt::rialto::server
-{
-class GstProfilerAccessor
-{
-public:
-    static std::optional<GstProfiler::PipelineMetrics> calculateMetrics(const GstProfiler &profiler)
-    {
-        return profiler.calculateMetrics();
-    }
-};
-} // namespace firebolt::rialto::server
 
 class GstProfilerTests : public ::testing::Test
 {
@@ -129,19 +121,6 @@ protected:
         EXPECT_CALL(*m_gstWrapperMock, gstElementClassGetMetadata(_, _)).WillOnce(Return("Source"));
 
         EXPECT_CALL(*m_glibWrapperMock, gStrrstr(_, _)).WillOnce(Return(const_cast<gchar *>("Source")));
-    }
-
-    void addRecordAndWait(const std::string &stage, const std::optional<std::string> &info = std::nullopt)
-    {
-        std::optional<IGstProfiler::RecordId> id;
-
-        if (info)
-            id = m_gstProfiler->createRecord(stage, *info);
-        else
-            id = m_gstProfiler->createRecord(stage);
-
-        ASSERT_TRUE(id.has_value());
-        std::this_thread::sleep_for(std::chrono::milliseconds{2});
     }
 };
 
@@ -248,12 +227,12 @@ TEST_F(GstProfilerTests, DumpToFileUsesCachedEnvValue)
 /**
  * Test that GstProfiler can log pipeline metrics.
  */
-TEST_F(GstProfilerTests, LogPipeline)
+TEST_F(GstProfilerTests, LogPipelineSummary)
 {
     setProfilerEnabledEnv(true);
     createGstProfiler();
 
-    EXPECT_NO_THROW(m_gstProfiler->logPipeline());
+    EXPECT_NO_THROW(m_gstProfiler->logPipelineSummary());
 }
 
 /**
@@ -548,54 +527,6 @@ TEST_F(GstProfilerTests, DestroyAfterCreateWithPipeline)
 }
 
 /**
- * Test that metrics calculation returns null when required records are missing.
- */
-TEST_F(GstProfilerTests, CalculateMetricsReturnsNulloptWhenRecordsMissing)
-{
-    setProfilerEnabledEnv(true);
-    createGstProfiler();
-
-    addRecordAndWait("Pipeline Created");
-    addRecordAndWait("All Sources Attached");
-
-    EXPECT_FALSE(GstProfilerAccessor::calculateMetrics(*m_gstProfiler).has_value());
-}
-
-/**
- * Test that metrics calculation succeeds for a full clear pipeline path.
- */
-TEST_F(GstProfilerTests, CalculateMetricsReturnsValuesForNonEncryptedPlayback)
-{
-    setProfilerEnabledEnv(true);
-    createGstProfiler();
-
-    addRecordAndWait("Pipeline Created");
-    addRecordAndWait("All Sources Attached");
-    addRecordAndWait("First Segment Received", "Video");
-    addRecordAndWait("First Segment Received", "Audio");
-    addRecordAndWait("Source FB Exit", "Video");
-    addRecordAndWait("Source FB Exit", "Audio");
-    addRecordAndWait("Decoder FB Exit", "Video");
-    addRecordAndWait("Decoder FB Exit", "Audio");
-    addRecordAndWait("Pipeline State Changed", "PAUSED");
-    addRecordAndWait("Pipeline State Changed", "PLAYING");
-
-    const auto metrics = GstProfilerAccessor::calculateMetrics(*m_gstProfiler);
-    ASSERT_TRUE(metrics.has_value());
-    EXPECT_TRUE(metrics->preparation.has_value());
-    EXPECT_TRUE(metrics->videoDownload.has_value());
-    EXPECT_TRUE(metrics->audioDownload.has_value());
-    EXPECT_TRUE(metrics->videoSource.has_value());
-    EXPECT_TRUE(metrics->audioSource.has_value());
-    EXPECT_TRUE(metrics->videoDecode.has_value());
-    EXPECT_TRUE(metrics->audioDecode.has_value());
-    EXPECT_TRUE(metrics->preRoll.has_value());
-    EXPECT_TRUE(metrics->play.has_value());
-    EXPECT_TRUE(metrics->total.has_value());
-    EXPECT_TRUE(metrics->totalWithoutApp.has_value());
-}
-
-/**
  * Test that public API can be called multiple times.
  */
 TEST_F(GstProfilerTests, MultipleCalls)
@@ -612,6 +543,6 @@ TEST_F(GstProfilerTests, MultipleCalls)
         [[maybe_unused]] const auto id2 = m_gstProfiler->createRecord("AllSourcesAttached", "audio+video");
         m_gstProfiler->logRecord(1);
         m_gstProfiler->scheduleGstElementRecord(m_realElement);
-        m_gstProfiler->logPipeline();
+        m_gstProfiler->logPipelineSummary();
     });
 }

--- a/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
+++ b/tests/unittests/media/server/gstplayer/profiler/GstProfilerTests.cpp
@@ -131,7 +131,7 @@ TEST_F(GstProfilerTests, CreateWithNullPipeline)
 {
     setProfilerEnabledEnv(true);
     createGstProfiler();
-    EXPECT_TRUE(m_gstProfiler->isEnabled());
+    EXPECT_TRUE(m_gstProfiler->createRecord("CreateWithNullPipeline").has_value());
 }
 
 /**
@@ -141,7 +141,7 @@ TEST_F(GstProfilerTests, CreateWithPipeline)
 {
     setProfilerEnabledEnv(true);
     createGstProfiler(&m_pipeline);
-    EXPECT_TRUE(m_gstProfiler->isEnabled());
+    EXPECT_TRUE(m_gstProfiler->createRecord("CreateWithPipeline").has_value());
 }
 
 /**
@@ -243,7 +243,6 @@ TEST_F(GstProfilerTests, DisabledProfilerPreventsRecordCreationAndScheduling)
     setProfilerEnabledEnv(false);
     createGstProfiler();
 
-    EXPECT_FALSE(m_gstProfiler->isEnabled());
     EXPECT_FALSE(m_gstProfiler->createRecord("Pipeline Created").has_value());
 
     EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(m_realElement));
@@ -257,7 +256,7 @@ TEST_F(GstProfilerTests, EnabledProfilerAllowsScheduling)
     setProfilerEnabledEnv(true);
     EXPECT_NO_THROW(m_gstProfiler = std::make_unique<GstProfiler>(nullptr, m_gstWrapperMock, m_glibWrapperMock));
     ASSERT_NE(m_gstProfiler, nullptr);
-    ASSERT_TRUE(m_gstProfiler->isEnabled());
+    ASSERT_TRUE(m_gstProfiler->createRecord("EnabledProfilerAllowsScheduling").has_value());
 
     expectElementRecognizedAsSource(m_realElement);
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(m_realElement, StrEq("src"))).WillOnce(Return(nullptr));
@@ -305,13 +304,11 @@ TEST_F(GstProfilerTests, ScheduleElementRecord)
             [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
                GDestroyNotify destroyData) -> gulong
             {
-                if (destroyData)
-                {
-                    destroyData(userData);
-                }
+                EXPECT_EQ(destroyData, nullptr);
                 return 1;
             }));
 
+    EXPECT_CALL(*m_gstWrapperMock, gstPadRemoveProbe(&m_pad, 1));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_pad));
 
     EXPECT_NO_THROW(m_gstProfiler->scheduleGstElementRecord(m_realElement));
@@ -335,21 +332,16 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
     EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryListIsType(_, GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO))
         .WillOnce(Return(true));
 
+    GstPadProbeCallback callback = nullptr;
+    gpointer userData = nullptr;
     EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
         .WillOnce(Invoke(
-            [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
-               GDestroyNotify destroyData) -> gulong
+            [&callback, &userData](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback probeCallback,
+                                   gpointer probeUserData, GDestroyNotify destroyData) -> gulong
             {
-                GstBuffer *buffer = gst_buffer_new();
-                GstPadProbeInfo info{};
-                info.type = GST_PAD_PROBE_TYPE_BUFFER;
-                info.data = buffer;
-
-                EXPECT_EQ(callback(pad, &info, userData), GST_PAD_PROBE_REMOVE);
-
-                gst_buffer_unref(buffer);
-                if (destroyData)
-                    destroyData(userData);
+                callback = probeCallback;
+                userData = probeUserData;
+                EXPECT_EQ(destroyData, nullptr);
 
                 return 1;
             }));
@@ -358,7 +350,18 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfo)
 
     m_gstProfiler->scheduleGstElementRecord(m_realElement);
 
-    const auto &records = m_gstProfiler->getRecords();
+    ASSERT_NE(callback, nullptr);
+    ASSERT_NE(userData, nullptr);
+    GstBuffer *buffer = gst_buffer_new();
+    GstPadProbeInfo info{};
+    info.type = GST_PAD_PROBE_TYPE_BUFFER;
+    info.data = buffer;
+
+    EXPECT_EQ(callback(&m_pad, &info, userData), GST_PAD_PROBE_REMOVE);
+
+    gst_buffer_unref(buffer);
+
+    const auto records = m_gstProfiler->getRecords();
     ASSERT_FALSE(records.empty());
     EXPECT_EQ(records.back().stage, "Source FB Exit");
     EXPECT_EQ(records.back().info, "Video");
@@ -388,21 +391,16 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfoFro
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
     EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
 
+    GstPadProbeCallback callback = nullptr;
+    gpointer userData = nullptr;
     EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
         .WillOnce(Invoke(
-            [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
-               GDestroyNotify destroyData) -> gulong
+            [&callback, &userData](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback probeCallback,
+                                   gpointer probeUserData, GDestroyNotify destroyData) -> gulong
             {
-                GstBuffer *buffer = gst_buffer_new();
-                GstPadProbeInfo info{};
-                info.type = GST_PAD_PROBE_TYPE_BUFFER;
-                info.data = buffer;
-
-                EXPECT_EQ(callback(pad, &info, userData), GST_PAD_PROBE_REMOVE);
-
-                gst_buffer_unref(buffer);
-                if (destroyData)
-                    destroyData(userData);
+                callback = probeCallback;
+                userData = probeUserData;
+                EXPECT_EQ(destroyData, nullptr);
 
                 return 1;
             }));
@@ -411,7 +409,18 @@ TEST_F(GstProfilerTests, ScheduleElementRecordCreatesProbeRecordWithVideoInfoFro
 
     m_gstProfiler->scheduleGstElementRecord(m_realElement);
 
-    const auto &records = m_gstProfiler->getRecords();
+    ASSERT_NE(callback, nullptr);
+    ASSERT_NE(userData, nullptr);
+    GstBuffer *buffer = gst_buffer_new();
+    GstPadProbeInfo info{};
+    info.type = GST_PAD_PROBE_TYPE_BUFFER;
+    info.data = buffer;
+
+    EXPECT_EQ(callback(&m_pad, &info, userData), GST_PAD_PROBE_REMOVE);
+
+    gst_buffer_unref(buffer);
+
+    const auto records = m_gstProfiler->getRecords();
     ASSERT_FALSE(records.empty());
     EXPECT_EQ(records.back().stage, "Source FB Exit");
     EXPECT_EQ(records.back().info, "Video");
@@ -441,21 +450,16 @@ TEST_F(GstProfilerTests, ScheduleElementRecordFallsBackToRawElementName)
     EXPECT_CALL(*m_gstWrapperMock, gstElementGetName(m_realElement)).WillOnce(Return(rawName));
     EXPECT_CALL(*m_glibWrapperMock, gFree(rawName)).WillOnce(Invoke([](gpointer ptr) { g_free(ptr); }));
 
+    GstPadProbeCallback callback = nullptr;
+    gpointer userData = nullptr;
     EXPECT_CALL(*m_gstWrapperMock, gstPadAddProbe(&m_pad, _, _, _, _))
         .WillOnce(Invoke(
-            [](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
-               GDestroyNotify destroyData) -> gulong
+            [&callback, &userData](GstPad *pad, GstPadProbeType mask, GstPadProbeCallback probeCallback,
+                                   gpointer probeUserData, GDestroyNotify destroyData) -> gulong
             {
-                GstBuffer *buffer = gst_buffer_new();
-                GstPadProbeInfo info{};
-                info.type = GST_PAD_PROBE_TYPE_BUFFER;
-                info.data = buffer;
-
-                EXPECT_EQ(callback(pad, &info, userData), GST_PAD_PROBE_REMOVE);
-
-                gst_buffer_unref(buffer);
-                if (destroyData)
-                    destroyData(userData);
+                callback = probeCallback;
+                userData = probeUserData;
+                EXPECT_EQ(destroyData, nullptr);
 
                 return 1;
             }));
@@ -464,7 +468,18 @@ TEST_F(GstProfilerTests, ScheduleElementRecordFallsBackToRawElementName)
 
     m_gstProfiler->scheduleGstElementRecord(m_realElement);
 
-    const auto &records = m_gstProfiler->getRecords();
+    ASSERT_NE(callback, nullptr);
+    ASSERT_NE(userData, nullptr);
+    GstBuffer *buffer = gst_buffer_new();
+    GstPadProbeInfo info{};
+    info.type = GST_PAD_PROBE_TYPE_BUFFER;
+    info.data = buffer;
+
+    EXPECT_EQ(callback(&m_pad, &info, userData), GST_PAD_PROBE_REMOVE);
+
+    gst_buffer_unref(buffer);
+
+    const auto records = m_gstProfiler->getRecords();
     ASSERT_FALSE(records.empty());
     EXPECT_EQ(records.back().stage, "Source FB Exit");
     EXPECT_EQ(records.back().info, "custom-element");

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerFactoryMock.h
@@ -17,33 +17,29 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_SERVER_GST_PROFILER_MOCK_H_
-#define FIREBOLT_RIALTO_SERVER_GST_PROFILER_MOCK_H_
+#ifndef FIREBOLT_RIALTO_SERVER_GST_PROFILER_FACTORY_MOCK_H_
+#define FIREBOLT_RIALTO_SERVER_GST_PROFILER_FACTORY_MOCK_H_
 
 #include "IGstProfiler.h"
 
 #include <gmock/gmock.h>
-#include <optional>
-#include <string>
 
 namespace firebolt::rialto::server
 {
-class GstProfilerMock : public IGstProfiler
+class GstProfilerFactoryMock : public IGstProfilerFactory
 {
 public:
-    GstProfilerMock() = default;
-    ~GstProfilerMock() override = default;
+    using IGstWrapper = firebolt::rialto::wrappers::IGstWrapper;
+    using IGlibWrapper = firebolt::rialto::wrappers::IGlibWrapper;
 
-    MOCK_METHOD(bool, isEnabled, (), (const, override));
+    GstProfilerFactoryMock() = default;
+    ~GstProfilerFactoryMock() override = default;
 
-    MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage), (override));
-    MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage, std::string info), (override));
-
-    MOCK_METHOD(void, scheduleGstElementRecord, (GstElement * element), (override));
-
-    MOCK_METHOD(void, logRecord, (RecordId id), (override));
-    MOCK_METHOD(void, logPipeline, (), (const, override));
+    MOCK_METHOD(std::unique_ptr<IGstProfiler>, createGstProfiler,
+                (GstElement * pipeline, const std::shared_ptr<IGstWrapper> &gstWrapper,
+                 const std::shared_ptr<IGlibWrapper> &glibWrapper),
+                (const, override));
 };
 } // namespace firebolt::rialto::server
 
-#endif // FIREBOLT_RIALTO_SERVER_GST_PROFILER_MOCK_H_
+#endif // FIREBOLT_RIALTO_SERVER_GST_PROFILER_FACTORY_MOCK_H_

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerFactoryMock.h
@@ -23,6 +23,7 @@
 #include "IGstProfiler.h"
 
 #include <gmock/gmock.h>
+#include <memory>
 
 namespace firebolt::rialto::server
 {

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
@@ -17,24 +17,30 @@
  * limitations under the License.
  */
 
-#ifndef FIREBOLT_RIALTO_COMMON_PROFILER_FACTORY_MOCK_H_
-#define FIREBOLT_RIALTO_COMMON_PROFILER_FACTORY_MOCK_H_
+#ifndef FIREBOLT_RIALTO_SERVER_GST_PROFILER_MOCK_H_
+#define FIREBOLT_RIALTO_SERVER_GST_PROFILER_MOCK_H_
 
-#include "IProfiler.h"
+#include "IGstProfiler.h"
+
 #include <gmock/gmock.h>
-#include <memory>
+#include <optional>
 #include <string>
 
-namespace firebolt::rialto::common
+namespace firebolt::rialto::server
 {
-class ProfilerFactoryMock : public IProfilerFactory
+class GstProfilerMock : public IGstProfiler
 {
 public:
-    ProfilerFactoryMock() = default;
-    virtual ~ProfilerFactoryMock() = default;
+    GstProfilerMock() = default;
+    virtual ~GstProfilerMock() = default;
 
-    MOCK_METHOD(std::unique_ptr<IProfiler>, createProfiler, (std::string moduleName), (const, override));
+    MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage), (override));
+    MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage, std::string info), (override));
+
+    MOCK_METHOD(void, scheduleGstElementRecord, (GstElement * element), (override));
+
+    MOCK_METHOD(void, logRecord, (RecordId id), (override));
 };
-} // namespace firebolt::rialto::common
+} // namespace firebolt::rialto::server
 
-#endif // FIREBOLT_RIALTO_COMMON_PROFILER_FACTORY_MOCK_H_
+#endif // FIREBOLT_RIALTO_SERVER_GST_PROFILER_MOCK_H_

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
@@ -34,6 +34,10 @@ public:
     GstProfilerMock() = default;
     ~GstProfilerMock() override = default;
 
+    MOCK_METHOD(void, enable, (), (override));
+    MOCK_METHOD(void, disable, (), (override));
+    MOCK_METHOD(bool, isEnabled, (), (const, override));
+
     MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage), (override));
     MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage, std::string info), (override));
 

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
@@ -32,7 +32,7 @@ class GstProfilerMock : public IGstProfiler
 {
 public:
     GstProfilerMock() = default;
-    virtual ~GstProfilerMock() = default;
+    ~GstProfilerMock() override = default;
 
     MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage), (override));
     MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage, std::string info), (override));
@@ -40,6 +40,7 @@ public:
     MOCK_METHOD(void, scheduleGstElementRecord, (GstElement * element), (override));
 
     MOCK_METHOD(void, logRecord, (RecordId id), (override));
+    MOCK_METHOD(void, logPipeline, (), (const, override));
 };
 } // namespace firebolt::rialto::server
 

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
@@ -42,6 +42,7 @@ public:
     MOCK_METHOD(void, scheduleGstElementRecord, (GstElement * element), (override));
 
     MOCK_METHOD(void, logRecord, (RecordId id), (override));
+    MOCK_METHOD(void, dumpToFile, (), (const, override));
     MOCK_METHOD(void, logPipeline, (), (const, override));
 };
 } // namespace firebolt::rialto::server

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
@@ -37,15 +37,15 @@ public:
 
     MOCK_METHOD(bool, isEnabled, (), (const, override));
 
-    MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage), (override));
-    MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage, std::string info), (override));
+    MOCK_METHOD(std::optional<RecordId>, createRecord, (const std::string &stage), (override));
+    MOCK_METHOD(std::optional<RecordId>, createRecord, (const std::string &stage, const std::string &info), (override));
 
     MOCK_METHOD(void, scheduleGstElementRecord, (GstElement * element), (override));
     MOCK_METHOD((const std::vector<Record> &), getRecords, (), (const, override));
 
     MOCK_METHOD(void, logRecord, (RecordId id), (override));
     MOCK_METHOD(void, dumpToFile, (), (const, override));
-    MOCK_METHOD(void, logPipeline, (), (const, override));
+    MOCK_METHOD(void, logPipelineSummary, (), (const, override));
 };
 } // namespace firebolt::rialto::server
 

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
@@ -35,13 +35,11 @@ public:
     GstProfilerMock() = default;
     ~GstProfilerMock() override = default;
 
-    MOCK_METHOD(bool, isEnabled, (), (const, override));
-
     MOCK_METHOD(std::optional<RecordId>, createRecord, (const std::string &stage), (override));
     MOCK_METHOD(std::optional<RecordId>, createRecord, (const std::string &stage, const std::string &info), (override));
 
     MOCK_METHOD(void, scheduleGstElementRecord, (GstElement * element), (override));
-    MOCK_METHOD((const std::vector<Record> &), getRecords, (), (const, override));
+    MOCK_METHOD(std::vector<Record>, getRecords, (), (const, override));
 
     MOCK_METHOD(void, logRecord, (RecordId id), (override));
     MOCK_METHOD(void, dumpToFile, (), (const, override));

--- a/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstProfilerMock.h
@@ -25,6 +25,7 @@
 #include <gmock/gmock.h>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace firebolt::rialto::server
 {
@@ -40,6 +41,7 @@ public:
     MOCK_METHOD(std::optional<RecordId>, createRecord, (std::string stage, std::string info), (override));
 
     MOCK_METHOD(void, scheduleGstElementRecord, (GstElement * element), (override));
+    MOCK_METHOD((const std::vector<Record> &), getRecords, (), (const, override));
 
     MOCK_METHOD(void, logRecord, (RecordId id), (override));
     MOCK_METHOD(void, dumpToFile, (), (const, override));

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -616,6 +616,12 @@ public:
     gboolean gstBinRemove(GstBin *bin, GstElement *element) override { return gst_bin_remove(bin, element); }
 
     GstObject *gstPadGetParent(GstPad *pad) override { return gst_pad_get_parent(pad); }
+
+    gulong gstPadAddProbe(GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
+                          GDestroyNotify destroyData) override
+    {
+        return gst_pad_add_probe(pad, mask, callback, userData, destroyData);
+    }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -622,6 +622,8 @@ public:
     {
         return gst_pad_add_probe(pad, mask, callback, userData, destroyData);
     }
+
+    void gstPadRemoveProbe(GstPad *pad, gulong id) override { gst_pad_remove_probe(pad, id); }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -1490,6 +1490,14 @@ public:
      */
     virtual gulong gstPadAddProbe(GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
                                   GDestroyNotify destroyData) = 0;
+
+    /**
+     * @brief Removes a probe from the pad.
+     *
+     * @param[in] pad : The GstPad to remove the probe from.
+     * @param[in] id : The probe id returned by gstPadAddProbe.
+     */
+    virtual void gstPadRemoveProbe(GstPad *pad, gulong id) = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -1476,6 +1476,20 @@ public:
      * @retval The parent GstObject. Unref after usage. NULL if pad has no parent.
      */
     virtual GstObject *gstPadGetParent(GstPad *pad) = 0;
+
+    /**
+     * @brief Adds probe to the pad.
+     *
+     * @param[in] pad : The GstPad to add the probe to.
+     * @param[in] mask : The probe mask.
+     * @param[in] callback : GstPadProbeCallback that will be called with notifications of the pad state.
+     * @param[in] userData : User data passed to the callback.
+     * @param[in] destroyData : GDestroyNotify for user_data.
+     *
+     * @retval An id or 0 if no probe is pending. The id can be used to remove the probe with gst_pad_remove_probe.
+     */
+    virtual gulong gstPadAddProbe(GstPad *pad, GstPadProbeType mask, GstPadProbeCallback callback, gpointer userData,
+                                  GDestroyNotify destroyData) = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers


### PR DESCRIPTION
Summary: Added profiling to Rialto Server. IProfiler for use throughout server and IGstProfiler for use on server GST media pipeline. Added IGstProfiler method calls throughout media/server pipeline for recording points of interest. Added metrics calculation on top, with following one line log.
Type: Feature
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-11764