### PR TITLE
DUMMY COMMIT - DO NOT MERGE

### DIFF
--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -485,7 +485,7 @@ bool MediaKeySession::checkForOcdmErrors(const char *operationStr)
     std::lock_guard<std::mutex> lock(m_ocdmErrorMutex);
     if (m_ocdmError)
     {
-        RIALTO_SERVER_LOG_ERROR("MediaKeySession received an onError callback, operation '%s' failed", operationStr);
+        RIALTO_SERVER_LOG_ERROR("MediaKeySession recved an onError callback, operation '%s' failed", operationStr);
         error = true;
     }
     m_ongoingOcdmOperation = false;


### PR DESCRIPTION
DUMMY COMMIT - DO NOT MERGE
Changes Included HDMI issue fix and Disabling synchronous play in Rialto Server

Summary: GstPipeline Decryption Error due to HDMI Hotplug issue
Type: Fix
Test Plan: UT/CI, Fullstack
Jira: DELIA-70454