### PR TITLE
RDKEMW-19797: Tag is not updated in rialto logs for release branches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 
 # Retrieve release tag
 execute_process(
-    COMMAND bash -c "git tag --points-at ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+    COMMAND bash -c "git tag --points-at ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-r[0-9]+)?$'"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE TAGS
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Reason for change: Tag is not updated in rialto logs for release branches Test Procedure: None
Risks: Low
Priority: P0
Signed-off-by:mkooda197@cable.comcast.com