### PR TITLE
Set correct segment start position to prevent bogus position reporting on AmLogic device after playback rate change

### DIFF
--- a/media/server/gstplayer/include/GenericPlayerContext.h
+++ b/media/server/gstplayer/include/GenericPlayerContext.h
@@ -271,6 +271,11 @@ struct GenericPlayerContext
      * @brief Workaround for the gstreamer flush issue
      */
     std::shared_ptr<IFlushOnPrerollController> flushOnPrerollController{std::make_shared<FlushOnPrerollController>()};
+
+    /**
+     * @brief The audio position set in the GstSegment.
+     */
+    int64_t audioGstSegmentPosition{-1};
 };
 } // namespace firebolt::rialto::server
 

--- a/media/server/gstplayer/include/GstGenericPlayer.h
+++ b/media/server/gstplayer/include/GstGenericPlayer.h
@@ -186,7 +186,6 @@ private:
     void addAutoAudioSinkChild(GObject *object) override;
     void removeAutoVideoSinkChild(GObject *object) override;
     void removeAutoAudioSinkChild(GObject *object) override;
-    void pushSampleIfRequired(GstElement *source, const std::string &typeStr) override;
     bool reattachSource(const std::unique_ptr<IMediaPipeline::MediaSource> &source) override;
     bool hasSourceType(const MediaSourceType &mediaSourceType) const override;
     GstElement *getSink(const MediaSourceType &mediaSourceType) const override;
@@ -399,6 +398,14 @@ private:
      * @param[in] enableAudio : Whether to enable audio flags.
      */
     void setPlaybinFlags(bool enableAudio = true);
+
+    /**
+     * @brief Pushes GstSample if playback position has changed or new segment needs to be sent.
+     *
+     * @param[in] source          : The Gst Source element, that should receive new sample
+     * @param[in] mediaSourceType : The media source type
+     */
+    void pushSampleIfRequired(GstElement *source, const MediaSourceType &mediaSourceType);
 
 private:
     /**

--- a/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
+++ b/media/server/gstplayer/include/IGstGenericPlayerPrivate.h
@@ -272,14 +272,6 @@ public:
     virtual GstElement *getSink(const MediaSourceType &mediaSourceType) const = 0;
 
     /**
-     * @brief Pushes GstSample if playback position has changed or new segment needs to be sent.
-     *
-     * @param[in] source          : The Gst Source element, that should receive new sample
-     * @param[in] typeStr         : The media source type string
-     */
-    virtual void pushSampleIfRequired(GstElement *source, const std::string &typeStr) = 0;
-
-    /**
      * @brief Reattaches source (or switches it)
      *
      * @param[in] source          : The new media source

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -1275,7 +1275,7 @@ void GstGenericPlayer::attachData(const firebolt::rialto::MediaSourceType mediaT
         }
         else
         {
-            pushSampleIfRequired(streamInfo.appSrc, common::convertMediaSourceType(mediaType));
+            pushSampleIfRequired(streamInfo.appSrc, mediaType);
         }
         if (mediaType == firebolt::rialto::MediaSourceType::AUDIO)
         {
@@ -1419,7 +1419,7 @@ bool GstGenericPlayer::setCodecData(GstCaps *caps, const std::shared_ptr<CodecDa
     return false;
 }
 
-void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::string &typeStr)
+void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const MediaSourceType &mediaSourceType)
 {
     auto initialPosition = m_context.initialPositions.find(source);
     if (m_context.initialPositions.end() == initialPosition)
@@ -1435,7 +1435,7 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
     for (const auto &[position, resetTime, appliedRate, stopPosition] : initialPosition->second)
     {
         GstSeekFlags seekFlag = resetTime ? GST_SEEK_FLAG_FLUSH : GST_SEEK_FLAG_NONE;
-        RIALTO_SERVER_LOG_DEBUG("Pushing new %s sample...", typeStr.c_str());
+        RIALTO_SERVER_LOG_DEBUG("Pushing new %s sample...", common::convertMediaSourceType(mediaSourceType));
         GstSegment *segment{m_gstWrapper->gstSegmentNew()};
         m_gstWrapper->gstSegmentInit(segment, GST_FORMAT_TIME);
         if (!m_gstWrapper->gstSegmentDoSeek(segment, m_context.playbackRate, GST_FORMAT_TIME, seekFlag,
@@ -1449,8 +1449,8 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
         segment->applied_rate = appliedRate;
         RIALTO_SERVER_LOG_MIL("New %s segment: [%" GST_TIME_FORMAT ", %" GST_TIME_FORMAT
                               "], rate: %f, appliedRate %f, reset_time: %d\n",
-                              typeStr.c_str(), GST_TIME_ARGS(segment->start), GST_TIME_ARGS(segment->stop),
-                              segment->rate, segment->applied_rate, resetTime);
+                              common::convertMediaSourceType(mediaSourceType), GST_TIME_ARGS(segment->start),
+                              GST_TIME_ARGS(segment->stop), segment->rate, segment->applied_rate, resetTime);
 
         GstCaps *currentCaps = m_gstWrapper->gstAppSrcGetCaps(GST_APP_SRC(source));
         // We can't pass buffer in GstSample, because implementation of gst_app_src_push_sample
@@ -1462,6 +1462,11 @@ void GstGenericPlayer::pushSampleIfRequired(GstElement *source, const std::strin
         m_gstWrapper->gstCapsUnref(currentCaps);
 
         m_gstWrapper->gstSegmentFree(segment);
+
+        if (MediaSourceType::AUDIO == mediaSourceType)
+        {
+            m_context.audioGstSegmentPosition = position;
+        }
     }
     m_context.currentPosition[source] = initialPosition->second.back();
     m_context.initialPositions.erase(initialPosition);

--- a/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
+++ b/media/server/gstplayer/source/tasks/generic/FinishSetupSource.cpp
@@ -67,7 +67,6 @@ void appSrcEnoughData(GstAppSrc *src, gpointer user_data)
  */
 gboolean appSrcSeekData(GstAppSrc *src, guint64 offset, gpointer user_data)
 {
-    appSrcEnoughData(src, user_data);
     return TRUE;
 }
 } // namespace

