### PR TITLE
handling race conditions for GstPlayer, Fix pipeline setup async requests executing at pipeline teardown

### DIFF
--- a/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
@@ -408,13 +408,13 @@ public:
      * @param[in] context       : The GstGenericPlayer context
      * @param[in] player        : The GstGenericPlayer instance
      * @param[in] typefind      : The typefind element.
-     * @param[in] caps          : The GstCaps of added element
+     * @param[in] caps          : The GstCaps of added element.
      *
      * @retval the new UpdatePlaybackGroup task instance.
      */
     virtual std::unique_ptr<IPlayerTask> createUpdatePlaybackGroup(GenericPlayerContext &context,
                                                                    IGstGenericPlayerPrivate &player,
-                                                                   GstElement *typefind, const GstCaps *caps) const = 0;
+                                                                   GstElement *typefind, GstCaps *caps) const = 0;
 
     /**
      * @brief Creates a RenderFrame task.

--- a/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
@@ -105,7 +105,7 @@ public:
                                                           MediaSourceType sourceType) const override;
     std::unique_ptr<IPlayerTask> createUpdatePlaybackGroup(GenericPlayerContext &context,
                                                            IGstGenericPlayerPrivate &player, GstElement *typefind,
-                                                           const GstCaps *caps) const override;
+                                                           GstCaps *caps) const override;
     std::unique_ptr<IPlayerTask> createRenderFrame(GenericPlayerContext &context,
                                                    IGstGenericPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createPing(std::unique_ptr<IHeartbeatHandler> &&heartbeatHandler) const override;

--- a/media/server/gstplayer/include/tasks/generic/UpdatePlaybackGroup.h
+++ b/media/server/gstplayer/include/tasks/generic/UpdatePlaybackGroup.h
@@ -36,7 +36,7 @@ public:
     UpdatePlaybackGroup(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                         const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                         const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
-                        GstElement *typefind, const GstCaps *caps);
+                        GstElement *typefind, GstCaps *caps);
     ~UpdatePlaybackGroup() override;
     void execute() const override;
 
@@ -46,7 +46,7 @@ private:
     std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
     std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
     GstElement *m_typefind;
-    const GstCaps *m_caps;
+    GstCaps *m_caps;
 };
 } // namespace firebolt::rialto::server::tasks::generic
 

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -396,6 +396,7 @@ void GstGenericPlayer::deepElementAdded(GstBin *pipeline, GstBin *bin, GstElemen
     RIALTO_SERVER_LOG_DEBUG("Deep element %s added to the pipeline", GST_ELEMENT_NAME(element));
     if (self->m_workerThread)
     {
+        self->m_gstWrapper->gstObjectRef(element);
         self->m_workerThread->enqueueTask(
             self->m_taskFactory->createDeepElementAdded(self->m_context, *self, pipeline, bin, element));
     }
@@ -2734,7 +2735,12 @@ void GstGenericPlayer::handleBusMessage(GstMessage *message)
 
 void GstGenericPlayer::updatePlaybackGroup(GstElement *typefind, const GstCaps *caps)
 {
-    m_workerThread->enqueueTask(m_taskFactory->createUpdatePlaybackGroup(m_context, *this, typefind, caps));
+    if (m_workerThread)
+    {
+        m_gstWrapper->gstObjectRef(typefind);
+        GstCaps *ownedCaps{caps ? m_gstWrapper->gstCapsCopy(caps) : nullptr};
+        m_workerThread->enqueueTask(m_taskFactory->createUpdatePlaybackGroup(m_context, *this, typefind, ownedCaps));
+    }
 }
 
 void GstGenericPlayer::addAutoVideoSinkChild(GObject *object)

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -310,6 +310,7 @@ void GstGenericPlayer::termPipeline()
     }
 
     m_finishSourceSetupTimer.reset();
+    stopNotifyPlaybackInfoTimer();
 
     for (auto &elem : m_context.streamInfo)
     {

--- a/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
+++ b/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
@@ -64,6 +64,7 @@ DeepElementAdded::~DeepElementAdded()
 {
     RIALTO_SERVER_LOG_DEBUG("DeepElementAdded finished");
     m_glibWrapper->gFree(m_elementName);
+    m_gstWrapper->gstObjectUnref(m_element);
 }
 
 void DeepElementAdded::execute() const

--- a/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
@@ -282,8 +282,7 @@ std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createFirstFrameReceived(
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createUpdatePlaybackGroup(GenericPlayerContext &context,
                                                                                  IGstGenericPlayerPrivate &player,
-                                                                                 GstElement *typefind,
-                                                                                 const GstCaps *caps) const
+                                                                                 GstElement *typefind, GstCaps *caps) const
 {
     return std::make_unique<tasks::generic::UpdatePlaybackGroup>(context, player, m_gstWrapper, m_glibWrapper, typefind,
                                                                  caps);

--- a/media/server/gstplayer/source/tasks/generic/UpdatePlaybackGroup.cpp
+++ b/media/server/gstplayer/source/tasks/generic/UpdatePlaybackGroup.cpp
@@ -25,7 +25,7 @@ namespace firebolt::rialto::server::tasks::generic
 UpdatePlaybackGroup::UpdatePlaybackGroup(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                          const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                                          const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
-                                         GstElement *typefind, const GstCaps *caps)
+                                         GstElement *typefind, GstCaps *caps)
     : m_context{context}, m_player{player}, m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}, m_typefind{typefind},
       m_caps{caps}
 {
@@ -35,6 +35,11 @@ UpdatePlaybackGroup::UpdatePlaybackGroup(GenericPlayerContext &context, IGstGene
 UpdatePlaybackGroup::~UpdatePlaybackGroup()
 {
     RIALTO_SERVER_LOG_DEBUG("UpdatePlaybackGroup finished");
+    m_gstWrapper->gstObjectUnref(m_typefind);
+    if (m_caps)
+    {
+        m_gstWrapper->gstCapsUnref(m_caps);
+    }
 }
 
 void UpdatePlaybackGroup::execute() const

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -1832,12 +1832,27 @@ TEST_F(GstGenericPlayerPrivateTest, shouldUpdatePlaybackGroup)
 {
     GstElement typefind;
     GstCaps caps;
+    GstCaps copiedCaps;
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
-    EXPECT_CALL(m_taskFactoryMock, createUpdatePlaybackGroup(_, _, &typefind, &caps))
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&typefind));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCopy(&caps)).WillOnce(Return(&copiedCaps));
+    EXPECT_CALL(m_taskFactoryMock, createUpdatePlaybackGroup(_, _, &typefind, &copiedCaps))
         .WillOnce(Return(ByMove(std::move(task))));
 
     m_sut->updatePlaybackGroup(&typefind, &caps);
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldUpdatePlaybackGroupWithNullCaps)
+{
+    GstElement typefind;
+    std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
+    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&typefind));
+    EXPECT_CALL(m_taskFactoryMock, createUpdatePlaybackGroup(_, _, &typefind, nullptr))
+        .WillOnce(Return(ByMove(std::move(task))));
+
+    m_sut->updatePlaybackGroup(&typefind, nullptr);
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldAddAutoVideoSinkChildSink)

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -1696,6 +1696,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldStartPlaybackInfoTimer)
 {
     willNotifyPlaybackInfo();
     std::unique_ptr<common::ITimer> playbackInfoTimerMock = std::make_unique<StrictMock<TimerMock>>();
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), isActive()).WillOnce(Return(true));
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), cancel());
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kPlaybackInfoTimerMs, _, common::TimerType::PERIODIC))
         .WillOnce(Return(ByMove(std::move(playbackInfoTimerMock))));
 
@@ -1706,6 +1708,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldNotifyPlaybackInfoWithAudioFade)
 {
     willNotifyPlaybackInfoWithAudioFade();
     std::unique_ptr<common::ITimer> playbackInfoTimerMock = std::make_unique<StrictMock<TimerMock>>();
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), isActive()).WillOnce(Return(true));
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), cancel());
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kPlaybackInfoTimerMs, _, common::TimerType::PERIODIC))
         .WillOnce(Return(ByMove(std::move(playbackInfoTimerMock))));
 
@@ -1726,7 +1730,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldNotStartPositionReportingTimerWhenItIs
 TEST_F(GstGenericPlayerPrivateTest, shouldNotStartPlaybackInfoTimerWhenItIsActive)
 {
     std::unique_ptr<common::ITimer> timerMock = std::make_unique<StrictMock<TimerMock>>();
-    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*timerMock), isActive()).WillOnce(Return(true));
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*timerMock), isActive()).WillOnce(Return(true)).WillOnce(Return(true));
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*timerMock), cancel());
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kPlaybackInfoTimerMs, _, common::TimerType::PERIODIC))
         .WillOnce(Return(ByMove(std::move(timerMock))));
     willNotifyPlaybackInfo();
@@ -1758,6 +1763,8 @@ TEST_F(GstGenericPlayerPrivateTest, shouldSchedulePlaybackInfoWhenPlaybackInfoTi
     std::unique_ptr<common::ITimer> timerMock = std::make_unique<StrictMock<TimerMock>>();
     willNotifyPlaybackInfo();
     std::unique_ptr<common::ITimer> playbackInfoTimerMock = std::make_unique<StrictMock<TimerMock>>();
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), isActive()).WillOnce(Return(true));
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), cancel());
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kPlaybackInfoTimerMs, _, common::TimerType::PERIODIC))
         .WillOnce(Invoke(
             [&](const std::chrono::milliseconds &timeout, const std::function<void()> &callback, common::TimerType timerType)
@@ -1785,7 +1792,9 @@ TEST_F(GstGenericPlayerPrivateTest, shouldStopActivePlaybackInfoTimerTimer)
 {
     willNotifyPlaybackInfo();
     std::unique_ptr<common::ITimer> playbackInfoTimerMock = std::make_unique<StrictMock<TimerMock>>();
-    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), isActive()).WillOnce(Return(true));
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), isActive())
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), cancel());
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kPlaybackInfoTimerMs, _, common::TimerType::PERIODIC))
         .WillOnce(Return(ByMove(std::move(playbackInfoTimerMock))));
@@ -1809,7 +1818,7 @@ TEST_F(GstGenericPlayerPrivateTest, shouldNotStopInactivePlaybackInfoTimer)
 {
     willNotifyPlaybackInfo();
     std::unique_ptr<common::ITimer> playbackInfoTimerMock = std::make_unique<StrictMock<TimerMock>>();
-    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), isActive()).WillOnce(Return(false));
+    EXPECT_CALL(dynamic_cast<StrictMock<TimerMock> &>(*playbackInfoTimerMock), isActive()).WillRepeatedly(Return(false));
     EXPECT_CALL(*m_timerFactoryMock, createTimer(kPlaybackInfoTimerMs, _, common::TimerType::PERIODIC))
         .WillOnce(Return(ByMove(std::move(playbackInfoTimerMock))));
 

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -283,6 +283,7 @@ TEST_F(GstGenericPlayerTest, shouldAddDeepElement)
     GstElement element{};
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&element));
     EXPECT_CALL(m_taskFactoryMock, createDeepElementAdded(_, _, _, _, &element)).WillOnce(Return(ByMove(std::move(task))));
 
     triggerDeepElementAdded(&element);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -2067,6 +2067,8 @@ void GenericTasksTestsBase::shouldNotRegisterCallbackWhenPtrsAreNotEqual()
 
 void GenericTasksTestsBase::constructDeepElementAdded()
 {
+    // The element reference taken in GstGenericPlayer::deepElementAdded is released in the task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
     firebolt::rialto::server::tasks::generic::DeepElementAdded task{testContext->m_context,
                                                                     testContext->m_gstPlayer,
                                                                     testContext->m_gstWrapper,
@@ -2149,6 +2151,8 @@ void GenericTasksTestsBase::shouldSetTypefindElement()
 
 void GenericTasksTestsBase::triggerDeepElementAdded()
 {
+    // The element reference taken in GstGenericPlayer::deepElementAdded is released in the task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
     firebolt::rialto::server::tasks::generic::DeepElementAdded task{testContext->m_context,
                                                                     testContext->m_gstPlayer,
                                                                     testContext->m_gstWrapper,
@@ -2313,6 +2317,8 @@ void GenericTasksTestsBase::checkAudioSinkPlaybackGroupAdded()
 
 void GenericTasksTestsBase::triggerUpdatePlaybackGroupNoCaps()
 {
+    // The typefind reference taken in GstGenericPlayer::updatePlaybackGroup is released in the task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
     firebolt::rialto::server::tasks::generic::UpdatePlaybackGroup task{testContext->m_context,
                                                                        testContext->m_gstPlayer,
                                                                        testContext->m_gstWrapper,
@@ -2335,6 +2341,10 @@ void GenericTasksTestsBase::shouldReturnNullCaps()
 
 void GenericTasksTestsBase::triggerUpdatePlaybackGroup()
 {
+    // The typefind and caps references (owned copy) taken in GstGenericPlayer::updatePlaybackGroup are released in the
+    // task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstCapsUnref(&testContext->m_gstCaps1));
     firebolt::rialto::server::tasks::generic::UpdatePlaybackGroup task{testContext->m_context,
                                                                        testContext->m_gstPlayer,
                                                                        testContext->m_gstWrapper,

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GstGenericPlayerTestCommon.cpp
@@ -56,6 +56,7 @@ void GstGenericPlayerTestCommon::gstPlayerWillBeDestroyed()
 {
     expectShutdown();
     expectStop();
+    EXPECT_CALL(*m_timerFactoryMock, createTimer(_, _, _)).Times(0);
     EXPECT_CALL(*m_gstWrapperMock, gstPipelineGetBus(GST_PIPELINE(&m_pipeline))).WillOnce(Return(&m_bus));
     EXPECT_CALL(*m_gstWrapperMock, gstBusSetSyncHandler(&m_bus, nullptr, nullptr, nullptr));
     EXPECT_CALL(*m_gstWrapperMock, gstObjectUnref(&m_bus));

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
@@ -113,11 +113,14 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateAttachSource)
 
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateDeepElementAdded)
 {
+    GstElement element{};
     EXPECT_CALL(*m_gstWrapper, gstObjectParent(_)).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapper, gstObjectCast(_)).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapper, gstElementGetName(_)).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_glibWrapper, gFree(nullptr));
-    auto task = m_sut.createDeepElementAdded(m_context, m_gstPlayer, nullptr, nullptr, nullptr);
+    // The task destructor releases the element reference taken when the task is scheduled.
+    EXPECT_CALL(*m_gstWrapper, gstObjectUnref(&element));
+    auto task = m_sut.createDeepElementAdded(m_context, m_gstPlayer, nullptr, nullptr, &element);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::DeepElementAdded &>(*task));
 }
@@ -320,7 +323,10 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetPlaybackRate)
 
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateUpdatePlaybackGroup)
 {
-    auto task = m_sut.createUpdatePlaybackGroup(m_context, m_gstPlayer, nullptr, nullptr);
+    GstElement typefind{};
+    // The task destructor releases the typefind reference taken when the task is scheduled.
+    EXPECT_CALL(*m_gstWrapper, gstObjectUnref(&typefind));
+    auto task = m_sut.createUpdatePlaybackGroup(m_context, m_gstPlayer, &typefind, nullptr);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::UpdatePlaybackGroup &>(*task));
 }

--- a/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
@@ -113,8 +113,7 @@ public:
                  MediaSourceType sourceType),
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createUpdatePlaybackGroup,
-                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, GstElement *typefind,
-                 const GstCaps *caps),
+                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, GstElement *typefind, GstCaps *caps),
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createRenderFrame,
                 (GenericPlayerContext & context, IGstGenericPlayerPrivate &player), (const, override));


### PR DESCRIPTION
Summary: handling race conditions for GstPlayer, Fix pipeline setup async requests executing at pipeline teardown
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-22111 RDKEMW-21806 RDKEMW-18434