### PR TITLE
Summary: Playback rate is not preserved after seek/sample replacement.

### DIFF
--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -1432,7 +1432,13 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
         RIALTO_SERVER_LOG_DEBUG("Pushing new %s sample...", typeStr.c_str());
         GstSegment *segment{m_gstWrapper->gstSegmentNew()};
         m_gstWrapper->gstSegmentInit(segment, GST_FORMAT_TIME);
-        if (!m_gstWrapper->gstSegmentDoSeek(segment, m_context.playbackRate, GST_FORMAT_TIME, seekFlag,
+
+        // Use pendingPlaybackRate if set (race condition mitigation)
+        double segmentRate = (m_context.pendingPlaybackRate != kNoPendingPlaybackRate)
+                                 ? m_context.pendingPlaybackRate
+                                 : m_context.playbackRate;
+
+        if (!m_gstWrapper->gstSegmentDoSeek(segment, segmentRate, GST_FORMAT_TIME, seekFlag,
                                             GST_SEEK_TYPE_SET, position, GST_SEEK_TYPE_SET, stopPosition, nullptr))
         {
             RIALTO_SERVER_LOG_WARN("Segment seek failed.");


### PR DESCRIPTION
Summary: Playback rate is not preserved after seek
Type: Fix
Test Plan: All Seek related tests
Jira: RDKEMW-15125 [WPEWebKit] playback rate after seeking/rebuffering.