### PR TITLE
DELIA-70580 : PROVIDED THE LAST DECRYPT STATUS VIA OCDM

### DIFF
--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -236,7 +236,7 @@ MediaKeyErrorStatus MediaKeySession::decrypt(GstBuffer *encrypted, GstCaps *caps
             RIALTO_SERVER_LOG_WARN("Decrypt failed due to HDCP output protection (DRM error %u)", lastDrmError);
             return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
         }
-        RIALTO_SERVER_LOG_ERROR("Failed to decrypt buffer");
+        RIALTO_SERVER_LOG_DEBUG("Failed to decrypt buffer");
     }
 
     if ((checkForOcdmErrors("decrypt")) && (MediaKeyErrorStatus::OK == status))

--- a/media/server/main/source/MediaKeysServerInternal.cpp
+++ b/media/server/main/source/MediaKeysServerInternal.cpp
@@ -593,7 +593,7 @@ MediaKeyErrorStatus MediaKeysServerInternal::decryptInternal(int32_t keySessionI
     MediaKeyErrorStatus status = sessionIter->second->decrypt(encrypted, caps);
     if (MediaKeyErrorStatus::OK != status)
     {
-        RIALTO_SERVER_LOG_ERROR("Failed to decrypt buffer.");
+        RIALTO_SERVER_LOG_DEBUG("Failed to decrypt buffer.");
         return status;
     }
     RIALTO_SERVER_LOG_INFO("Successfully decrypted buffer.");

--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -63,6 +63,7 @@ if( NOT CMAKE_BUILD_FLAG STREQUAL "UnitTests" AND NOT CMAKE_BUILD_FLAG STREQUAL 
         ocdm::ocdm
         WPEFrameworkCore::WPEFrameworkCore
         WPEFrameworkCOM::WPEFrameworkCOM
+        RialtoEthanLog
         ${CMAKE_DL_LIBS})
 
     set(WRAPPER_SOURCES
@@ -110,6 +111,7 @@ target_include_directories(
 
         PRIVATE
         include
+        ../common/interface/
         ${GStreamerApp_INCLUDE_DIRS}
         $<TARGET_PROPERTY:RialtoPlayerPublic,INTERFACE_INCLUDE_DIRECTORIES>
         ${WRAPPER_INCLUDES}

--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -63,7 +63,6 @@ if( NOT CMAKE_BUILD_FLAG STREQUAL "UnitTests" AND NOT CMAKE_BUILD_FLAG STREQUAL 
         ocdm::ocdm
         WPEFrameworkCore::WPEFrameworkCore
         WPEFrameworkCOM::WPEFrameworkCOM
-        RialtoEthanLog
         ${CMAKE_DL_LIBS})
 
     set(WRAPPER_SOURCES
@@ -111,7 +110,6 @@ target_include_directories(
 
         PRIVATE
         include
-        ../common/interface/
         ${GStreamerApp_INCLUDE_DIRS}
         $<TARGET_PROPERTY:RialtoPlayerPublic,INTERFACE_INCLUDE_DIRECTORIES>
         ${WRAPPER_INCLUDES}

--- a/wrappers/include/OcdmSession.h
+++ b/wrappers/include/OcdmSession.h
@@ -95,6 +95,7 @@ private:
     using OcdmGstSessionDecryptExFn = OpenCDMError (*)(struct OpenCDMSession *, GstBuffer *, GstBuffer *,
                                                        const uint32_t, GstBuffer *, GstBuffer *, uint32_t, GstCaps *);
     using OcdmGstSessionDecryptBufferOnceFn = OpenCDMError (*)(struct OpenCDMSession *, GstBuffer *, GstCaps *);
+    using OcdmSessionLastDecryptStatusFn = OpenCDMError (*)(const struct OpenCDMSession *, uint32_t *);
     /**
      * @brief The System handle.
      */
@@ -117,6 +118,7 @@ private:
 
     static OcdmGstSessionDecryptExFn m_ocdmGstSessionDecryptEx;
     static OcdmGstSessionDecryptBufferOnceFn m_ocdmGstSessionDecryptBufferOnce;
+    static OcdmSessionLastDecryptStatusFn m_ocdmSessionLastDecryptStatus;
     /**
      * @brief Requests the processing of the challenge data.
      *

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -25,6 +25,9 @@
 #include <mutex>
 namespace
 {
+constexpr uint32_t kWidevineStatusKeyUsageBlockedByPolicy{105};
+constexpr uint32_t kWidevineStatusKeyUsageBlockedByPolicyHdcp22{902};
+
 LicenseType convertLicenseType(const firebolt::rialto::KeySessionType &sessionType)
 {
     switch (sessionType)
@@ -103,12 +106,19 @@ const firebolt::rialto::KeyStatus convertKeyStatus(const KeyStatus &ocdmKeyStatu
     }
     }
 }
+
+bool isOutputRestrictedDecryptStatus(const uint32_t decryptStatus)
+{
+    return (decryptStatus == kWidevineStatusKeyUsageBlockedByPolicy) ||
+           (decryptStatus == kWidevineStatusKeyUsageBlockedByPolicyHdcp22);
+}
 } // namespace
 
 namespace firebolt::rialto::wrappers
 {
 OcdmSession::OcdmGstSessionDecryptExFn OcdmSession::m_ocdmGstSessionDecryptEx{nullptr};
 OcdmSession::OcdmGstSessionDecryptBufferOnceFn OcdmSession::m_ocdmGstSessionDecryptBufferOnce{nullptr};
+OcdmSession::OcdmSessionLastDecryptStatusFn OcdmSession::m_ocdmSessionLastDecryptStatus{nullptr};
 
 OcdmSession::OcdmSession(struct OpenCDMSystem *systemHandle, IOcdmSessionClient *client)
     : m_systemHandle(systemHandle), m_ocdmSessionClient(client), m_session(nullptr)
@@ -125,6 +135,9 @@ OcdmSession::OcdmSession(struct OpenCDMSystem *systemHandle, IOcdmSessionClient 
                        m_ocdmGstSessionDecryptBufferOnce =
                            (OcdmGstSessionDecryptBufferOnceFn)dlsym(handle,
                                                                     "opencdm_gstreamer_session_decrypt_buffer_once");
+                       m_ocdmSessionLastDecryptStatus =
+                           (OcdmSessionLastDecryptStatusFn)dlsym(handle,
+                                                                 "opencdm_session_last_decrypt_status");
                    });
 }
 
@@ -248,11 +261,32 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
             }
         }
 
+        if (result != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
+        {
+            uint32_t lastDecryptStatus{0};
+            if ((m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus) == ERROR_NONE) &&
+                isOutputRestrictedDecryptStatus(lastDecryptStatus))
+            {
+                return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
+            }
+        }
+
         return convertOpenCdmError(result);
     }
 
     // Fallback: adapter without _once handles retries internally.
     OpenCDMError status = opencdm_gstreamer_session_decrypt_buffer(m_session, encrypted, caps);
+
+    if (status != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
+    {
+        uint32_t lastDecryptStatus{0};
+        if ((m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus) == ERROR_NONE) &&
+            isOutputRestrictedDecryptStatus(lastDecryptStatus))
+        {
+            return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
+        }
+    }
+
     return convertOpenCdmError(status);
 }
 

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -19,7 +19,6 @@
 
 #include "OcdmSession.h"
 #include "OcdmCommon.h"
-#include "RialtoCommonLogging.h"
 #include "opencdm/open_cdm_adapter.h"
 #include "opencdm/open_cdm_ext.h"
 #include <dlfcn.h>
@@ -265,26 +264,11 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
         if (result != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
         {
             uint32_t lastDecryptStatus{0};
-            const OpenCDMError lastStatusRet = m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus);
-            RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(_once): decrypt failed result=%u, "
-                                    "lastDecryptStatusRet=%u, lastDecryptStatus=%u",
-                                    static_cast<uint32_t>(result), static_cast<uint32_t>(lastStatusRet),
-                                    lastDecryptStatus);
-
-            if ((lastStatusRet == ERROR_NONE) && isOutputRestrictedDecryptStatus(lastDecryptStatus))
+            if ((m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus) == ERROR_NONE) &&
+                isOutputRestrictedDecryptStatus(lastDecryptStatus))
             {
-                RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(_once): mapping decrypt failure to "
-                                        "OUTPUT_RESTRICTED (status=%u)",
-                                        lastDecryptStatus);
                 return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
             }
-        }
-        else if (result != ERROR_NONE)
-        {
-            RIALTO_COMMON_LOG_ERROR(
-                "VRN OcdmSession decryptBuffer(_once): decrypt failed result=%u and LastDecryptStatus API is "
-                "unavailable",
-                static_cast<uint32_t>(result));
         }
 
         return convertOpenCdmError(result);
@@ -296,26 +280,11 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
     if (status != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
     {
         uint32_t lastDecryptStatus{0};
-        const OpenCDMError lastStatusRet = m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus);
-        RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(fallback): decrypt failed status=%u, "
-                    "lastDecryptStatusRet=%u, lastDecryptStatus=%u",
-                    static_cast<uint32_t>(status), static_cast<uint32_t>(lastStatusRet),
-                    lastDecryptStatus);
-
-        if ((lastStatusRet == ERROR_NONE) && isOutputRestrictedDecryptStatus(lastDecryptStatus))
+        if ((m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus) == ERROR_NONE) &&
+            isOutputRestrictedDecryptStatus(lastDecryptStatus))
         {
-            RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(fallback): mapping decrypt failure to "
-                                    "OUTPUT_RESTRICTED (status=%u)",
-                                    lastDecryptStatus);
             return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
         }
-    }
-    else if (status != ERROR_NONE)
-    {
-        RIALTO_COMMON_LOG_ERROR(
-            "VRN OcdmSession decryptBuffer(fallback): decrypt failed status=%u and LastDecryptStatus API is "
-            "unavailable",
-            static_cast<uint32_t>(status));
     }
 
     return convertOpenCdmError(status);

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -260,7 +260,8 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
                 return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
             }
         }
-
+#if 0
+#errrrr123
         if (result != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
         {
             uint32_t lastDecryptStatus{0};
@@ -270,13 +271,14 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
                 return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
             }
         }
-
+#endif
         return convertOpenCdmError(result);
     }
 
     // Fallback: adapter without _once handles retries internally.
     OpenCDMError status = opencdm_gstreamer_session_decrypt_buffer(m_session, encrypted, caps);
-
+#if 0
+#errrrr123
     if (status != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
     {
         uint32_t lastDecryptStatus{0};
@@ -286,6 +288,7 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
             return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
         }
     }
+#endif
 
     return convertOpenCdmError(status);
 }

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -19,6 +19,7 @@
 
 #include "OcdmSession.h"
 #include "OcdmCommon.h"
+#include "RialtoCommonLogging.h"
 #include "opencdm/open_cdm_adapter.h"
 #include "opencdm/open_cdm_ext.h"
 #include <dlfcn.h>
@@ -264,11 +265,26 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
         if (result != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
         {
             uint32_t lastDecryptStatus{0};
-            if ((m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus) == ERROR_NONE) &&
-                isOutputRestrictedDecryptStatus(lastDecryptStatus))
+            const OpenCDMError lastStatusRet = m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus);
+            RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(_once): decrypt failed result=%u, "
+                                    "lastDecryptStatusRet=%u, lastDecryptStatus=%u",
+                                    static_cast<uint32_t>(result), static_cast<uint32_t>(lastStatusRet),
+                                    lastDecryptStatus);
+
+            if ((lastStatusRet == ERROR_NONE) && isOutputRestrictedDecryptStatus(lastDecryptStatus))
             {
+                RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(_once): mapping decrypt failure to "
+                                        "OUTPUT_RESTRICTED (status=%u)",
+                                        lastDecryptStatus);
                 return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
             }
+        }
+        else if (result != ERROR_NONE)
+        {
+            RIALTO_COMMON_LOG_ERROR(
+                "VRN OcdmSession decryptBuffer(_once): decrypt failed result=%u and LastDecryptStatus API is "
+                "unavailable",
+                static_cast<uint32_t>(result));
         }
 
         return convertOpenCdmError(result);
@@ -280,11 +296,26 @@ MediaKeyErrorStatus OcdmSession::decryptBuffer(GstBuffer *encrypted, GstCaps *ca
     if (status != ERROR_NONE && m_ocdmSessionLastDecryptStatus)
     {
         uint32_t lastDecryptStatus{0};
-        if ((m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus) == ERROR_NONE) &&
-            isOutputRestrictedDecryptStatus(lastDecryptStatus))
+        const OpenCDMError lastStatusRet = m_ocdmSessionLastDecryptStatus(m_session, &lastDecryptStatus);
+        RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(fallback): decrypt failed status=%u, "
+                    "lastDecryptStatusRet=%u, lastDecryptStatus=%u",
+                    static_cast<uint32_t>(status), static_cast<uint32_t>(lastStatusRet),
+                    lastDecryptStatus);
+
+        if ((lastStatusRet == ERROR_NONE) && isOutputRestrictedDecryptStatus(lastDecryptStatus))
         {
+            RIALTO_COMMON_LOG_ERROR("VRN OcdmSession decryptBuffer(fallback): mapping decrypt failure to "
+                                    "OUTPUT_RESTRICTED (status=%u)",
+                                    lastDecryptStatus);
             return MediaKeyErrorStatus::OUTPUT_RESTRICTED;
         }
+    }
+    else if (status != ERROR_NONE)
+    {
+        RIALTO_COMMON_LOG_ERROR(
+            "VRN OcdmSession decryptBuffer(fallback): decrypt failed status=%u and LastDecryptStatus API is "
+            "unavailable",
+            static_cast<uint32_t>(status));
     }
 
     return convertOpenCdmError(status);


### PR DESCRIPTION
Reason for change: To address the technical fault issue, the last decrypt status was used as a workaround, as the key status notification from the CDM is delayed by approximately 6 seconds in RDK-V. 
Test Procedure: Hot-plug HDMI cable and observe retry logic keep 
Risks: Low