### PR TITLE
Fixed initialisation of playbackGroup elements in GenericPlayerContex…

### DIFF
--- a/media/server/gstplayer/include/Utils.h
+++ b/media/server/gstplayer/include/Utils.h
@@ -32,6 +32,7 @@ namespace firebolt::rialto::server
 bool isVideoDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isAudioDecoder(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isVideoParser(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
+bool isAudioParser(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isVideoSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isAudioSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);
 bool isSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element);

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -301,6 +301,11 @@ void GstGenericPlayer::termPipeline()
         m_gstWrapper->gstObjectUnref(m_context.videoSink);
         m_context.videoSink = nullptr;
     }
+    if (m_context.playbackGroup.m_curAudioPlaysinkBin)
+    {
+        m_gstWrapper->gstObjectUnref(m_context.playbackGroup.m_curAudioPlaysinkBin);
+        m_context.playbackGroup.m_curAudioPlaysinkBin = nullptr;
+    }
 
     // Delete the pipeline
     m_gstWrapper->gstObjectUnref(m_context.pipeline);

--- a/media/server/gstplayer/source/Utils.cpp
+++ b/media/server/gstplayer/source/Utils.cpp
@@ -64,6 +64,11 @@ bool isVideoParser(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, Gs
     return isType(gstWrapper, element, GST_ELEMENT_FACTORY_TYPE_PARSER | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);
 }
 
