### PR TITLE
RDKEMW-15484: High CPU usage

### DIFF
--- a/ipc/server/include/IIpcServer.h
+++ b/ipc/server/include/IIpcServer.h
@@ -218,6 +218,13 @@ public:
     virtual bool wait(int timeoutMSecs) = 0;
 
     /**
+     * @brief Wakes any thread currently blocked in `wait()`.
+     *
+     * \\threadsafe
+     */
+    virtual void wake() const = 0;
+
+    /**
      * @brief This is the heart of the server, it is where we wait for new incoming
      * connections or data from clients, and send data back to clients.
      *

--- a/ipc/server/source/IpcServerImpl.cpp
+++ b/ipc/server/source/IpcServerImpl.cpp
@@ -443,6 +443,11 @@ bool ServerImpl::wait(int timeoutMSecs)
     return true;
 }
 
+void ServerImpl::wake() const
+{
+    wakeEventLoop();
+}
+
 bool ServerImpl::process()
 {
     if (m_pollFd < 0)

--- a/ipc/server/source/IpcServerImpl.h
+++ b/ipc/server/source/IpcServerImpl.h
@@ -75,6 +75,7 @@ public:
 
     int fd() const override;
     bool wait(int timeoutMSecs) override;
+    void wake() const override;
     bool process() override;
 
 protected:

--- a/media/server/ipc/source/SessionManagementServer.cpp
+++ b/media/server/ipc/source/SessionManagementServer.cpp
@@ -141,18 +141,32 @@ void SessionManagementServer::start()
     m_ipcServerThread = std::thread(
         [this]()
         {
-            constexpr int kPollInterval{100};
-            while (m_ipcServer->process() && m_isRunning.load())
+            while (m_isRunning.load())
             {
-                m_ipcServer->wait(kPollInterval);
+                if (!m_ipcServer->process())
+                {
+                    break;
+                }
+
+                if (m_isRunning.load())
+                {
+                    m_ipcServer->wait(-1);
+                }
             }
+
+            m_isRunning.store(false);
             RIALTO_SERVER_LOG_MIL("Session Management Server event loop finished.");
         });
 }
 
 void SessionManagementServer::stop()
 {
-    m_isRunning.store(false);
+    if (!m_isRunning.exchange(false) || !m_ipcServer)
+    {
+        return;
+    }
+
+    m_ipcServer->wake();
 }
 
 void SessionManagementServer::setLogLevels(RIALTO_DEBUG_LEVEL defaultLogLevels, RIALTO_DEBUG_LEVEL clientLogLevels,

--- a/tests/unittests/ipc/mocks/IpcServerMock.h
+++ b/tests/unittests/ipc/mocks/IpcServerMock.h
@@ -46,6 +46,7 @@ public:
                 (int socketFd, std::function<void(const std::shared_ptr<IClient> &)> clientDisconnectedCb), (override));
     MOCK_METHOD(int, fd, (), (override, const));
     MOCK_METHOD(bool, wait, (int timeoutMSecs), (override));
+    MOCK_METHOD(void, wake, (), (override, const));
     MOCK_METHOD(bool, process, (), (override));
 };
 } // namespace firebolt::rialto::ipc

--- a/tests/unittests/media/server/ipc/sessionManagementServer/SessionManagementServerTestsFixture.cpp
+++ b/tests/unittests/media/server/ipc/sessionManagementServer/SessionManagementServerTestsFixture.cpp
@@ -28,6 +28,7 @@
 #include "SessionManagementServer.h"
 #include "WebAudioPlayerModuleServiceFactoryMock.h"
 #include <fcntl.h>
+#include <future>
 #include <string>
 #include <sys/stat.h>
 #include <utility>
@@ -162,7 +163,15 @@ void SessionManagementServerTests::serverWillFailToInitializeWithFd()
 
 void SessionManagementServerTests::serverWillStart()
 {
-    EXPECT_CALL(*m_serverMock, process()).WillOnce(Return(false));
+    auto promise = std::make_shared<std::promise<void>>();
+    m_serverStartedFuture = promise->get_future();
+    EXPECT_CALL(*m_serverMock, process())
+        .WillOnce(Invoke(
+            [promise]()
+            {
+                promise->set_value();
+                return false;
+            }));
     EXPECT_CALL(*m_serverMock, wake()).Times(testing::AtMost(1));
 }
 
@@ -232,6 +241,7 @@ void SessionManagementServerTests::sendServerInitializeWithFdAndExpectFailure()
 void SessionManagementServerTests::sendServerStart()
 {
     m_sut->start();
+    m_serverStartedFuture.wait();
 }
 
 void SessionManagementServerTests::sendConnectClient()

--- a/tests/unittests/media/server/ipc/sessionManagementServer/SessionManagementServerTestsFixture.cpp
+++ b/tests/unittests/media/server/ipc/sessionManagementServer/SessionManagementServerTestsFixture.cpp
@@ -163,6 +163,7 @@ void SessionManagementServerTests::serverWillFailToInitializeWithFd()
 void SessionManagementServerTests::serverWillStart()
 {
     EXPECT_CALL(*m_serverMock, process()).WillOnce(Return(false));
+    EXPECT_CALL(*m_serverMock, wake()).Times(testing::AtMost(1));
 }
 
 void SessionManagementServerTests::clientWillConnect()

--- a/tests/unittests/media/server/ipc/sessionManagementServer/SessionManagementServerTestsFixture.h
+++ b/tests/unittests/media/server/ipc/sessionManagementServer/SessionManagementServerTestsFixture.h
@@ -34,6 +34,7 @@
 #include "PlaybackServiceMock.h"
 #include "WebAudioPlayerModuleServiceMock.h"
 #include "WebAudioPlayerServiceMock.h"
+#include <future>
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -84,6 +85,7 @@ private:
 
     std::function<void(const std::shared_ptr<firebolt::rialto::ipc::IClient> &)> m_clientConnectedCb;
     std::function<void(const std::shared_ptr<firebolt::rialto::ipc::IClient> &)> m_clientDisconnectedCb;
+    std::future<void> m_serverStartedFuture;
 };
 
 #endif // SESSION_MANAGEMENT_SERVER_TESTS_FIXTURE_H_


### PR DESCRIPTION
Summary: Replace polling loop with blocking wait and wake() in SessionManagementServer
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-15484