### PR TITLE
Refactor TextTrackPluginWrapper to include module definition and headers in source file

### DIFF
--- a/wrappers/include/TextTrackPluginWrapper.h
+++ b/wrappers/include/TextTrackPluginWrapper.h
@@ -19,13 +19,7 @@
 #ifndef FIREBOLT_RIALTO_WRAPPERS_TEXT_TRACK_PLUGIN_WRAPPER_H_
 #define FIREBOLT_RIALTO_WRAPPERS_TEXT_TRACK_PLUGIN_WRAPPER_H_
 
-#ifndef MODULE_NAME
-#define MODULE_NAME TextTrackClosedCaptionsStyleClient
-#endif
-
 #include "ITextTrackPluginWrapper.h"
-#include <com/com.h>
-#include <core/core.h>
 #ifdef RIALTO_ENABLE_TEXT_TRACK
 #include <interfaces/ITextTrack.h>
 #endif // RIALTO_ENABLE_TEXT_TRACK

--- a/wrappers/source/TextTrackPluginWrapper.cpp
+++ b/wrappers/source/TextTrackPluginWrapper.cpp
@@ -17,9 +17,16 @@
  * limitations under the License.
  */
 
+#define MODULE_NAME TextTrackClosedCaptionsStyleClient
+
+#include <com/com.h>
+#include <core/core.h>
+
 #include "TextTrackPluginWrapper.h"
 #include "TextTrackPluginWrapperFactory.h"
 #include "TextTrackWrapper.h"
+
+MODULE_NAME_ARCHIVE_DECLARATION
 
 namespace firebolt::rialto::wrappers
 {


### PR DESCRIPTION
## Fix undefined reference to `TextTrackClosedCaptionsStyleClient`

`TextTrackPluginWrapper.h` defined `MODULE_NAME` as `TextTrackClosedCaptionsStyleClient` and
included `<com/com.h>` and `<core/core.h>`. This caused `CallsignTLS<&TextTrackClosedCaptionsStyleClient>`
to be instantiated in every translation unit that included the header. However `TextTrackClosedCaptionsStyleClient`
was never defined anywhere, resulting in an undefined reference at link time for any library linking
against `libRialtoWrappers`.

### Changes
- Remove `MODULE_NAME` definition and Thunder includes from `TextTrackPluginWrapper.h`
- Move them to `TextTrackPluginWrapper.cpp` as the owning translation unit
- Add `MODULE_NAME_ARCHIVE_DECLARATION` to properly define `TextTrackClosedCaptionsStyleClient`

### Why `MODULE_NAME_ARCHIVE_DECLARATION`
`libRialtoWrappers` is a static library — the archive variant is correct here as it omits the
shared library metadata registration that `MODULE_NAME_DECLARATION` adds.

### Impact
Downstream packages linking against `libRialtoWrappers` were failing with
`undefined reference to 'TextTrackClosedCaptionsStyleClient'` at link time.
This fix resolves that.