### PR TITLE
Suppress g_memdup deprecation warnings across media/server CMake targets

### DIFF
--- a/media/server/CMakeLists.txt
+++ b/media/server/CMakeLists.txt
@@ -19,6 +19,12 @@
 
 set( CMAKE_CXX_STANDARD 17 )
 
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 include( CheckCXXCompilerFlag )
 

--- a/media/server/common/CMakeLists.txt
+++ b/media/server/common/CMakeLists.txt
@@ -19,6 +19,12 @@
 
 set( CMAKE_CXX_STANDARD 17 )
 
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 include( CheckCXXCompilerFlag )
 

--- a/media/server/ipc/CMakeLists.txt
+++ b/media/server/ipc/CMakeLists.txt
@@ -20,6 +20,12 @@
 # Find includes in corresponding build directories
 set( CMAKE_INCLUDE_CURRENT_DIR ON )
 
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 add_library (
         RialtoServerIpc
         STATIC

--- a/media/server/main/CMakeLists.txt
+++ b/media/server/main/CMakeLists.txt
@@ -19,6 +19,12 @@
 
 set( CMAKE_CXX_STANDARD 17 )
 
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 include( CheckCXXCompilerFlag )
 

--- a/media/server/service/CMakeLists.txt
+++ b/media/server/service/CMakeLists.txt
@@ -19,6 +19,13 @@
 
 # Find includes in corresponding build directories
 set( CMAKE_INCLUDE_CURRENT_DIR ON )
+
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 add_library (
         RialtoServerService STATIC
 


### PR DESCRIPTION
Summary: Fix errors in build due to g_memdup reference
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: NO-JIRA