--- a/media/server/gstplayer/source/tasks/generic/SetPlaybackRate.cpp
+++ b/media/server/gstplayer/source/tasks/generic/SetPlaybackRate.cpp
@@ -21,6 +21,7 @@
 #include "IGlibWrapper.h"
 #include "IGstWrapper.h"
 #include "RialtoServerLogging.h"
+#include "TypeConverters.h"
 #include <gst/base/gstbasesink.h>
 
 namespace
@@ -75,7 +76,7 @@ void SetPlaybackRate::execute() const
         GstSegment *segment{m_gstWrapper->gstSegmentNew()};
         m_gstWrapper->gstSegmentInit(segment, GST_FORMAT_TIME);
         segment->rate = m_rate;
-        segment->start = GST_CLOCK_TIME_NONE;
+        segment->start = m_context.audioGstSegmentPosition;
         segment->position = GST_CLOCK_TIME_NONE;
         success = m_gstWrapper->gstPadSendEvent(GST_BASE_SINK_PAD(audioSink), m_gstWrapper->gstEventNewSegment(segment));
         RIALTO_SERVER_LOG_DEBUG("Sent new segment, success = %s", success ? "true" : "false");

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/FinishSetupSourceTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/FinishSetupSourceTest.cpp
@@ -83,7 +83,6 @@ TEST_F(FinishSetupSourceTest, shouldScheduleAudioSeekData)
     shouldFinishSetupSource();
     triggerFinishSetupSource();
     checkSetupSourceFinished();
-    shouldScheduleEnoughDataAudio();
     triggerAudioCallbackSeekData();
 }
 
@@ -92,7 +91,6 @@ TEST_F(FinishSetupSourceTest, shouldScheduleVideoSeekData)
     shouldFinishSetupSource();
     triggerFinishSetupSource();
     checkSetupSourceFinished();
-    shouldScheduleEnoughDataVideo();
     triggerVideoCallbackSeekData();
 }
 TEST_F(FinishSetupSourceTest, shouldntFinishSetupSourceWhenSourceNotSet)

--- a/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GstGenericPlayerPrivateMock.h
@@ -70,7 +70,6 @@ public:
     MOCK_METHOD(GstElement *, getSink, (const MediaSourceType &mediaSourceType), (const, override));
     MOCK_METHOD(void, addAudioClippingToBuffer, (GstBuffer * buffer, uint64_t clippingStart, uint64_t clippingEnd),
                 (const, override));
-    MOCK_METHOD(void, pushSampleIfRequired, (GstElement * source, const std::string &typeStr), (override));
     MOCK_METHOD(bool, reattachSource, (const std::unique_ptr<IMediaPipeline::MediaSource> &source), (override));
     MOCK_METHOD(void, setSourceFlushed, (const MediaSourceType &mediaSourceType), (override));
     MOCK_METHOD(void, startSubtitleClockResyncTimer, (), (override));


### PR DESCRIPTION
Summary: Set correct segment start position to prevent bogus position reporting on AmLogic device after playback rate change
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-20535