### PR TITLE
RDKEMW-18434 : [BCM Rogers Monarch IUI V2] RialtoServer process crash observed while switching between Xumo FAST channels during CC verification.

### DIFF
--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -188,11 +188,6 @@ MediaPipelineServerInternal::~MediaPipelineServerInternal()
 
         m_shmBuffer.reset();
         m_mainThread->unregisterClient(m_mainThreadClientId);
-
-        // Destroy GstPlayer first, while the main thread client is still registered.
-        // This ensures that during the worker thread drain in ~GstGenericPlayer,
-        // any callbacks (notifyNeedMediaData, notifyPlaybackState, etc.) that
-        // enqueue tasks on the main thread can still be accepted and won't crash.
         m_gstPlayer.reset();
     };
     m_mainThread->enqueueTaskAndWait(m_mainThreadClientId, task);

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -1593,9 +1593,13 @@ void MediaPipelineServerInternal::notifySourceFlushed(MediaSourceType mediaSourc
 
 void MediaPipelineServerInternal::notifyPlaybackInfo(const PlaybackInfo &playbackInfo)
 {
-    if (m_mediaPipelineClient)
+    if (m_gstPlayer && m_mediaPipelineClient)
     {
         m_mediaPipelineClient->notifyPlaybackInfo(playbackInfo);
+    }
+    else
+    {
+        RIALTO_SERVER_LOG_WARN("notifyPlaybackInfo skipped due to invalid gstPlayer");
     }
 }
 

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -188,9 +188,9 @@ MediaPipelineServerInternal::~MediaPipelineServerInternal()
 
         m_shmBuffer.reset();
         m_mainThread->unregisterClient(m_mainThreadClientId);
-        m_gstPlayer.reset();
     };
     m_mainThread->enqueueTaskAndWait(m_mainThreadClientId, task);
+    m_gstPlayer.reset();
 }
 
 bool MediaPipelineServerInternal::load(MediaType type, const std::string &mimeType, const std::string &url)

--- a/media/server/main/source/MediaPipelineServerInternal.cpp
+++ b/media/server/main/source/MediaPipelineServerInternal.cpp
@@ -188,6 +188,12 @@ MediaPipelineServerInternal::~MediaPipelineServerInternal()
 
         m_shmBuffer.reset();
         m_mainThread->unregisterClient(m_mainThreadClientId);
+
+        // Destroy GstPlayer first, while the main thread client is still registered.
+        // This ensures that during the worker thread drain in ~GstGenericPlayer,
+        // any callbacks (notifyNeedMediaData, notifyPlaybackState, etc.) that
+        // enqueue tasks on the main thread can still be accepted and won't crash.
+        m_gstPlayer.reset();
     };
     m_mainThread->enqueueTaskAndWait(m_mainThreadClientId, task);
 }


### PR DESCRIPTION
Summary: handling race conditions for GstPlayer 
Type: Fix
Test Plan: UT/CT, Fullstac
Jira: RDKEMW-18434