### PR TITLE
Clear all CDM resources when switching to inactive state

### DIFF
--- a/media/server/service/source/CdmService.cpp
+++ b/media/server/service/source/CdmService.cpp
@@ -57,6 +57,8 @@ void CdmService::switchToInactive()
     {
         std::lock_guard<std::mutex> lock{m_mediaKeysMutex};
         m_mediaKeys.clear();
+        m_mediaKeysClients.clear();
+        m_sessionInfo.clear();
     }
 }
 

--- a/tests/unittests/media/server/service/cdmService/CdmServiceTests.cpp
+++ b/tests/unittests/media/server/service/cdmService/CdmServiceTests.cpp
@@ -716,6 +716,17 @@ TEST_F(CdmServiceTests, shouldFailToReleaseKeySessionWhenMediaKeysFails)
     destroyMediaKeysShouldSucceed();
 }
 
+TEST_F(CdmServiceTests, shouldFailToReleaseKeySessionAfterSwitchToInactive)
+{
+    triggerSwitchToActiveSuccess();
+    mediaKeysFactoryWillCreateMediaKeys();
+    createMediaKeysShouldSucceed();
+    mediaKeysWillCreateKeySessionWithStatus(firebolt::rialto::MediaKeyErrorStatus::OK);
+    createKeySessionShouldSucceed();
+    triggerSwitchToInactive();
+    releaseKeySessionShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus::FAIL);
+}
+
 TEST_F(CdmServiceTests, shouldGetNoKeySystemsFromGetSupportedKeySystemsInInactiveState)
 {
     getSupportedKeySystemsReturnNon();


### PR DESCRIPTION
Summary: Clear all CDM resources when switching to inactive state.
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-19750