+bool isAudioParser(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
+{
+    return isType(gstWrapper, element, GST_ELEMENT_FACTORY_TYPE_PARSER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO);
+}
+
 bool isVideoSink(const firebolt::rialto::wrappers::IGstWrapper &gstWrapper, GstElement *element)
 {
     return isType(gstWrapper, element, GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO);

--- a/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
+++ b/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
@@ -19,6 +19,7 @@
 
 #include "tasks/generic/DeepElementAdded.h"
 #include "RialtoServerLogging.h"
+#include "Utils.h"
 
 namespace
 {
@@ -69,42 +70,48 @@ void DeepElementAdded::execute() const
     m_context.playbackGroup.m_gstPipeline = GST_ELEMENT(m_pipeline);
 
     RIALTO_SERVER_LOG_DEBUG("Element = %p Bin = %p Pipeline = %p", m_element, m_bin, m_pipeline);
-    if (m_callbackRegistered)
-    {
-        m_context.playbackGroup.m_curAudioTypefind = m_element;
-    }
     if (m_elementName)
     {
         if (m_gstWrapper->gstObjectCast(m_bin) == m_gstWrapper->gstObjectCast(m_context.playbackGroup.m_curAudioDecodeBin))
         {
-            if (m_glibWrapper->gStrrstr(m_elementName, "parse"))
+            if (isAudioParser(*m_gstWrapper, m_element))
             {
                 RIALTO_SERVER_LOG_DEBUG("curAudioParse = %s", m_elementName);
                 m_context.playbackGroup.m_curAudioParse = m_element;
             }
-            else if (m_glibWrapper->gStrrstr(m_elementName, "dec"))
+            else if (isAudioDecoder(*m_gstWrapper, m_element))
             {
                 RIALTO_SERVER_LOG_DEBUG("curAudioDecoder = %s", m_elementName);
                 m_context.playbackGroup.m_curAudioDecoder = m_element;
             }
-        }
-        else
-        {
-            if (m_glibWrapper->gStrrstr(m_elementName, "audiosink"))
+            else if (m_callbackRegistered && m_glibWrapper->gStrrstr(m_elementName, "typefind"))
             {
-                GstElement *audioSinkParent =
-                    reinterpret_cast<GstElement *>(m_gstWrapper->gstElementGetParent(m_element));
-                if (audioSinkParent)
+                RIALTO_SERVER_LOG_DEBUG("curAudioTypefind = %s", m_elementName);
+                m_context.playbackGroup.m_curAudioTypefind = m_element;
+            }
+        }
+        else if (isAudioSink(*m_gstWrapper, m_element))
+        {
+            GstElement *audioSinkParent = reinterpret_cast<GstElement *>(m_gstWrapper->gstElementGetParent(m_element));
+            if (audioSinkParent)
+            {
+                gchar *audioSinkParentName = m_gstWrapper->gstElementGetName(audioSinkParent);
+                RIALTO_SERVER_LOG_DEBUG("audioSinkParentName = %s", audioSinkParentName);
+                if (audioSinkParentName && m_glibWrapper->gStrrstr(audioSinkParentName, "bin"))
                 {
-                    gchar *audioSinkParentName = m_gstWrapper->gstElementGetName(audioSinkParent);
-                    RIALTO_SERVER_LOG_DEBUG("audioSinkParentName = %s", audioSinkParentName);
-                    if (audioSinkParentName && m_glibWrapper->gStrrstr(audioSinkParentName, "bin"))
+                    RIALTO_SERVER_LOG_DEBUG("curAudioPlaysinkBin = %s", audioSinkParentName);
+                    if (m_context.playbackGroup.m_curAudioPlaysinkBin)
                     {
-                        RIALTO_SERVER_LOG_DEBUG("curAudioPlaysinkBin = %s", audioSinkParentName);
-                        m_context.playbackGroup.m_curAudioPlaysinkBin = audioSinkParent;
+                        // Unref previous audio playsink bin, if exists
+                        m_gstWrapper->gstObjectUnref(m_context.playbackGroup.m_curAudioPlaysinkBin);
                     }
-                    m_glibWrapper->gFree(audioSinkParentName);
+                    m_context.playbackGroup.m_curAudioPlaysinkBin = audioSinkParent;
                 }
+                else
+                {
+                    m_gstWrapper->gstObjectUnref(audioSinkParent);
+                }
+                m_glibWrapper->gFree(audioSinkParentName);
             }
         }
     }

--- a/media/server/gstplayer/source/tasks/generic/UpdatePlaybackGroup.cpp
+++ b/media/server/gstplayer/source/tasks/generic/UpdatePlaybackGroup.cpp
@@ -68,6 +68,20 @@ void UpdatePlaybackGroup::execute() const
                     {
                         m_player.setUseBuffering();
                     }
+                    if (m_context.playbackGroup.m_linkTypefindParser && m_context.playbackGroup.m_curAudioTypefind &&
+                        m_context.playbackGroup.m_curAudioParse)
+                    {
+                        if (m_gstWrapper->gstElementLink(m_context.playbackGroup.m_curAudioTypefind,
+                                                         m_context.playbackGroup.m_curAudioParse))
+                        {
+                            RIALTO_SERVER_LOG_DEBUG("Linked typefind to parser");
+                            m_context.playbackGroup.m_linkTypefindParser = false;
+                        }
+                        else
+                        {
+                            RIALTO_SERVER_LOG_DEBUG("Failed to link typefind to parser");
+                        }
+                    }
                 }
                 m_glibWrapper->gFree(elementName);
                 m_gstWrapper->gstObjectUnref(typeFindParent);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -2240,6 +2240,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldReattachAmlhalasinkAudioSourceWithFirs
     EXPECT_CALL(*m_gstWrapperMock, gstElementSyncStateWithParent(&decodeBin)).WillOnce(Return(TRUE));
     // end of reattachSource: caps was updated to configCaps inside performAudioTrackCodecChannelSwitch
     EXPECT_CALL(*m_gstWrapperMock, gstCapsUnref(&configCaps));
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&playsinkBin));
 
     std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> source =
         std::make_unique<firebolt::rialto::IMediaPipeline::MediaSourceAudio>("audio/aac", false);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -1941,7 +1941,7 @@ void GenericTasksTestsBase::shouldNotRegisterCallbackWhenElementNameIsNotTypefin
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetName(testContext->m_element))
         .WillOnce(Return(testContext->m_elementName));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_elementName, StrEq("typefind")))
-        .WillOnce(Return(nullptr));
+        .WillRepeatedly(Return(nullptr));
     EXPECT_CALL(*testContext->m_glibWrapper, gFree(testContext->m_elementName));
 }
 
@@ -1952,7 +1952,7 @@ void GenericTasksTestsBase::shouldRegisterCallbackForTypefindElement()
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetName(testContext->m_element))
         .WillOnce(Return(testContext->m_typefindElementName));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_typefindElementName, StrEq("typefind")))
