### PR TITLE
Fix pipeline setup async requests executing at pipeline teardown

### DIFF
--- a/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/IGenericPlayerTaskFactory.h
@@ -409,13 +409,13 @@ public:
      * @param[in] context       : The GstGenericPlayer context
      * @param[in] player        : The GstGenericPlayer instance
      * @param[in] typefind      : The typefind element.
-     * @param[in] caps          : The GstCaps of added element
+     * @param[in] caps          : The GstCaps of added element.
      *
      * @retval the new UpdatePlaybackGroup task instance.
      */
     virtual std::unique_ptr<IPlayerTask> createUpdatePlaybackGroup(GenericPlayerContext &context,
                                                                    IGstGenericPlayerPrivate &player,
-                                                                   GstElement *typefind, const GstCaps *caps) const = 0;
+                                                                   GstElement *typefind, GstCaps *caps) const = 0;
 
     /**
      * @brief Creates a RenderFrame task.

--- a/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
+++ b/media/server/gstplayer/include/tasks/generic/GenericPlayerTaskFactory.h
@@ -106,7 +106,7 @@ public:
                              AudioFirstFrameAction audioAction = AudioFirstFrameAction::CLEAR_PROBE) const override;
     std::unique_ptr<IPlayerTask> createUpdatePlaybackGroup(GenericPlayerContext &context,
                                                            IGstGenericPlayerPrivate &player, GstElement *typefind,
-                                                           const GstCaps *caps) const override;
+                                                           GstCaps *caps) const override;
     std::unique_ptr<IPlayerTask> createRenderFrame(GenericPlayerContext &context,
                                                    IGstGenericPlayerPrivate &player) const override;
     std::unique_ptr<IPlayerTask> createPing(std::unique_ptr<IHeartbeatHandler> &&heartbeatHandler) const override;

--- a/media/server/gstplayer/include/tasks/generic/UpdatePlaybackGroup.h
+++ b/media/server/gstplayer/include/tasks/generic/UpdatePlaybackGroup.h
@@ -36,7 +36,7 @@ public:
     UpdatePlaybackGroup(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                         const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                         const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
-                        GstElement *typefind, const GstCaps *caps);
+                        GstElement *typefind, GstCaps *caps);
     ~UpdatePlaybackGroup() override;
     void execute() const override;
 
@@ -46,7 +46,7 @@ private:
     std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> m_gstWrapper;
     std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> m_glibWrapper;
     GstElement *m_typefind;
-    const GstCaps *m_caps;
+    GstCaps *m_caps;
 };
 } // namespace firebolt::rialto::server::tasks::generic
 

--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -400,6 +400,7 @@ void GstGenericPlayer::deepElementAdded(GstBin *pipeline, GstBin *bin, GstElemen
     RIALTO_SERVER_LOG_DEBUG("Deep element %s added to the pipeline", GST_ELEMENT_NAME(element));
     if (self->m_workerThread)
     {
+        self->m_gstWrapper->gstObjectRef(element);
         self->m_workerThread->enqueueTask(
             self->m_taskFactory->createDeepElementAdded(self->m_context, *self, pipeline, bin, element));
     }
@@ -2902,7 +2903,12 @@ void GstGenericPlayer::handleBusMessage(GstMessage *message)
 
 void GstGenericPlayer::updatePlaybackGroup(GstElement *typefind, const GstCaps *caps)
 {
-    m_workerThread->enqueueTask(m_taskFactory->createUpdatePlaybackGroup(m_context, *this, typefind, caps));
+    if (m_workerThread)
+    {
+        m_gstWrapper->gstObjectRef(typefind);
+        GstCaps *ownedCaps{caps ? m_gstWrapper->gstCapsCopy(caps) : nullptr};
+        m_workerThread->enqueueTask(m_taskFactory->createUpdatePlaybackGroup(m_context, *this, typefind, ownedCaps));
+    }
 }
 
 void GstGenericPlayer::addAutoVideoSinkChild(GObject *object)

--- a/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
+++ b/media/server/gstplayer/source/tasks/generic/DeepElementAdded.cpp
@@ -64,6 +64,7 @@ DeepElementAdded::~DeepElementAdded()
 {
     RIALTO_SERVER_LOG_DEBUG("DeepElementAdded finished");
     m_glibWrapper->gFree(m_elementName);
+    m_gstWrapper->gstObjectUnref(m_element);
 }
 
 void DeepElementAdded::execute() const

--- a/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
+++ b/media/server/gstplayer/source/tasks/generic/GenericPlayerTaskFactory.cpp
@@ -284,8 +284,7 @@ std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createFirstFrameReceived(
 
 std::unique_ptr<IPlayerTask> GenericPlayerTaskFactory::createUpdatePlaybackGroup(GenericPlayerContext &context,
                                                                                  IGstGenericPlayerPrivate &player,
-                                                                                 GstElement *typefind,
-                                                                                 const GstCaps *caps) const
+                                                                                 GstElement *typefind, GstCaps *caps) const
 {
     return std::make_unique<tasks::generic::UpdatePlaybackGroup>(context, player, m_gstWrapper, m_glibWrapper, typefind,
                                                                  caps);

--- a/media/server/gstplayer/source/tasks/generic/UpdatePlaybackGroup.cpp
+++ b/media/server/gstplayer/source/tasks/generic/UpdatePlaybackGroup.cpp
@@ -25,7 +25,7 @@ namespace firebolt::rialto::server::tasks::generic
 UpdatePlaybackGroup::UpdatePlaybackGroup(GenericPlayerContext &context, IGstGenericPlayerPrivate &player,
                                          const std::shared_ptr<firebolt::rialto::wrappers::IGstWrapper> &gstWrapper,
                                          const std::shared_ptr<firebolt::rialto::wrappers::IGlibWrapper> &glibWrapper,
-                                         GstElement *typefind, const GstCaps *caps)
+                                         GstElement *typefind, GstCaps *caps)
     : m_context{context}, m_player{player}, m_gstWrapper{gstWrapper}, m_glibWrapper{glibWrapper}, m_typefind{typefind},
       m_caps{caps}
 {
@@ -35,6 +35,11 @@ UpdatePlaybackGroup::UpdatePlaybackGroup(GenericPlayerContext &context, IGstGene
 UpdatePlaybackGroup::~UpdatePlaybackGroup()
 {
     RIALTO_SERVER_LOG_DEBUG("UpdatePlaybackGroup finished");
+    m_gstWrapper->gstObjectUnref(m_typefind);
+    if (m_caps)
+    {
+        m_gstWrapper->gstCapsUnref(m_caps);
+    }
 }
 
 void UpdatePlaybackGroup::execute() const

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerPrivateTest.cpp
@@ -1970,12 +1970,27 @@ TEST_F(GstGenericPlayerPrivateTest, shouldUpdatePlaybackGroup)
 {
     GstElement typefind;
     GstCaps caps;
+    GstCaps copiedCaps;
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
-    EXPECT_CALL(m_taskFactoryMock, createUpdatePlaybackGroup(_, _, &typefind, &caps))
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&typefind));
+    EXPECT_CALL(*m_gstWrapperMock, gstCapsCopy(&caps)).WillOnce(Return(&copiedCaps));
+    EXPECT_CALL(m_taskFactoryMock, createUpdatePlaybackGroup(_, _, &typefind, &copiedCaps))
         .WillOnce(Return(ByMove(std::move(task))));
 
     m_sut->updatePlaybackGroup(&typefind, &caps);
+}
+
+TEST_F(GstGenericPlayerPrivateTest, shouldUpdatePlaybackGroupWithNullCaps)
+{
+    GstElement typefind;
+    std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
+    EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&typefind));
+    EXPECT_CALL(m_taskFactoryMock, createUpdatePlaybackGroup(_, _, &typefind, nullptr))
+        .WillOnce(Return(ByMove(std::move(task))));
+
+    m_sut->updatePlaybackGroup(&typefind, nullptr);
 }
 
 TEST_F(GstGenericPlayerPrivateTest, shouldAddAutoVideoSinkChildSink)

--- a/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/GstGenericPlayerTest.cpp
@@ -283,6 +283,7 @@ TEST_F(GstGenericPlayerTest, shouldAddDeepElement)
     GstElement element{};
     std::unique_ptr<IPlayerTask> task{std::make_unique<StrictMock<PlayerTaskMock>>()};
     EXPECT_CALL(dynamic_cast<StrictMock<PlayerTaskMock> &>(*task), execute());
+    EXPECT_CALL(*m_gstWrapperMock, gstObjectRef(&element));
     EXPECT_CALL(m_taskFactoryMock, createDeepElementAdded(_, _, _, _, &element)).WillOnce(Return(ByMove(std::move(task))));
 
     triggerDeepElementAdded(&element);

--- a/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/common/GenericTasksTestsBase.cpp
@@ -2192,6 +2192,8 @@ void GenericTasksTestsBase::shouldNotRegisterCallbackWhenPtrsAreNotEqual()
 
 void GenericTasksTestsBase::constructDeepElementAdded()
 {
+    // The element reference taken in GstGenericPlayer::deepElementAdded is released in the task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
     firebolt::rialto::server::tasks::generic::DeepElementAdded task{testContext->m_context,
                                                                     testContext->m_gstPlayer,
                                                                     testContext->m_gstWrapper,
@@ -2274,6 +2276,8 @@ void GenericTasksTestsBase::shouldSetTypefindElement()
 
 void GenericTasksTestsBase::triggerDeepElementAdded()
 {
+    // The element reference taken in GstGenericPlayer::deepElementAdded is released in the task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
     firebolt::rialto::server::tasks::generic::DeepElementAdded task{testContext->m_context,
                                                                     testContext->m_gstPlayer,
                                                                     testContext->m_gstWrapper,
@@ -2438,6 +2442,8 @@ void GenericTasksTestsBase::checkAudioSinkPlaybackGroupAdded()
 
 void GenericTasksTestsBase::triggerUpdatePlaybackGroupNoCaps()
 {
+    // The typefind reference taken in GstGenericPlayer::updatePlaybackGroup is released in the task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
     firebolt::rialto::server::tasks::generic::UpdatePlaybackGroup task{testContext->m_context,
                                                                        testContext->m_gstPlayer,
                                                                        testContext->m_gstWrapper,
@@ -2460,6 +2466,10 @@ void GenericTasksTestsBase::shouldReturnNullCaps()
 
 void GenericTasksTestsBase::triggerUpdatePlaybackGroup()
 {
+    // The typefind and caps references (owned copy) taken in GstGenericPlayer::updatePlaybackGroup are released in the
+    // task destructor.
+    EXPECT_CALL(*testContext->m_gstWrapper, gstObjectUnref(testContext->m_element));
+    EXPECT_CALL(*testContext->m_gstWrapper, gstCapsUnref(&testContext->m_gstCaps1));
     firebolt::rialto::server::tasks::generic::UpdatePlaybackGroup task{testContext->m_context,
                                                                        testContext->m_gstPlayer,
                                                                        testContext->m_gstWrapper,

--- a/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
+++ b/tests/unittests/media/server/gstplayer/genericPlayer/tasksTests/GenericPlayerTaskFactoryTest.cpp
@@ -114,11 +114,14 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateAttachSource)
 
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateDeepElementAdded)
 {
+    GstElement element{};
     EXPECT_CALL(*m_gstWrapper, gstObjectParent(_)).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapper, gstObjectCast(_)).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_gstWrapper, gstElementGetName(_)).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_glibWrapper, gFree(nullptr));
-    auto task = m_sut.createDeepElementAdded(m_context, m_gstPlayer, nullptr, nullptr, nullptr);
+    // The task destructor releases the element reference taken when the task is scheduled.
+    EXPECT_CALL(*m_gstWrapper, gstObjectUnref(&element));
+    auto task = m_sut.createDeepElementAdded(m_context, m_gstPlayer, nullptr, nullptr, &element);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::DeepElementAdded &>(*task));
 }
@@ -321,7 +324,10 @@ TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateSetPlaybackRate)
 
 TEST_F(GenericPlayerTaskFactoryTest, ShouldCreateUpdatePlaybackGroup)
 {
-    auto task = m_sut.createUpdatePlaybackGroup(m_context, m_gstPlayer, nullptr, nullptr);
+    GstElement typefind{};
+    // The task destructor releases the typefind reference taken when the task is scheduled.
+    EXPECT_CALL(*m_gstWrapper, gstObjectUnref(&typefind));
+    auto task = m_sut.createUpdatePlaybackGroup(m_context, m_gstPlayer, &typefind, nullptr);
     EXPECT_NE(task, nullptr);
     EXPECT_NO_THROW(dynamic_cast<firebolt::rialto::server::tasks::generic::UpdatePlaybackGroup &>(*task));
 }

--- a/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
+++ b/tests/unittests/media/server/mocks/gstplayer/GenericPlayerTaskFactoryMock.h
@@ -114,8 +114,7 @@ public:
                  MediaSourceType sourceType),
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createUpdatePlaybackGroup,
-                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, GstElement *typefind,
-                 const GstCaps *caps),
+                (GenericPlayerContext & context, IGstGenericPlayerPrivate &player, GstElement *typefind, GstCaps *caps),
                 (const, override));
     MOCK_METHOD(std::unique_ptr<IPlayerTask>, createRenderFrame,
                 (GenericPlayerContext & context, IGstGenericPlayerPrivate &player), (const, override));


### PR DESCRIPTION
Summary: Fix pipeline setup async requests executing at pipeline teardown
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-21806