### PR TITLE
Removed blocking get_state calls from aml codec switch

### DIFF
--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -322,6 +322,61 @@ private:
     createAudioAttributes(const std::unique_ptr<IMediaPipeline::MediaSource> &source) const;
 
     /**
+     * @brief Configures audio caps based on audio attributes.
+     *        Called by worker thread only!
+     *
+     * @param[in]     pAttrib    : The audio attributes.
+     * @param[out]    audioaac   : Set to true if AAC, false otherwise.
+     * @param[in]     svpenabled : Whether SVP is enabled.
+     * @param[in,out] appsrcCaps : The caps to configure.
+     */
+    void configAudioCap(firebolt::rialto::wrappers::AudioAttributesPrivate *pAttrib, bool *audioaac, bool svpenabled,
+                        GstCaps **appsrcCaps);
+
+    /**
+     * @brief Halts audio playback by setting playsink to READY and decodebin to PAUSED.
+     *        Called by worker thread only!
+     */
+    void haltAudioPlayback();
+
+    /**
+     * @brief Resumes audio playback by syncing playsink and decodebin with parent.
+     *        Called by worker thread only!
+     */
+    void resumeAudioPlayback();
+
+    /**
+     * @brief First-time codec switch from AC3 to AAC when no decoder exists yet.
+     *        Called by worker thread only!
+     *
+     * @param[in] newAudioCaps : The new audio caps to apply.
+     */
+    void firstTimeSwitchFromAC3toAAC(GstCaps *newAudioCaps);
+
+    /**
+     * @brief Switches the audio codec by unlinking old parser/decoder and linking new ones.
+     *        Called by worker thread only!
+     *
+     * @param[in] isAudioAAC   : Whether the new codec is AAC.
+     * @param[in] newAudioCaps : The new audio caps to apply.
+     *
+     * @retval true if codec was switched, false if same codec.
+     */
+    bool switchAudioCodec(bool isAudioAAC, GstCaps *newAudioCaps);
+
+    /**
+     * @brief Top-level audio track codec channel switch, ported from rdk_gstreamer_utils_soc.
+     *        Called by worker thread only!
+     */
+    bool performAudioTrackCodecChannelSwitch(const void *pSampleAttr,
+                                             firebolt::rialto::wrappers::AudioAttributesPrivate *pAudioAttr,
+                                             uint32_t *pStatus, unsigned int *pui32Delay,
+                                             long long *pAudioChangeTargetPts, // NOLINT(runtime/int)
+                                             const long long *pcurrentDispPts, // NOLINT(runtime/int)
+                                             unsigned int *audioChangeStage, GstCaps **appsrcCaps, bool *audioaac,
+                                             bool svpenabled, GstElement *aSrc, bool *ret);
+
+    /**
      * @brief Sets text track position before pushing data
      *
      * @param[in] source : the subtitle media source

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -19,6 +19,8 @@
 
 #include <chrono>
 #include <cinttypes>
+#include <cstring>
+#include <ctime>
 #include <stdexcept>
 
 #include "FlushWatcher.h"
@@ -620,6 +622,466 @@ GstGenericPlayer::createAudioAttributes(const std::unique_ptr<IMediaPipeline::Me
     return audioAttributes;
 }
 
+void GstGenericPlayer::configAudioCap(firebolt::rialto::wrappers::AudioAttributesPrivate *pAttrib, bool *audioaac,
+                                      bool svpenabled, GstCaps **appsrcCaps)
+{
+    // this function comes from rdk_gstreamer_utils
+    if (!pAttrib || !audioaac || !appsrcCaps)
+    {
+        RIALTO_SERVER_LOG_ERROR("configAudioCap: invalid null parameter");
+        return;
+    }
+    gchar *capsString;
+    RIALTO_SERVER_LOG_DEBUG("Config audio codec %s sampling rate %d channel %d alignment %d",
+                            pAttrib->m_codecParam.c_str(), pAttrib->m_samplesPerSecond, pAttrib->m_numberOfChannels,
+                            pAttrib->m_blockAlignment);
+    if (pAttrib->m_codecParam.compare(0, 4, std::string("mp4a")) == 0)
+    {
+        RIALTO_SERVER_LOG_DEBUG("Using AAC");
+        capsString = m_glibWrapper->gStrdupPrintf("audio/mpeg, mpegversion=4, enable-svp=(string)%s",
+                                                  svpenabled ? "true" : "false");
+        *audioaac = true;
+    }
+    else
+    {
+        RIALTO_SERVER_LOG_DEBUG("Using EAC3");
+        capsString = m_glibWrapper->gStrdupPrintf("audio/x-eac3, framed=(boolean)true, rate=(int)%u, channels=(int)%u, "
+                                                  "alignment=(string)frame, enable-svp=(string)%s",
+                                                  pAttrib->m_samplesPerSecond, pAttrib->m_numberOfChannels,
+                                                  svpenabled ? "true" : "false");
+        *audioaac = false;
+    }
+    *appsrcCaps = m_gstWrapper->gstCapsFromString(capsString);
+    m_glibWrapper->gFree(capsString);
+}
+
+void GstGenericPlayer::haltAudioPlayback()
+{
+    // this function comes from rdk_gstreamer_utils
+    if (!m_context.playbackGroup.m_curAudioPlaysinkBin || !m_context.playbackGroup.m_curAudioDecodeBin)
+    {
+        RIALTO_SERVER_LOG_ERROR("haltAudioPlayback: audio playsink bin or decode bin is null");
+        return;
+    }
+    GstState currentState{GST_STATE_VOID_PENDING}, pending{GST_STATE_VOID_PENDING};
+
+    // Transition Playsink to Ready
+    if (GST_STATE_CHANGE_FAILURE ==
+        m_gstWrapper->gstElementSetState(m_context.playbackGroup.m_curAudioPlaysinkBin, GST_STATE_READY))
+    {
+        RIALTO_SERVER_LOG_WARN("Failed to set AudioPlaysinkBin to READY");
+        return;
+    }
+    m_gstWrapper->gstElementGetState(m_context.playbackGroup.m_curAudioPlaysinkBin, &currentState, &pending,
+                                     GST_CLOCK_TIME_NONE);
+    if (currentState == GST_STATE_PAUSED)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioPlaySinkBin State = %d", currentState);
+    // Transition Decodebin to Paused
+    if (GST_STATE_CHANGE_FAILURE ==
+        m_gstWrapper->gstElementSetState(m_context.playbackGroup.m_curAudioDecodeBin, GST_STATE_PAUSED))
+    {
+        RIALTO_SERVER_LOG_WARN("Failed to set AudioDecodeBin to PAUSED");
+        return;
+    }
+    m_gstWrapper->gstElementGetState(m_context.playbackGroup.m_curAudioDecodeBin, &currentState, &pending,
+                                     GST_CLOCK_TIME_NONE);
+    if (currentState == GST_STATE_PAUSED)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current DecodeBin State = %d", currentState);
+}
+
+void GstGenericPlayer::resumeAudioPlayback()
+{
+    // this function comes from rdk_gstreamer_utils
+    if (!m_context.playbackGroup.m_curAudioPlaysinkBin || !m_context.playbackGroup.m_curAudioDecodeBin)
+    {
+        RIALTO_SERVER_LOG_ERROR("resumeAudioPlayback: audio playsink bin or decode bin is null");
+        return;
+    }
+    GstState currentState{GST_STATE_VOID_PENDING}, pending{GST_STATE_VOID_PENDING};
+    m_gstWrapper->gstElementSyncStateWithParent(m_context.playbackGroup.m_curAudioPlaysinkBin);
+    m_gstWrapper->gstElementGetState(m_context.playbackGroup.m_curAudioPlaysinkBin, &currentState, &pending,
+                                     GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> AudioPlaysinkbin State = %d Pending = %d", currentState, pending);
+    m_gstWrapper->gstElementSyncStateWithParent(m_context.playbackGroup.m_curAudioDecodeBin);
+    m_gstWrapper->gstElementGetState(m_context.playbackGroup.m_curAudioDecodeBin, &currentState, &pending,
+                                     GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> Decodebin State = %d Pending = %d", currentState, pending);
+}
+
+void GstGenericPlayer::firstTimeSwitchFromAC3toAAC(GstCaps *newAudioCaps)
+{
+    // this function comes from rdk_gstreamer_utils
+    if (!m_context.playbackGroup.m_curAudioTypefind || !m_context.playbackGroup.m_curAudioDecodeBin)
+    {
+        RIALTO_SERVER_LOG_ERROR("firstTimeSwitchFromAC3toAAC: audio typefind or decode bin is null");
+        return;
+    }
+    GstState currentState{GST_STATE_VOID_PENDING}, pending{GST_STATE_VOID_PENDING};
+    GstPad *pTypfdSrcPad = NULL;
+    GstPad *pTypfdSrcPeerPad = NULL;
+    GstPad *pNewAudioDecoderSrcPad = NULL;
+    GstElement *newAudioParse = NULL;
+    GstElement *newAudioDecoder = NULL;
+    GstElement *newQueue = NULL;
+    gboolean linkRet = false;
+
+    /* Get the SinkPad of ASink - pTypfdSrcPeerPad */
+    if ((pTypfdSrcPad = m_gstWrapper->gstElementGetStaticPad(m_context.playbackGroup.m_curAudioTypefind, "src")) !=
+        NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current Typefind SrcPad = %p", pTypfdSrcPad);
+    if ((pTypfdSrcPeerPad = m_gstWrapper->gstPadGetPeer(pTypfdSrcPad)) != NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current Typefind Src Downstream Element Pad = %p", pTypfdSrcPeerPad);
+    // AudioDecoder Downstream Unlink
+    if (m_gstWrapper->gstPadUnlink(pTypfdSrcPad, pTypfdSrcPeerPad) == FALSE)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Typefind Downstream Unlink Failed");
+    newAudioParse = m_gstWrapper->gstElementFactoryMake("aacparse", "aacparse");
+    newAudioDecoder = m_gstWrapper->gstElementFactoryMake("avdec_aac", "avdec_aac");
+    newQueue = m_gstWrapper->gstElementFactoryMake("queue", "aqueue");
+    // Add new Decoder to Decodebin
+    if (m_gstWrapper->gstBinAdd(GST_BIN(m_context.playbackGroup.m_curAudioDecodeBin.load()), newAudioDecoder) == TRUE)
+    {
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Added New AudioDecoder = %p", newAudioDecoder);
+    }
+    // Add new Parser to Decodebin
+    if (m_gstWrapper->gstBinAdd(GST_BIN(m_context.playbackGroup.m_curAudioDecodeBin.load()), newAudioParse) == TRUE)
+    {
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Added New AudioParser = %p", newAudioParse);
+    }
+    // Add new Queue to Decodebin
+    if (m_gstWrapper->gstBinAdd(GST_BIN(m_context.playbackGroup.m_curAudioDecodeBin.load()), newQueue) == TRUE)
+    {
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Added New queue = %p", newQueue);
+    }
+    if ((pNewAudioDecoderSrcPad = m_gstWrapper->gstElementGetStaticPad(newAudioDecoder, "src")) != NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder Src Pad = %p", pNewAudioDecoderSrcPad);
+    // Connect decoder to ASINK
+    if (m_gstWrapper->gstPadLink(pNewAudioDecoderSrcPad, pTypfdSrcPeerPad) != GST_PAD_LINK_OK)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder Downstream Link Failed");
+    linkRet = m_gstWrapper->gstElementLink(newAudioParse, newQueue) &&
+              m_gstWrapper->gstElementLink(newQueue, newAudioDecoder);
+    if (!linkRet)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Downstream Link Failed for typefind, parser, decoder");
+    /* Force Caps */
+    RIALTO_SERVER_LOG_DEBUG("OTF -> Typefind Setting to READY");
+    if (GST_STATE_CHANGE_FAILURE ==
+        m_gstWrapper->gstElementSetState(m_context.playbackGroup.m_curAudioTypefind, GST_STATE_READY))
+    {
+        RIALTO_SERVER_LOG_WARN("Failed to set Typefind to READY");
+        m_gstWrapper->gstObjectUnref(pTypfdSrcPad);
+        m_gstWrapper->gstObjectUnref(pTypfdSrcPeerPad);
+        m_gstWrapper->gstObjectUnref(pNewAudioDecoderSrcPad);
+        return;
+    }
+    m_glibWrapper->gObjectSet(G_OBJECT(m_context.playbackGroup.m_curAudioTypefind), "force-caps", newAudioCaps, NULL);
+    m_gstWrapper->gstElementSyncStateWithParent(m_context.playbackGroup.m_curAudioTypefind);
+    m_gstWrapper->gstElementGetState(m_context.playbackGroup.m_curAudioTypefind, &currentState, &pending,
+                                     GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> New Typefind State = %d Pending = %d", currentState, pending);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> Typefind Syncing with Parent");
+    m_context.playbackGroup.m_linkTypefindParser = true;
+    /* Update the state */
+    m_gstWrapper->gstElementSyncStateWithParent(newAudioDecoder);
+    m_gstWrapper->gstElementGetState(newAudioDecoder, &currentState, &pending, GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder State = %d Pending = %d", currentState, pending);
+    m_gstWrapper->gstElementSyncStateWithParent(newQueue);
+    m_gstWrapper->gstElementGetState(newQueue, &currentState, &pending, GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> New queue State = %d Pending = %d", currentState, pending);
+    m_gstWrapper->gstElementSyncStateWithParent(newAudioParse);
+    m_gstWrapper->gstElementGetState(newAudioParse, &currentState, &pending, GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioParser State = %d Pending = %d", currentState, pending);
+    m_gstWrapper->gstObjectUnref(pTypfdSrcPad);
+    m_gstWrapper->gstObjectUnref(pTypfdSrcPeerPad);
+    m_gstWrapper->gstObjectUnref(pNewAudioDecoderSrcPad);
+    return;
+}
+
+bool GstGenericPlayer::switchAudioCodec(bool isAudioAAC, GstCaps *newAudioCaps)
+{ // this function comes from rdk_gstreamer_utils
+    bool ret = false;
+    RIALTO_SERVER_LOG_DEBUG("Current Audio Codec AAC = %d Same as Incoming audio Codec AAC = %d",
+                            m_context.playbackGroup.m_isAudioAAC, isAudioAAC);
+    if (m_context.playbackGroup.m_isAudioAAC == isAudioAAC)
+    {
+        return ret;
+    }
+    if ((m_context.playbackGroup.m_curAudioDecoder == NULL) && (!(m_context.playbackGroup.m_isAudioAAC)) && (isAudioAAC))
+    {
+        firstTimeSwitchFromAC3toAAC(newAudioCaps);
+        m_context.playbackGroup.m_isAudioAAC = isAudioAAC;
+        return true;
+    }
+    if (!m_context.playbackGroup.m_curAudioDecoder || !m_context.playbackGroup.m_curAudioParse ||
+        !m_context.playbackGroup.m_curAudioDecodeBin)
+    {
+        RIALTO_SERVER_LOG_ERROR("switchAudioCodec: audio decoder, parser or decode bin is null");
+        return false;
+    }
+    GstElement *newAudioParse = NULL;
+    GstElement *newAudioDecoder = NULL;
+    GstPad *newAudioParseSrcPad = NULL;
+    GstPad *newAudioParseSinkPad = NULL;
+    GstPad *newAudioDecoderSrcPad = NULL;
+    GstPad *newAudioDecoderSinkPad = NULL;
+    GstPad *audioDecSrcPad = NULL;
+    GstPad *audioDecSinkPad = NULL;
+    GstPad *audioDecSrcPeerPad = NULL;
+    GstPad *audioDecSinkPeerPad = NULL;
+    GstPad *audioParseSrcPad = NULL;
+    GstPad *audioParseSinkPad = NULL;
+    GstPad *audioParseSrcPeerPad = NULL;
+    GstPad *audioParseSinkPeerPad = NULL;
+    GstState currentState{GST_STATE_VOID_PENDING}, pending{GST_STATE_VOID_PENDING};
+
+    // Get AudioDecoder Src Pads
+    if ((audioDecSrcPad = m_gstWrapper->gstElementGetStaticPad(m_context.playbackGroup.m_curAudioDecoder, "src")) !=
+        NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioDecoder Src Pad = %p", audioDecSrcPad);
+    // Get AudioDecoder Sink Pads
+    if ((audioDecSinkPad = m_gstWrapper->gstElementGetStaticPad(m_context.playbackGroup.m_curAudioDecoder, "sink")) !=
+        NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioDecoder Sink Pad = %p", audioDecSinkPad);
+    // Get AudioDecoder Src Peer i.e. Downstream Element Pad
+    if ((audioDecSrcPeerPad = m_gstWrapper->gstPadGetPeer(audioDecSrcPad)) != NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioDecoder Src Downstream Element Pad = %p", audioDecSrcPeerPad);
+    // Get AudioDecoder Sink Peer i.e. Upstream Element Pad
+    if ((audioDecSinkPeerPad = m_gstWrapper->gstPadGetPeer(audioDecSinkPad)) != NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioDecoder Sink Upstream Element Pad = %p", audioDecSinkPeerPad);
+    // Get AudioParser Src Pads
+    if ((audioParseSrcPad = m_gstWrapper->gstElementGetStaticPad(m_context.playbackGroup.m_curAudioParse, "src")) !=
+        NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioParser Src Pad = %p", audioParseSrcPad);
+    // Get AudioParser Sink Pads
+    if ((audioParseSinkPad = m_gstWrapper->gstElementGetStaticPad(m_context.playbackGroup.m_curAudioParse, "sink")) !=
+        NULL) // Unref the Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioParser Sink Pad = %p", audioParseSinkPad);
+    // Get AudioParser Src Peer i.e. Downstream Element Pad
+    if ((audioParseSrcPeerPad = m_gstWrapper->gstPadGetPeer(audioParseSrcPad)) != NULL) // Unref the Peer Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioParser Src Downstream Element Pad = %p", audioParseSrcPeerPad);
+    // Get AudioParser Sink Peer i.e. Upstream Element Pad
+    if ((audioParseSinkPeerPad = m_gstWrapper->gstPadGetPeer(audioParseSinkPad)) != NULL) // Unref the Peer Pad
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioParser Sink Upstream Element Pad = %p", audioParseSinkPeerPad);
+    // AudioDecoder Downstream Unlink
+    if (m_gstWrapper->gstPadUnlink(audioDecSrcPad, audioDecSrcPeerPad) == FALSE)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> AudioDecoder Downstream Unlink Failed");
+    // AudioDecoder Upstream Unlink
+    if (m_gstWrapper->gstPadUnlink(audioDecSinkPeerPad, audioDecSinkPad) == FALSE)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> AudioDecoder Upstream Unlink Failed");
+    // AudioParser Downstream Unlink
+    if (m_gstWrapper->gstPadUnlink(audioParseSrcPad, audioParseSrcPeerPad) == FALSE)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> AudioParser Downstream Unlink Failed");
+    // AudioParser Upstream Unlink
+    if (m_gstWrapper->gstPadUnlink(audioParseSinkPeerPad, audioParseSinkPad) == FALSE)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> AudioParser Upstream Unlink Failed");
+    // Current Audio Decoder NULL
+    if (GST_STATE_CHANGE_FAILURE ==
+        m_gstWrapper->gstElementSetState(m_context.playbackGroup.m_curAudioDecoder, GST_STATE_NULL))
+    {
+        RIALTO_SERVER_LOG_WARN("Failed to set AudioDecoder to NULL");
+    }
+    m_gstWrapper->gstElementGetState(m_context.playbackGroup.m_curAudioDecoder, &currentState, &pending,
+                                     GST_CLOCK_TIME_NONE);
+    if (currentState == GST_STATE_NULL)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioDecoder State = %d", currentState);
+    // Current Audio Parser NULL
+    if (GST_STATE_CHANGE_FAILURE ==
+        m_gstWrapper->gstElementSetState(m_context.playbackGroup.m_curAudioParse, GST_STATE_NULL))
+    {
+        RIALTO_SERVER_LOG_WARN("Failed to set AudioParser to NULL");
+    }
+    m_gstWrapper->gstElementGetState(m_context.playbackGroup.m_curAudioParse, &currentState, &pending,
+                                     GST_CLOCK_TIME_NONE);
+    if (currentState == GST_STATE_NULL)
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Current AudioParser State = %d", currentState);
+    // Remove Audio Decoder From Decodebin
+    if (m_gstWrapper->gstBinRemove(GST_BIN(m_context.playbackGroup.m_curAudioDecodeBin.load()),
+                                   m_context.playbackGroup.m_curAudioDecoder) == TRUE)
+    {
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Removed AudioDecoder = %p", m_context.playbackGroup.m_curAudioDecoder);
+        m_context.playbackGroup.m_curAudioDecoder = NULL;
+    }
+    // Remove Audio Parser From Decodebin
+    if (m_gstWrapper->gstBinRemove(GST_BIN(m_context.playbackGroup.m_curAudioDecodeBin.load()),
+                                   m_context.playbackGroup.m_curAudioParse) == TRUE)
+    {
+        RIALTO_SERVER_LOG_DEBUG("OTF -> Removed AudioParser = %p", m_context.playbackGroup.m_curAudioParse);
+        m_context.playbackGroup.m_curAudioParse = NULL;
+    }
+    // Create new Audio Decoder and Parser. The inverse of the current
+    if (m_context.playbackGroup.m_isAudioAAC)
+    {
+        newAudioParse = m_gstWrapper->gstElementFactoryMake("ac3parse", "ac3parse");
+        newAudioDecoder = m_gstWrapper->gstElementFactoryMake("identity", "fake_aud_ac3dec");
+    }
+    else
+    {
+        newAudioParse = m_gstWrapper->gstElementFactoryMake("aacparse", "aacparse");
+        newAudioDecoder = m_gstWrapper->gstElementFactoryMake("avdec_aac", "avdec_aac");
+    }
+    {
+        GstPadLinkReturn gstPadLinkRet = GST_PAD_LINK_OK;
+        GstElement *audioParseUpstreamEl = NULL;
+        // Add new Decoder to Decodebin
+        if (m_gstWrapper->gstBinAdd(GST_BIN(m_context.playbackGroup.m_curAudioDecodeBin.load()), newAudioDecoder) == TRUE)
+        {
+            RIALTO_SERVER_LOG_DEBUG("OTF -> Added New AudioDecoder = %p", newAudioDecoder);
+        }
+        // Add new Parser to Decodebin
+        if (m_gstWrapper->gstBinAdd(GST_BIN(m_context.playbackGroup.m_curAudioDecodeBin.load()), newAudioParse) == TRUE)
+        {
+            RIALTO_SERVER_LOG_DEBUG("OTF -> Added New AudioParser = %p", newAudioParse);
+        }
+        if ((newAudioDecoderSrcPad = m_gstWrapper->gstElementGetStaticPad(newAudioDecoder, "src")) !=
+            NULL) // Unref the Pad
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder Src Pad = %p", newAudioDecoderSrcPad);
+        if ((newAudioDecoderSinkPad = m_gstWrapper->gstElementGetStaticPad(newAudioDecoder, "sink")) !=
+            NULL) // Unref the Pad
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder Sink Pad = %p", newAudioDecoderSinkPad);
+        // Link New Decoder to Downstream followed by UpStream
+        if ((gstPadLinkRet = m_gstWrapper->gstPadLink(newAudioDecoderSrcPad, audioDecSrcPeerPad)) != GST_PAD_LINK_OK)
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder Downstream Link Failed");
+        if ((gstPadLinkRet = m_gstWrapper->gstPadLink(audioDecSinkPeerPad, newAudioDecoderSinkPad)) != GST_PAD_LINK_OK)
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder Upstream Link Failed");
+        if ((newAudioParseSrcPad = m_gstWrapper->gstElementGetStaticPad(newAudioParse, "src")) != NULL) // Unref the Pad
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioParser Src Pad = %p", newAudioParseSrcPad);
+        if ((newAudioParseSinkPad = m_gstWrapper->gstElementGetStaticPad(newAudioParse, "sink")) != NULL) // Unref the Pad
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioParser Sink Pad = %p", newAudioParseSinkPad);
+        // Link New Parser to Downstream followed by UpStream
+        if ((gstPadLinkRet = m_gstWrapper->gstPadLink(newAudioParseSrcPad, audioParseSrcPeerPad)) != GST_PAD_LINK_OK)
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioParser Downstream Link Failed %d", gstPadLinkRet);
+        if ((audioParseUpstreamEl = GST_ELEMENT_CAST(m_gstWrapper->gstPadGetParent(audioParseSinkPeerPad))) ==
+            m_context.playbackGroup.m_curAudioTypefind)
+        {
+            RIALTO_SERVER_LOG_DEBUG("OTF -> Typefind Setting to READY");
+            if (GST_STATE_CHANGE_FAILURE == m_gstWrapper->gstElementSetState(audioParseUpstreamEl, GST_STATE_READY))
+            {
+                RIALTO_SERVER_LOG_WARN("Failed to set Typefind to READY in switchAudioCodec");
+            }
+            m_glibWrapper->gObjectSet(G_OBJECT(audioParseUpstreamEl), "force-caps", newAudioCaps, NULL);
+            m_gstWrapper->gstElementSyncStateWithParent(audioParseUpstreamEl);
+            m_gstWrapper->gstElementGetState(audioParseUpstreamEl, &currentState, &pending, GST_CLOCK_TIME_NONE);
+            RIALTO_SERVER_LOG_DEBUG("OTF -> New Typefind State = %d Pending = %d", currentState, pending);
+            RIALTO_SERVER_LOG_DEBUG("OTF -> Typefind Syncing with Parent");
+            m_context.playbackGroup.m_linkTypefindParser = true;
+            m_gstWrapper->gstObjectUnref(audioParseUpstreamEl);
+        }
+        m_gstWrapper->gstObjectUnref(newAudioDecoderSrcPad);
+        m_gstWrapper->gstObjectUnref(newAudioDecoderSinkPad);
+        m_gstWrapper->gstObjectUnref(newAudioParseSrcPad);
+        m_gstWrapper->gstObjectUnref(newAudioParseSinkPad);
+    }
+    m_gstWrapper->gstObjectUnref(audioParseSinkPeerPad);
+    m_gstWrapper->gstObjectUnref(audioParseSrcPeerPad);
+    m_gstWrapper->gstObjectUnref(audioParseSinkPad);
+    m_gstWrapper->gstObjectUnref(audioParseSrcPad);
+    m_gstWrapper->gstObjectUnref(audioDecSinkPeerPad);
+    m_gstWrapper->gstObjectUnref(audioDecSrcPeerPad);
+    m_gstWrapper->gstObjectUnref(audioDecSinkPad);
+    m_gstWrapper->gstObjectUnref(audioDecSrcPad);
+    m_gstWrapper->gstElementSyncStateWithParent(newAudioDecoder);
+    m_gstWrapper->gstElementGetState(newAudioDecoder, &currentState, &pending, GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioDecoder State = %d Pending = %d", currentState, pending);
+    m_gstWrapper->gstElementSyncStateWithParent(newAudioParse);
+    m_gstWrapper->gstElementGetState(newAudioParse, &currentState, &pending, GST_CLOCK_TIME_NONE);
+    RIALTO_SERVER_LOG_DEBUG("OTF -> New AudioParser State = %d Pending = %d", currentState, pending);
+    m_context.playbackGroup.m_isAudioAAC = isAudioAAC;
+    return true;
+}
+
+bool GstGenericPlayer::performAudioTrackCodecChannelSwitch(const void *pSampleAttr,
+                                                           firebolt::rialto::wrappers::AudioAttributesPrivate *pAudioAttr,
+                                                           uint32_t *pStatus, unsigned int *pui32Delay,
+                                                           long long *pAudioChangeTargetPts, // NOLINT(runtime/int)
+                                                           const long long *pcurrentDispPts, // NOLINT(runtime/int)
+                                                           unsigned int *audioChangeStage, GstCaps **appsrcCaps,
+                                                           bool *audioaac, bool svpenabled, GstElement *aSrc, bool *ret)
+{
+    // this function comes from rdk_gstreamer_utils
+    if (!pStatus || !pui32Delay || !pAudioChangeTargetPts || !pcurrentDispPts || !audioChangeStage || !appsrcCaps ||
+        !audioaac || !aSrc || !ret)
+    {
+        RIALTO_SERVER_LOG_ERROR("performAudioTrackCodecChannelSwitch: invalid null parameter");
+        return false;
+    }
+
+    constexpr uint32_t kOk = 0;
+    constexpr uint32_t kWaitWhileIdling = 100;
+    constexpr int kAudioChangeGapThresholdMS = 40;
+    constexpr unsigned int kAudchgAlign = 3;
+
+    struct timespec ts, now;
+    unsigned int reconfigDelayMs;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    if (*pStatus != kOk || pSampleAttr == nullptr)
+    {
+        RIALTO_SERVER_LOG_DEBUG("No audio data ready yet");
+        *pui32Delay = kWaitWhileIdling;
+        *ret = false;
+        return true;
+    }
+    RIALTO_SERVER_LOG_DEBUG("Received first audio packet after a flush, PTS");
+    if (pAudioAttr)
+    {
+        const char *pCodecStr = pAudioAttr->m_codecParam.c_str();
+        const char *pCodecAcc = strstr(pCodecStr, "mp4a");
+        bool isAudioAAC = (pCodecAcc) ? true : false;
+        bool isCodecSwitch = false;
+        RIALTO_SERVER_LOG_DEBUG("Audio Attribute format %s channel %d samp %d, bitrate %d blockAlignment %d", pCodecStr,
+                                pAudioAttr->m_numberOfChannels, pAudioAttr->m_samplesPerSecond, pAudioAttr->m_bitrate,
+                                pAudioAttr->m_blockAlignment);
+        *pAudioChangeTargetPts = *pcurrentDispPts;
+        *audioChangeStage = kAudchgAlign;
+        if (*appsrcCaps)
+        {
+            m_gstWrapper->gstCapsUnref(*appsrcCaps);
+            *appsrcCaps = NULL;
+        }
+        if (isAudioAAC != *audioaac)
+            isCodecSwitch = true;
+        configAudioCap(pAudioAttr, audioaac, svpenabled, appsrcCaps);
+        {
+            gboolean sendRet = FALSE;
+            GstEvent *flushStart = NULL;
+            GstEvent *flushStop = NULL;
+            flushStart = m_gstWrapper->gstEventNewFlushStart();
+            sendRet = m_gstWrapper->gstElementSendEvent(aSrc, flushStart);
+            if (!sendRet)
+                RIALTO_SERVER_LOG_DEBUG("failed to send flush-start event");
+            flushStop = m_gstWrapper->gstEventNewFlushStop(TRUE);
+            sendRet = m_gstWrapper->gstElementSendEvent(aSrc, flushStop);
+            if (!sendRet)
+                RIALTO_SERVER_LOG_DEBUG("failed to send flush-stop event");
+        }
+        if (!isCodecSwitch)
+        {
+            m_gstWrapper->gstAppSrcSetCaps(GST_APP_SRC(aSrc), *appsrcCaps);
+        }
+        else
+        {
+            RIALTO_SERVER_LOG_DEBUG("CODEC SWITCH mAudioAAC = %d", *audioaac);
+            haltAudioPlayback();
+            if (switchAudioCodec(*audioaac, *appsrcCaps) == false)
+            {
+                RIALTO_SERVER_LOG_DEBUG("CODEC SWITCH FAILED switchAudioCodec mAudioAAC = %d", *audioaac);
+            }
+            m_gstWrapper->gstAppSrcSetCaps(GST_APP_SRC(aSrc), *appsrcCaps);
+            resumeAudioPlayback();
+        }
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        reconfigDelayMs = now.tv_nsec > ts.tv_nsec ? (now.tv_nsec - ts.tv_nsec) / 1000000
+                                                   : (1000 - (ts.tv_nsec - now.tv_nsec) / 1000000);
+        (*pAudioChangeTargetPts) += (reconfigDelayMs + kAudioChangeGapThresholdMS);
+    }
+    else
+    {
+        RIALTO_SERVER_LOG_DEBUG("first audio after change no attribute drop!");
+        *pui32Delay = 0;
+        *ret = false;
+        return true;
+    }
+    *ret = true;
+    return true;
+}
+
 bool GstGenericPlayer::setImmediateOutput(const MediaSourceType &mediaSourceType, bool immediateOutputParam)
 {
     if (!m_workerThread)
@@ -1055,9 +1517,24 @@ bool GstGenericPlayer::reattachSource(const std::unique_ptr<IMediaPipeline::Medi
     GstCaps *caps{createCapsFromMediaSource(m_gstWrapper, m_glibWrapper, source)};
     GstAppSrc *appSrc{GST_APP_SRC(m_context.streamInfo[source->getType()].appSrc)};
     GstCaps *oldCaps = m_gstWrapper->gstAppSrcGetCaps(appSrc);
+
     if ((!oldCaps) || (!m_gstWrapper->gstCapsIsEqual(caps, oldCaps)))
     {
         RIALTO_SERVER_LOG_DEBUG("Caps not equal. Perform audio track codec channel switch.");
+
+        GstElement *sink = getSink(MediaSourceType::AUDIO);
+        if (!sink)
+        {
+            RIALTO_SERVER_LOG_ERROR("Failed to get audio sink");
+            if (caps)
+                m_gstWrapper->gstCapsUnref(caps);
+            if (oldCaps)
+                m_gstWrapper->gstCapsUnref(oldCaps);
+            return false;
+        }
+        std::string sinkName = GST_ELEMENT_NAME(sink);
+        m_gstWrapper->gstObjectUnref(sink);
+
         int sampleAttributes{
             0}; // rdk_gstreamer_utils::performAudioTrackCodecChannelSwitch checks if this param != NULL only.
         std::uint32_t status{0};   // must be 0 to make rdk_gstreamer_utils::performAudioTrackCodecChannelSwitch work
@@ -1071,14 +1548,28 @@ bool GstGenericPlayer::reattachSource(const std::unique_ptr<IMediaPipeline::Medi
         bool audioAac{oldCapsStr.find("audio/mpeg") != std::string::npos};
         bool svpEnabled{true}; // assume always true
         bool retVal{false};    // Output param. Set to TRUE in rdk_gstreamer_utils function stub
-        bool result =
-            m_rdkGstreamerUtilsWrapper
-                ->performAudioTrackCodecChannelSwitch(&m_context.playbackGroup, &sampleAttributes, &(*audioAttributes),
-                                                      &status, &ui32Delay, &audioChangeTargetPts, &currentDispPts,
-                                                      &audioChangeStage,
-                                                      &caps, // may fail for amlogic - that implementation changes
-                                                             // this parameter, it's probably used by Netflix later
-                                                      &audioAac, svpEnabled, GST_ELEMENT(appSrc), &retVal);
+
+        bool result = false;
+        RIALTO_SERVER_LOG_MIL("Changing audio source. Sink name: %s, old caps: %s, new codec: %s", sinkName.c_str(),
+                              oldCapsStr.c_str(), audioAttributes->m_codecParam.c_str());
+        if (m_glibWrapper->gStrHasPrefix(sinkName.c_str(), "amlhalasink"))
+        {
+            // due to problems audio codec change in prerolling, temporarily moved the code from rdk gstreamer utils to
+            // Rialto and applied fixes
+            result = performAudioTrackCodecChannelSwitch(&sampleAttributes, &(*audioAttributes), &status, &ui32Delay,
+                                                         &audioChangeTargetPts, &currentDispPts, &audioChangeStage,
+                                                         &caps, &audioAac, svpEnabled, GST_ELEMENT(appSrc), &retVal);
+        }
+        else
+        {
+            result = m_rdkGstreamerUtilsWrapper->performAudioTrackCodecChannelSwitch(&m_context.playbackGroup,
+                                                                                     &sampleAttributes,
+                                                                                     &(*audioAttributes), &status,
+                                                                                     &ui32Delay, &audioChangeTargetPts,
+                                                                                     &currentDispPts, &audioChangeStage,
+                                                                                     &caps, &audioAac, svpEnabled,
+                                                                                     GST_ELEMENT(appSrc), &retVal);
+        }
 
         if (!result || !retVal)
         {

--- a/tests/common/externalLibraryMocks/GstWrapperMock.h
+++ b/tests/common/externalLibraryMocks/GstWrapperMock.h
@@ -220,6 +220,13 @@ public:
     MOCK_METHOD(gboolean, gstIsBaseParse, (GstElement * element), (const, override));
     MOCK_METHOD(void, gstBaseParseSetPtsInterpolation, (GstBaseParse * parse, gboolean ptsInterpolate),
                 (const, override));
+    MOCK_METHOD(GstStateChangeReturn, gstElementGetState,
+                (GstElement * element, GstState *state, GstState *pending, GstClockTime timeout), (override));
+    MOCK_METHOD(GstPad *, gstPadGetPeer, (GstPad * pad), (override));
+    MOCK_METHOD(gboolean, gstPadUnlink, (GstPad * srcpad, GstPad *sinkpad), (override));
+    MOCK_METHOD(GstPadLinkReturn, gstPadLink, (GstPad * srcpad, GstPad *sinkpad), (override));
+    MOCK_METHOD(gboolean, gstBinRemove, (GstBin * bin, GstElement *element), (override));
+    MOCK_METHOD(GstObject *, gstPadGetParent, (GstPad * pad), (override));
 
     GstCaps *gstCapsNewSimple(const char *media_type, const char *fieldname, ...) const override
     {

--- a/tests/componenttests/server/tests/mediaPipeline/AudioSourceSwitchTest.cpp
+++ b/tests/componenttests/server/tests/mediaPipeline/AudioSourceSwitchTest.cpp
@@ -26,6 +26,8 @@
 #include "MessageBuilders.h"
 
 using testing::_;
+using testing::AtLeast;
+using testing::Invoke;
 using testing::Return;
 using testing::StrEq;
 
@@ -39,11 +41,20 @@ namespace firebolt::rialto::server::ct
 class AudioSourceSwitchTest : public MediaPipelineTest
 {
 public:
-    AudioSourceSwitchTest() = default;
-    ~AudioSourceSwitchTest() = default;
+    AudioSourceSwitchTest() { m_audioSink = gst_element_factory_make("fakesrc", nullptr); }
+    ~AudioSourceSwitchTest() override { gst_object_unref(m_audioSink); }
 
     void willSwitchAudioSource()
     {
+        EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+            .WillOnce(Invoke(
+                [this](gpointer object, const gchar *first_property_name, void *element)
+                {
+                    GstElement **elementPtr = reinterpret_cast<GstElement **>(element);
+                    *elementPtr = m_audioSink;
+                }));
+        EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(m_audioSink)).Times(AtLeast(0));
+        EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(m_audioSink))).WillRepeatedly(Return("audio_sink"));
         EXPECT_CALL(*m_gstWrapperMock, gstCapsNewEmptySimple(StrEq("audio/mpeg"))).WillOnce(Return(&m_audioCaps));
         EXPECT_CALL(*m_gstWrapperMock,
                     gstCapsSetSimpleStringStub(&m_audioCaps, StrEq("alignment"), G_TYPE_STRING, StrEq("nal")));
@@ -61,6 +72,7 @@ public:
         EXPECT_CALL(*m_gstWrapperMock, gstCapsIsEqual(&m_audioCaps, &m_oldCaps)).WillOnce(Return(FALSE));
         EXPECT_CALL(*m_gstWrapperMock, gstCapsToString(&m_oldCaps)).WillOnce(Return(&m_oldCapsStr));
         EXPECT_CALL(*m_glibWrapperMock, gFree(&m_oldCapsStr));
+        EXPECT_CALL(*m_glibWrapperMock, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
         EXPECT_CALL(*m_rdkGstreamerUtilsWrapperMock,
                     performAudioTrackCodecChannelSwitch(_, _, _, _, _, _, _, _, _, _, kSvpEnabled,
                                                         GST_ELEMENT(&m_audioAppSrc), _))
@@ -80,6 +92,7 @@ public:
 private:
     GstCaps m_oldCaps{};
     gchar m_oldCapsStr{};
+    GstElement *m_audioSink{};
 };
 /*
  * Component Test: Switch audio source procedure test

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -1939,6 +1939,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachMpegAudioSource)
     GstCaps newGstCaps{};
     GstCaps oldGstCaps{};
     gchar capsStr[13]{"audio/x-eac3"};
+    GstElement *fakeSink = gst_element_factory_make("fakesink", "fakesink");
     setPipelineState(GST_STATE_PAUSED);
     firebolt::rialto::wrappers::PlaybackGroupPrivate *playbackGroup;
     modifyContext(
@@ -1960,6 +1961,12 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachMpegAudioSource)
     EXPECT_CALL(*m_gstWrapperMock, gstStateLock(_)).WillOnce(Return());
     EXPECT_CALL(*m_gstWrapperMock, gstElementQueryPosition(_, GST_FORMAT_TIME, _)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstStateUnlock(_)).WillOnce(Return());
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+        .WillOnce(Invoke([&](gpointer object, const gchar *first_property_name, void *element)
+                         { *reinterpret_cast<GstElement **>(element) = fakeSink; }));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(fakeSink));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(fakeSink))).WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*m_glibWrapperMock, gStrHasPrefix(StrEq("fakesink"), StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*m_rdkGstreamerUtilsWrapperMock,
                 performAudioTrackCodecChannelSwitch(playbackGroup, _, _, _, _, _, _, _, _, _, _, _, _))
         .WillOnce(Return(true));
@@ -1968,6 +1975,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachMpegAudioSource)
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
         std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac", false);
     EXPECT_TRUE(m_sut->reattachSource(source));
+    gst_object_unref(fakeSink);
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldReattachEac3AudioSource)
@@ -1976,6 +1984,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachEac3AudioSource)
     GstCaps newGstCaps{};
     GstCaps oldGstCaps{};
     gchar capsStr[11]{"audio/mpeg"};
+    GstElement *fakeSink = gst_element_factory_make("fakesink", "fakesink0");
     setPipelineState(GST_STATE_PAUSED);
     firebolt::rialto::wrappers::PlaybackGroupPrivate *playbackGroup;
     modifyContext(
@@ -1996,6 +2005,12 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachEac3AudioSource)
     EXPECT_CALL(*m_gstWrapperMock, gstStateLock(_)).WillOnce(Return());
     EXPECT_CALL(*m_gstWrapperMock, gstElementQueryPosition(_, GST_FORMAT_TIME, _)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstStateUnlock(_)).WillOnce(Return());
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+        .WillOnce(Invoke([&](gpointer object, const gchar *first_property_name, void *element)
+                         { *reinterpret_cast<GstElement **>(element) = fakeSink; }));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(fakeSink));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(fakeSink))).WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*m_glibWrapperMock, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*m_rdkGstreamerUtilsWrapperMock,
                 performAudioTrackCodecChannelSwitch(playbackGroup, _, _, _, _, _, _, _, _, _, _, _, _))
         .WillOnce(Return(true));
@@ -2004,6 +2019,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachEac3AudioSource)
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
         std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/x-eac3", false);
     EXPECT_TRUE(m_sut->reattachSource(source));
+    gst_object_unref(fakeSink);
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldReattachRawAudioSource)
@@ -2012,6 +2028,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachRawAudioSource)
     GstCaps newGstCaps{};
     GstCaps oldGstCaps{};
     gchar capsStr[11]{"audio/mpeg"};
+    GstElement *fakeSink = gst_element_factory_make("fakesink", "fakesink1");
     setPipelineState(GST_STATE_PAUSED);
     firebolt::rialto::wrappers::PlaybackGroupPrivate *playbackGroup;
     modifyContext(
@@ -2032,6 +2049,12 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachRawAudioSource)
     EXPECT_CALL(*m_gstWrapperMock, gstStateLock(_)).WillOnce(Return());
     EXPECT_CALL(*m_gstWrapperMock, gstElementQueryPosition(_, GST_FORMAT_TIME, _)).WillOnce(Return(TRUE));
     EXPECT_CALL(*m_gstWrapperMock, gstStateUnlock(_)).WillOnce(Return());
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+        .WillOnce(Invoke([&](gpointer object, const gchar *first_property_name, void *element)
+                         { *reinterpret_cast<GstElement **>(element) = fakeSink; }));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(fakeSink));
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(fakeSink))).WillOnce(Return(kElementTypeName.c_str()));
+    EXPECT_CALL(*m_glibWrapperMock, gStrHasPrefix(_, StrEq("amlhalasink"))).WillOnce(Return(FALSE));
     EXPECT_CALL(*m_rdkGstreamerUtilsWrapperMock,
                 performAudioTrackCodecChannelSwitch(playbackGroup, _, _, _, _, _, _, _, _, _, _, _, _))
         .WillOnce(Return(true));
@@ -2040,6 +2063,188 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachRawAudioSource)
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
         std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/x-raw", false);
     EXPECT_TRUE(m_sut->reattachSource(source));
+    gst_object_unref(fakeSink);
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldReattachAmlhalasinkAudioSourceNoCodecSwitch)
+{
+    GstAppSrc audioSrc{};
+    GstCaps newGstCaps{};
+    GstCaps oldGstCaps{};
+    GstCaps configCaps{};
+    GstEvent flushStartEvent{};
+    GstEvent flushStopEvent{};
+    gchar capsStr[11]{"audio/mpeg"}; // old caps was AAC
+    gchar configCapsStr[] = "audio/mpeg, mpegversion=4, enable-svp=(string)true";
+    GstElement *fakeSink = gst_element_factory_make("fakesink", "amlhalasink0");
+    setPipelineState(GST_STATE_PAUSED);
+    modifyContext(
+        [&](GenericPlayerContext &context)
+        {
+            context.streamInfo[firebolt::rialto::MediaSourceType::AUDIO].appSrc = GST_ELEMENT(&audioSrc);
+            context.playbackGroup.m_isAudioAAC = true; // current codec is AAC
+        });
+
+    // createCapsFromMediaSource for audio/aac
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsNewEmptySimple(StrEq("audio/mpeg"))).WillOnce(Return(&newGstCaps));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsSetSimpleIntStub(&newGstCaps, StrEq("mpegversion"), G_TYPE_INT, 4));
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcGetCaps(GST_APP_SRC(&audioSrc))).WillOnce(Return(&oldGstCaps));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsEqual(&newGstCaps, &oldGstCaps)).WillOnce(Return(FALSE));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsToString(&oldGstCaps)).WillOnce(Return(capsStr));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(capsStr));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&oldGstCaps));
+    // getPosition
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(_)).WillOnce(Return(GST_STATE_PAUSED));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStateReturn(_)).WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+    EXPECT_CALL(*m_gstWrapperMock, gstStateLock(_)).WillOnce(Return());
+    EXPECT_CALL(*m_gstWrapperMock, gstElementQueryPosition(_, GST_FORMAT_TIME, _)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstStateUnlock(_)).WillOnce(Return());
+    // getSink
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+        .WillOnce(Invoke([&](gpointer, const gchar *, void *element)
+                         { *reinterpret_cast<GstElement **>(element) = fakeSink; }));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(fakeSink));
+    // getSinkChildIfAutoAudioSink
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(fakeSink))).WillOnce(Return(kElementTypeName.c_str()));
+    // amlhalasink path
+    EXPECT_CALL(*m_glibWrapperMock, gStrHasPrefix(StrEq("amlhalasink0"), StrEq("amlhalasink"))).WillOnce(Return(TRUE));
+    // performAudioTrackCodecChannelSwitch (AAC->AAC, no codec switch):
+    // configAudioCap unrefs original caps and creates new ones
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&newGstCaps));
+    EXPECT_CALL(*m_glibWrapperMock, gStrdupPrintfStub(_)).WillOnce(Return(configCapsStr));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsFromString(configCapsStr)).WillOnce(Return(&configCaps));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(configCapsStr));
+    // flush events
+    EXPECT_CALL(*m_gstWrapperMock, gstEventNewFlushStart()).WillOnce(Return(&flushStartEvent));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSendEvent(GST_ELEMENT(&audioSrc), &flushStartEvent)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstEventNewFlushStop(kResetTime)).WillOnce(Return(&flushStopEvent));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSendEvent(GST_ELEMENT(&audioSrc), &flushStopEvent)).WillOnce(Return(TRUE));
+    // no codec switch - just set new caps
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcSetCaps(GST_APP_SRC(&audioSrc), &configCaps));
+    // end of reattachSource: caps was updated to configCaps
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&configCaps));
+
+    std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac", false);
+    EXPECT_TRUE(m_sut->reattachSource(source));
+    gst_object_unref(fakeSink);
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldReattachAmlhalasinkAudioSourceWithFirstTimeCodecSwitch)
+{
+    GstAppSrc audioSrc{};
+    GstCaps newGstCaps{};
+    GstCaps oldGstCaps{};
+    GstCaps configCaps{};
+    GstEvent flushStartEvent{};
+    GstEvent flushStopEvent{};
+    GstPad typefindSrcPad{};
+    GstPad typefindSrcPeerPad{};
+    GstElement newAudioDecoder{};
+    GstElement newAudioParse{};
+    GstElement newQueue{};
+    GstPad newAudioDecoderSrcPad{};
+    GstElement typefind{};
+    GstElement decodeBin{};
+    GstElement playsinkBin{};
+    gchar capsStr[13]{"audio/x-eac3"}; // old caps was EAC3 (no "audio/mpeg" → audioAac=false)
+    gchar configCapsStr[] = "audio/mpeg, mpegversion=4, enable-svp=(string)true";
+    GstElement *fakeSink = gst_element_factory_make("fakesink", "amlhalasink1");
+    setPipelineState(GST_STATE_PAUSED);
+    modifyContext(
+        [&](GenericPlayerContext &context)
+        {
+            context.streamInfo[firebolt::rialto::MediaSourceType::AUDIO].appSrc = GST_ELEMENT(&audioSrc);
+            context.playbackGroup.m_isAudioAAC = false;        // current codec is EAC3
+            context.playbackGroup.m_curAudioDecoder = nullptr; // first time switch: no existing decoder
+            context.playbackGroup.m_curAudioTypefind = &typefind;
+            context.playbackGroup.m_curAudioDecodeBin = &decodeBin;
+            context.playbackGroup.m_curAudioPlaysinkBin = &playsinkBin;
+        });
+
+    // createCapsFromMediaSource for audio/aac
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsNewEmptySimple(StrEq("audio/mpeg"))).WillOnce(Return(&newGstCaps));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsSetSimpleIntStub(&newGstCaps, StrEq("mpegversion"), G_TYPE_INT, 4));
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcGetCaps(GST_APP_SRC(&audioSrc))).WillOnce(Return(&oldGstCaps));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsIsEqual(&newGstCaps, &oldGstCaps)).WillOnce(Return(FALSE));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsToString(&oldGstCaps)).WillOnce(Return(capsStr));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(capsStr));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&oldGstCaps));
+    // getPosition
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(_)).WillOnce(Return(GST_STATE_PAUSED));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStateReturn(_)).WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+    EXPECT_CALL(*m_gstWrapperMock, gstStateLock(_)).WillOnce(Return());
+    EXPECT_CALL(*m_gstWrapperMock, gstElementQueryPosition(_, GST_FORMAT_TIME, _)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstStateUnlock(_)).WillOnce(Return());
+    // getSink
+    EXPECT_CALL(*m_glibWrapperMock, gObjectGetStub(_, StrEq("audio-sink"), _))
+        .WillOnce(Invoke([&](gpointer, const gchar *, void *element)
+                         { *reinterpret_cast<GstElement **>(element) = fakeSink; }));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(fakeSink));
+    // getSinkChildIfAutoAudioSink
+    EXPECT_CALL(*m_glibWrapperMock, gTypeName(G_OBJECT_TYPE(fakeSink))).WillOnce(Return(kElementTypeName.c_str()));
+    // amlhalasink path
+    EXPECT_CALL(*m_glibWrapperMock, gStrHasPrefix(StrEq("amlhalasink1"), StrEq("amlhalasink"))).WillOnce(Return(TRUE));
+    // performAudioTrackCodecChannelSwitch (EAC3->AAC, codec switch):
+    // configAudioCap unrefs original caps and creates new AAC caps
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&newGstCaps));
+    EXPECT_CALL(*m_glibWrapperMock, gStrdupPrintfStub(_)).WillOnce(Return(configCapsStr));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsFromString(configCapsStr)).WillOnce(Return(&configCaps));
+    EXPECT_CALL(*m_glibWrapperMock, gFree(configCapsStr));
+    // flush events
+    EXPECT_CALL(*m_gstWrapperMock, gstEventNewFlushStart()).WillOnce(Return(&flushStartEvent));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSendEvent(GST_ELEMENT(&audioSrc), &flushStartEvent)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstEventNewFlushStop(kResetTime)).WillOnce(Return(&flushStopEvent));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSendEvent(GST_ELEMENT(&audioSrc), &flushStopEvent)).WillOnce(Return(TRUE));
+    // haltAudioPlayback + resumeAudioPlayback: playsinkBin and decodeBin each called twice
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&playsinkBin, GST_STATE_READY))
+        .WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(&playsinkBin, _, _, GST_CLOCK_TIME_NONE)).Times(2);
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&decodeBin, GST_STATE_PAUSED))
+        .WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(&decodeBin, _, _, GST_CLOCK_TIME_NONE)).Times(2);
+    // switchAudioCodec -> firstTimeSwitchFromAC3toAAC
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(&typefind, StrEq("src"))).WillOnce(Return(&typefindSrcPad));
+    EXPECT_CALL(*m_gstWrapperMock, gstPadGetPeer(&typefindSrcPad)).WillOnce(Return(&typefindSrcPeerPad));
+    EXPECT_CALL(*m_gstWrapperMock, gstPadUnlink(&typefindSrcPad, &typefindSrcPeerPad)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("aacparse"), StrEq("aacparse")))
+        .WillOnce(Return(&newAudioParse));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("avdec_aac"), StrEq("avdec_aac")))
+        .WillOnce(Return(&newAudioDecoder));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementFactoryMake(StrEq("queue"), StrEq("aqueue"))).WillOnce(Return(&newQueue));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(_, &newAudioDecoder)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(_, &newAudioParse)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstBinAdd(_, &newQueue)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetStaticPad(&newAudioDecoder, StrEq("src")))
+        .WillOnce(Return(&newAudioDecoderSrcPad));
+    EXPECT_CALL(*m_gstWrapperMock, gstPadLink(&newAudioDecoderSrcPad, &typefindSrcPeerPad)).WillOnce(Return(GST_PAD_LINK_OK));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&newAudioParse, &newQueue)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementLink(&newQueue, &newAudioDecoder)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSetState(&typefind, GST_STATE_READY)).WillOnce(Return(GST_STATE_CHANGE_SUCCESS));
+    EXPECT_CALL(*m_glibWrapperMock, gObjectSetStub(&typefind, StrEq("force-caps")));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSyncStateWithParent(&typefind)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(&typefind, _, _, GST_CLOCK_TIME_NONE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSyncStateWithParent(&newAudioDecoder)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(&newAudioDecoder, _, _, GST_CLOCK_TIME_NONE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSyncStateWithParent(&newQueue)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(&newQueue, _, _, GST_CLOCK_TIME_NONE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSyncStateWithParent(&newAudioParse)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementGetState(&newAudioParse, _, _, GST_CLOCK_TIME_NONE));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&typefindSrcPad));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&typefindSrcPeerPad));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&newAudioDecoderSrcPad));
+    // gstAppSrcSetCaps after codec switch
+    EXPECT_CALL(*m_gstWrapperMock, gstAppSrcSetCaps(GST_APP_SRC(&audioSrc), &configCaps));
+    // resumeAudioPlayback
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSyncStateWithParent(&playsinkBin)).WillOnce(Return(TRUE));
+    EXPECT_CALL(*m_gstWrapperMock, gstElementSyncStateWithParent(&decodeBin)).WillOnce(Return(TRUE));
+    // end of reattachSource: caps was updated to configCaps inside performAudioTrackCodecChannelSwitch
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&configCaps));
+
+    std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
+        std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac", false);
+    EXPECT_TRUE(m_sut->reattachSource(source));
+    gst_object_unref(fakeSink);
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldSetSourceFlushed)

--- a/wrappers/include/GstWrapper.h
+++ b/wrappers/include/GstWrapper.h
@@ -595,6 +595,22 @@ public:
     {
         gst_base_parse_set_pts_interpolation(parse, ptsInterpolate);
     }
+
+    GstStateChangeReturn gstElementGetState(GstElement *element, GstState *state, GstState *pending,
+                                            GstClockTime timeout) override
+    {
+        return gst_element_get_state(element, state, pending, timeout);
+    }
+
+    GstPad *gstPadGetPeer(GstPad *pad) override { return gst_pad_get_peer(pad); }
+
+    gboolean gstPadUnlink(GstPad *srcpad, GstPad *sinkpad) override { return gst_pad_unlink(srcpad, sinkpad); }
+
+    GstPadLinkReturn gstPadLink(GstPad *srcpad, GstPad *sinkpad) override { return gst_pad_link(srcpad, sinkpad); }
+
+    gboolean gstBinRemove(GstBin *bin, GstElement *element) override { return gst_bin_remove(bin, element); }
+
+    GstObject *gstPadGetParent(GstPad *pad) override { return gst_pad_get_parent(pad); }
 };
 
 }; // namespace firebolt::rialto::wrappers

--- a/wrappers/interface/IGstWrapper.h
+++ b/wrappers/interface/IGstWrapper.h
@@ -1402,6 +1402,69 @@ public:
      * @param ptsInterpolate  : TRUE if parser should interpolate PTS timestamps
      */
     virtual void gstBaseParseSetPtsInterpolation(GstBaseParse *parse, gboolean ptsInterpolate) const = 0;
+
+    /**
+     * @brief Gets the state of the element (blocking version with timeout).
+     *
+     * @param[in]  element : A GstElement to get state of.
+     * @param[out] state   : A pointer to GstState to hold the state, or NULL.
+     * @param[out] pending : A pointer to GstState to hold the pending state, or NULL.
+     * @param[in]  timeout : A GstClockTime to specify the timeout.
+     *
+     * @retval GST_STATE_CHANGE_SUCCESS if the element has no more pending state
+     *         and the last state change succeeded, GST_STATE_CHANGE_ASYNC if the
+     *         element is still performing a state change, or other values on failure.
+     */
+    virtual GstStateChangeReturn gstElementGetState(GstElement *element, GstState *state, GstState *pending,
+                                                    GstClockTime timeout) = 0;
+
+    /**
+     * @brief Gets the peer pad of the given pad.
+     *
+     * @param[in] pad : A GstPad to get the peer of.
+     *
+     * @retval The peer GstPad. Unref after usage. NULL if pad has no peer.
+     */
+    virtual GstPad *gstPadGetPeer(GstPad *pad) = 0;
+
+    /**
+     * @brief Unlinks the source pad from the sink pad.
+     *
+     * @param[in] srcpad  : The source GstPad to unlink.
+     * @param[in] sinkpad : The sink GstPad to unlink.
+     *
+     * @retval TRUE if the pads were unlinked, FALSE otherwise.
+     */
+    virtual gboolean gstPadUnlink(GstPad *srcpad, GstPad *sinkpad) = 0;
+
+    /**
+     * @brief Links the source pad to the sink pad.
+     *
+     * @param[in] srcpad  : The source GstPad to link.
+     * @param[in] sinkpad : The sink GstPad to link.
+     *
+     * @retval A result code indicating if the connection worked or what went wrong.
+     */
+    virtual GstPadLinkReturn gstPadLink(GstPad *srcpad, GstPad *sinkpad) = 0;
+
+    /**
+     * @brief Removes an element from the bin.
+     *
+     * @param[in] bin     : The bin to remove the element from.
+     * @param[in] element : The element to remove.
+     *
+     * @retval TRUE if the element could be removed, FALSE otherwise.
+     */
+    virtual gboolean gstBinRemove(GstBin *bin, GstElement *element) = 0;
+
+    /**
+     * @brief Gets the parent of a pad.
+     *
+     * @param[in] pad : The pad to get the parent of.
+     *
+     * @retval The parent GstObject. Unref after usage. NULL if pad has no parent.
+     */
+    virtual GstObject *gstPadGetParent(GstPad *pad) = 0;
 };
 
 }; // namespace firebolt::rialto::wrappers


### PR DESCRIPTION
Summary: Removed blocking get_state calls from aml codec switch
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-13606, DELIA-70194