-        .WillOnce(Return(testContext->m_typefindElementName));
+        .WillRepeatedly(Return(testContext->m_typefindElementName));
     EXPECT_CALL(*testContext->m_glibWrapper,
                 gSignalConnect(G_OBJECT(testContext->m_element), StrEq("have-type"), _, &testContext->m_gstPlayer))
         .WillOnce(Return(kSignalId));
@@ -1982,9 +1982,19 @@ void GenericTasksTestsBase::shouldUpdatePlaybackGroupWhenCallbackIsCalled()
 
 void GenericTasksTestsBase::shouldSetTypefindElement()
 {
-    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectCast(nullptr)).WillOnce(Return(nullptr));
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_typefindElementName, StrEq("audiosink")))
-        .WillOnce(Return(nullptr));
+    testContext->m_context.playbackGroup.m_curAudioDecodeBin = &testContext->m_audioDecodeBin;
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectCast(&testContext->m_audioDecodeBin))
+        .WillOnce(Return(&testContext->m_obj1));
+
+    EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_PARSER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(FALSE));
 }
 
 void GenericTasksTestsBase::triggerDeepElementAdded()
@@ -2030,8 +2040,11 @@ void GenericTasksTestsBase::shouldSetParseElement()
     testContext->m_context.playbackGroup.m_curAudioDecodeBin = &testContext->m_audioDecodeBin;
     EXPECT_CALL(*testContext->m_gstWrapper, gstObjectCast(&testContext->m_audioDecodeBin))
         .WillOnce(Return(&testContext->m_obj1));
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_parseElementName, StrEq("parse")))
-        .WillOnce(Return(testContext->m_parseElementName));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_PARSER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
 }
 
 void GenericTasksTestsBase::checkParsePlaybackGroupAdded()
@@ -2056,10 +2069,15 @@ void GenericTasksTestsBase::shouldSetDecoderElement()
     testContext->m_context.playbackGroup.m_curAudioDecodeBin = &testContext->m_audioDecodeBin;
     EXPECT_CALL(*testContext->m_gstWrapper, gstObjectCast(&testContext->m_audioDecodeBin))
         .WillOnce(Return(&testContext->m_obj1));
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_decoderElementName, StrEq("parse")))
-        .WillOnce(Return(nullptr));
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_decoderElementName, StrEq("dec")))
-        .WillOnce(Return(testContext->m_decoderElementName));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_PARSER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(FALSE));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_DECODER | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
 }
 
 void GenericTasksTestsBase::checkDecoderPlaybackGroupAdded()
@@ -2074,8 +2092,11 @@ void GenericTasksTestsBase::checkDecoderPlaybackGroupAdded()
 void GenericTasksTestsBase::shouldSetGenericElement()
 {
     EXPECT_CALL(*testContext->m_gstWrapper, gstObjectCast(nullptr)).WillOnce(Return(nullptr));
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_elementName, StrEq("audiosink")))
-        .WillOnce(Return(nullptr));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(FALSE));
 }
 
 void GenericTasksTestsBase::shouldSetAudioSinkElement()
@@ -2089,8 +2110,11 @@ void GenericTasksTestsBase::shouldSetAudioSinkElement()
     EXPECT_CALL(*testContext->m_glibWrapper, gFree(testContext->m_audioSinkElementName));
 
     EXPECT_CALL(*testContext->m_gstWrapper, gstObjectCast(nullptr)).WillOnce(Return(nullptr));
-    EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_audioSinkElementName, StrEq("audiosink")))
-        .WillOnce(Return(testContext->m_audioSinkElementName));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetFactory(_)).WillRepeatedly(Return(testContext->m_elementFactory));
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementFactoryListIsType(testContext->m_elementFactory,
+                                            GST_ELEMENT_FACTORY_TYPE_SINK | GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO))
+        .WillOnce(Return(TRUE));
 }
 
 void GenericTasksTestsBase::shouldHaveNullParentSink()
@@ -2098,6 +2122,7 @@ void GenericTasksTestsBase::shouldHaveNullParentSink()
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetParent(testContext->m_element))
         .WillOnce(Return(GST_OBJECT(&testContext->m_audioParentSink)));
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetName(&testContext->m_audioParentSink)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(&testContext->m_audioParentSink));
     EXPECT_CALL(*testContext->m_glibWrapper, gFree(nullptr));
 }
 
@@ -2108,11 +2133,16 @@ void GenericTasksTestsBase::shouldHaveNonBinParentSink()
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetName(&testContext->m_audioParentSink))
         .WillOnce(Return(testContext->m_elementName));
     EXPECT_CALL(*testContext->m_glibWrapper, gStrrstr(testContext->m_elementName, StrEq("bin"))).WillOnce(Return(nullptr));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(&testContext->m_audioParentSink));
     EXPECT_CALL(*testContext->m_glibWrapper, gFree(testContext->m_elementName));
 }
 
 void GenericTasksTestsBase::shouldHaveBinParentSink()
 {
+    // Previous bin should be unrefed
+    testContext->m_context.playbackGroup.m_curAudioPlaysinkBin = &testContext->m_childElement;
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(&testContext->m_childElement));
+
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetParent(testContext->m_element))
         .WillOnce(Return(GST_OBJECT(&testContext->m_audioParentSink)));
     EXPECT_CALL(*testContext->m_gstWrapper, gstElementGetName(&testContext->m_audioParentSink))
@@ -2233,6 +2263,24 @@ void GenericTasksTestsBase::setUseBufferingPending()
 void GenericTasksTestsBase::shouldTriggerSetUseBuffering()
 {
     EXPECT_CALL(testContext->m_gstPlayer, setUseBuffering()).WillOnce(Return(true));
+}
+
+void GenericTasksTestsBase::shouldLinkTypefindAndParser()
+{
+    testContext->m_context.playbackGroup.m_linkTypefindParser = true;
+    testContext->m_context.playbackGroup.m_curAudioParse = &testContext->m_childElement;
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementLink(testContext->m_element, testContext->m_context.playbackGroup.m_curAudioParse))
+        .WillOnce(Return(TRUE));
+}
+
+void GenericTasksTestsBase::shouldFailToLinkTypefindAndParser()
+{
+    testContext->m_context.playbackGroup.m_linkTypefindParser = true;
+    testContext->m_context.playbackGroup.m_curAudioParse = &testContext->m_childElement;
+    EXPECT_CALL(*testContext->m_gstWrapper,
+                gstElementLink(testContext->m_element, testContext->m_context.playbackGroup.m_curAudioParse))
+        .WillOnce(Return(FALSE));
 }
 
 void GenericTasksTestsBase::shouldStopGstPlayer()

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.h
@@ -235,6 +235,8 @@ protected:
     void checkPlaybackGroupAdded();
     void setUseBufferingPending();
     void shouldTriggerSetUseBuffering();
+    void shouldLinkTypefindAndParser();
+    void shouldFailToLinkTypefindAndParser();
 
     // Stop test methods
     void shouldStopGstPlayer();

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/UpdatePlaybackGroupTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/UpdatePlaybackGroupTest.cpp
@@ -72,3 +72,19 @@ TEST_F(UpdatePlaybackGroupTest, shouldTriggerUseBuffering)
     triggerUpdatePlaybackGroup();
     checkPlaybackGroupAdded();
 }
+
+TEST_F(UpdatePlaybackGroupTest, shouldLinkTypefindWithParser)
+{
+    shouldSuccessfullyFindTypefindAndParent();
+    shouldLinkTypefindAndParser();
+    triggerUpdatePlaybackGroup();
+    checkPlaybackGroupAdded();
+}
+
+TEST_F(UpdatePlaybackGroupTest, shouldFailToLinkTypefindWithParser)
+{
+    shouldSuccessfullyFindTypefindAndParent();
+    shouldFailToLinkTypefindAndParser();
+    triggerUpdatePlaybackGroup();
+    checkPlaybackGroupAdded();
+}


### PR DESCRIPTION
Summary: Fixed initialisation of playbackGroup elements in GenericPlayerContext. Added linking of typefind and the parser after the audio switch
Type: Feature
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-16807