### PR TITLE
RDKEMW-22812: Add persistent DRM session support in Rialto

### DIFF
--- a/media/client/ipc/include/MediaKeysIpc.h
+++ b/media/client/ipc/include/MediaKeysIpc.h
@@ -72,11 +72,10 @@ public:
     MediaKeyErrorStatus createKeySession(KeySessionType sessionType, std::weak_ptr<IMediaKeysClient> client,
                                          int32_t &keySessionId) override;
 
-    MediaKeyErrorStatus generateRequest(int32_t keySessionId, InitDataType initDataType,
-                                        const std::vector<uint8_t> &initData,
-                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                                        const LimitedDurationLicense &ldlState =
-                                            LimitedDurationLicense::NOT_SPECIFIED) override;
+    MediaKeyErrorStatus
+    generateRequest(int32_t keySessionId, InitDataType initDataType, const std::vector<uint8_t> &initData,
+                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession(int32_t keySessionId) override;
 

--- a/media/client/ipc/include/MediaKeysIpc.h
+++ b/media/client/ipc/include/MediaKeysIpc.h
@@ -74,7 +74,9 @@ public:
 
     MediaKeyErrorStatus generateRequest(int32_t keySessionId, InitDataType initDataType,
                                         const std::vector<uint8_t> &initData,
-                                        const LimitedDurationLicense &ldlState) override;
+                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                        const LimitedDurationLicense &ldlState =
+                                            LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession(int32_t keySessionId) override;
 

--- a/media/client/ipc/source/MediaKeysIpc.cpp
+++ b/media/client/ipc/source/MediaKeysIpc.cpp
@@ -395,6 +395,7 @@ MediaKeyErrorStatus MediaKeysIpc::createKeySession(KeySessionType sessionType, s
 
 MediaKeyErrorStatus MediaKeysIpc::generateRequest(int32_t keySessionId, InitDataType initDataType,
                                                   const std::vector<uint8_t> &initData,
+                                                  const std::vector<uint8_t> &cdmData,
                                                   const LimitedDurationLicense &ldlState)
 {
     if (!reattachChannelIfRequired())
@@ -450,6 +451,11 @@ MediaKeyErrorStatus MediaKeysIpc::generateRequest(int32_t keySessionId, InitData
     for (auto it = initData.begin(); it != initData.end(); it++)
     {
         request.add_init_data(*it);
+    }
+
+    for (auto it = cdmData.begin(); it != cdmData.end(); it++)
+    {
+        request.add_cdm_data(*it);
     }
 
     firebolt::rialto::GenerateRequestResponse response;

--- a/media/client/main/include/MediaKeys.h
+++ b/media/client/main/include/MediaKeys.h
@@ -84,7 +84,9 @@ public:
 
     MediaKeyErrorStatus generateRequest(int32_t keySessionId, InitDataType initDataType,
                                         const std::vector<uint8_t> &initData,
-                                        const LimitedDurationLicense &ldlState) override;
+                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                        const LimitedDurationLicense &ldlState =
+                                            LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession(int32_t keySessionId) override;
 

--- a/media/client/main/include/MediaKeys.h
+++ b/media/client/main/include/MediaKeys.h
@@ -82,11 +82,10 @@ public:
     MediaKeyErrorStatus createKeySession(KeySessionType sessionType, std::weak_ptr<IMediaKeysClient> client,
                                          int32_t &keySessionId) override;
 
-    MediaKeyErrorStatus generateRequest(int32_t keySessionId, InitDataType initDataType,
-                                        const std::vector<uint8_t> &initData,
-                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                                        const LimitedDurationLicense &ldlState =
-                                            LimitedDurationLicense::NOT_SPECIFIED) override;
+    MediaKeyErrorStatus
+    generateRequest(int32_t keySessionId, InitDataType initDataType, const std::vector<uint8_t> &initData,
+                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession(int32_t keySessionId) override;
 

--- a/media/client/main/source/MediaKeys.cpp
+++ b/media/client/main/source/MediaKeys.cpp
@@ -128,8 +128,7 @@ MediaKeyErrorStatus MediaKeys::createKeySession(KeySessionType sessionType, std:
 }
 
 MediaKeyErrorStatus MediaKeys::generateRequest(int32_t keySessionId, InitDataType initDataType,
-                                               const std::vector<uint8_t> &initData,
-                                               const std::vector<uint8_t> &cdmData,
+                                               const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
                                                const LimitedDurationLicense &ldlState)
 {
     RIALTO_CLIENT_LOG_DEBUG("entry:");

--- a/media/client/main/source/MediaKeys.cpp
+++ b/media/client/main/source/MediaKeys.cpp
@@ -129,11 +129,12 @@ MediaKeyErrorStatus MediaKeys::createKeySession(KeySessionType sessionType, std:
 
 MediaKeyErrorStatus MediaKeys::generateRequest(int32_t keySessionId, InitDataType initDataType,
                                                const std::vector<uint8_t> &initData,
+                                               const std::vector<uint8_t> &cdmData,
                                                const LimitedDurationLicense &ldlState)
 {
     RIALTO_CLIENT_LOG_DEBUG("entry:");
 
-    return m_mediaKeysIpc->generateRequest(keySessionId, initDataType, initData, ldlState);
+    return m_mediaKeysIpc->generateRequest(keySessionId, initDataType, initData, cdmData, ldlState);
 }
 
 MediaKeyErrorStatus MediaKeys::loadSession(int32_t keySessionId)

--- a/media/public/include/IMediaKeys.h
+++ b/media/public/include/IMediaKeys.h
@@ -129,7 +129,7 @@ public:
      * @param[in]  keySessionId : The key session id for the session.
      * @param[in]  initDataType : The init data type.
      * @param[in]  initData     : The init data.
-    * @param[in]  cdmData      : Optional CDM data.
+     * @param[in]  cdmData      : Optional CDM data.
      * @param[in]  ldlState     : The Limited Duration License state. Most of key systems do not need this parameter,
      *                            so the default value is NOT_SPECIFIED.
      *

--- a/media/public/include/IMediaKeys.h
+++ b/media/public/include/IMediaKeys.h
@@ -129,6 +129,7 @@ public:
      * @param[in]  keySessionId : The key session id for the session.
      * @param[in]  initDataType : The init data type.
      * @param[in]  initData     : The init data.
+    * @param[in]  cdmData      : Optional CDM data.
      * @param[in]  ldlState     : The Limited Duration License state. Most of key systems do not need this parameter,
      *                            so the default value is NOT_SPECIFIED.
      *
@@ -136,6 +137,7 @@ public:
      */
     virtual MediaKeyErrorStatus
     generateRequest(int32_t keySessionId, InitDataType initDataType, const std::vector<uint8_t> &initData,
+                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
                     const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) = 0;
 
     /**

--- a/media/server/ipc/source/MediaKeysModuleService.cpp
+++ b/media/server/ipc/source/MediaKeysModuleService.cpp
@@ -302,6 +302,7 @@ void MediaKeysModuleService::generateRequest(::google::protobuf::RpcController *
         m_cdmService.generateRequest(request->media_keys_handle(), request->key_session_id(),
                                      covertInitDataType(request->init_data_type()),
                                      std::vector<std::uint8_t>{request->init_data().begin(), request->init_data().end()},
+                                     std::vector<std::uint8_t>{request->cdm_data().begin(), request->cdm_data().end()},
                                      covertLimitedDurationLicense(request->ldl_state()));
     response->set_error_status(convertMediaKeyErrorStatus(status));
     done->Run();

--- a/media/server/main/include/IMediaKeySession.h
+++ b/media/server/main/include/IMediaKeySession.h
@@ -83,15 +83,15 @@ public:
      *
      * @param[in]  initDataType : The init data type.
      * @param[in]  initData     : The init data.
-    * @param[in]  cdmData      : Optional CDM data.
+     * @param[in]  cdmData      : Optional CDM data.
      * @param[in]  ldlState     : The Limited Duration License state. Most of key systems do not need this parameter.
      *
      * @retval an error status.
      */
-    virtual MediaKeyErrorStatus generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
-                                                const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                                                const LimitedDurationLicense &ldlState =
-                                                    LimitedDurationLicense::NOT_SPECIFIED) = 0;
+    virtual MediaKeyErrorStatus
+    generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
+                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) = 0;
     /**
      * @brief Loads the existing key session.
      *

--- a/media/server/main/include/IMediaKeySession.h
+++ b/media/server/main/include/IMediaKeySession.h
@@ -83,12 +83,15 @@ public:
      *
      * @param[in]  initDataType : The init data type.
      * @param[in]  initData     : The init data.
+    * @param[in]  cdmData      : Optional CDM data.
      * @param[in]  ldlState     : The Limited Duration License state. Most of key systems do not need this parameter.
      *
      * @retval an error status.
      */
     virtual MediaKeyErrorStatus generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
-                                                const LimitedDurationLicense &ldlState) = 0;
+                                                const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                                const LimitedDurationLicense &ldlState =
+                                                    LimitedDurationLicense::NOT_SPECIFIED) = 0;
     /**
      * @brief Loads the existing key session.
      *

--- a/media/server/main/include/IMediaKeySession.h
+++ b/media/server/main/include/IMediaKeySession.h
@@ -88,10 +88,9 @@ public:
      *
      * @retval an error status.
      */
-    virtual MediaKeyErrorStatus
-    generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
-                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) = 0;
+    virtual MediaKeyErrorStatus generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
+                                                const std::vector<uint8_t> &cdmData,
+                                                const LimitedDurationLicense &ldlState) = 0;
     /**
      * @brief Loads the existing key session.
      *

--- a/media/server/main/include/MediaKeySession.h
+++ b/media/server/main/include/MediaKeySession.h
@@ -71,10 +71,9 @@ public:
      */
     virtual ~MediaKeySession();
 
-    MediaKeyErrorStatus
-    generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
-                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) override;
+    MediaKeyErrorStatus generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
+                                        const std::vector<uint8_t> &cdmData,
+                                        const LimitedDurationLicense &ldlState) override;
 
     MediaKeyErrorStatus loadSession() override;
 

--- a/media/server/main/include/MediaKeySession.h
+++ b/media/server/main/include/MediaKeySession.h
@@ -72,7 +72,9 @@ public:
     virtual ~MediaKeySession();
 
     MediaKeyErrorStatus generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
-                                        const LimitedDurationLicense &ldlState) override;
+                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                        const LimitedDurationLicense &ldlState =
+                                            LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession() override;
 

--- a/media/server/main/include/MediaKeySession.h
+++ b/media/server/main/include/MediaKeySession.h
@@ -71,10 +71,10 @@ public:
      */
     virtual ~MediaKeySession();
 
-    MediaKeyErrorStatus generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
-                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                                        const LimitedDurationLicense &ldlState =
-                                            LimitedDurationLicense::NOT_SPECIFIED) override;
+    MediaKeyErrorStatus
+    generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
+                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession() override;
 

--- a/media/server/main/include/MediaKeysServerInternal.h
+++ b/media/server/main/include/MediaKeysServerInternal.h
@@ -81,7 +81,9 @@ public:
 
     MediaKeyErrorStatus generateRequest(int32_t keySessionId, InitDataType initDataType,
                                         const std::vector<uint8_t> &initData,
-                                        const LimitedDurationLicense &ldlState) override;
+                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                        const LimitedDurationLicense &ldlState =
+                                            LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession(int32_t keySessionId) override;
 
@@ -172,6 +174,7 @@ private:
      */
     MediaKeyErrorStatus generateRequestInternal(int32_t keySessionId, InitDataType initDataType,
                                                 const std::vector<uint8_t> &initData,
+                                                const std::vector<uint8_t> &cdmData,
                                                 const LimitedDurationLicense &ldlState);
 
     /**

--- a/media/server/main/include/MediaKeysServerInternal.h
+++ b/media/server/main/include/MediaKeysServerInternal.h
@@ -79,11 +79,10 @@ public:
     MediaKeyErrorStatus createKeySession(KeySessionType sessionType, std::weak_ptr<IMediaKeysClient> client,
                                          int32_t &keySessionId) override;
 
-    MediaKeyErrorStatus generateRequest(int32_t keySessionId, InitDataType initDataType,
-                                        const std::vector<uint8_t> &initData,
-                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                                        const LimitedDurationLicense &ldlState =
-                                            LimitedDurationLicense::NOT_SPECIFIED) override;
+    MediaKeyErrorStatus
+    generateRequest(int32_t keySessionId, InitDataType initDataType, const std::vector<uint8_t> &initData,
+                    const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) override;
 
     MediaKeyErrorStatus loadSession(int32_t keySessionId) override;
 
@@ -173,8 +172,7 @@ private:
      * @retval an error status.
      */
     MediaKeyErrorStatus generateRequestInternal(int32_t keySessionId, InitDataType initDataType,
-                                                const std::vector<uint8_t> &initData,
-                                                const std::vector<uint8_t> &cdmData,
+                                                const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
                                                 const LimitedDurationLicense &ldlState);
 
     /**

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -113,11 +113,11 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
                                                      const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
-    m_extendedInterfaceInUse = (LimitedDurationLicense::NOT_SPECIFIED != ldlState) || !cdmData.empty() ||
-                               !m_queuedDrmHeader.empty();
-
-    if (LimitedDurationLicense::NOT_SPECIFIED == ldlState)
+     if (LimitedDurationLicense::NOT_SPECIFIED != ldlState)
     {
+        m_extendedInterfaceInUse = true;
+    }
+    else    {
         // Set the request flag for the onLicenseRequest callback
         m_licenseRequested = true;
     }
@@ -129,10 +129,9 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
     {
         initOcdmErrorChecking();
 
-        const std::vector<uint8_t> &cdmDataToUse = cdmData.empty() ? m_queuedDrmHeader : cdmData;
         const uint8_t *initDataPtr = initData.empty() ? nullptr : initData.data();
-        const uint8_t *cdmDataPtr = cdmDataToUse.empty() ? nullptr : cdmDataToUse.data();
-        const uint32_t cdmDataSize = cdmDataToUse.size();
+        const uint8_t *cdmDataPtr = cdmData.empty() ? nullptr : cdmData.data();
+        const uint32_t cdmDataSize = cdmData.size();
 
         status = m_ocdmSession->constructSession(m_kSessionType, initDataType, initDataPtr, initData.size(), cdmDataPtr,
                                                  cdmDataSize);
@@ -144,7 +143,12 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
         else
         {
             m_isSessionConstructed = true;
-            m_queuedDrmHeader.clear();
+            if (!m_queuedDrmHeader.empty())
+            {
+                RIALTO_SERVER_LOG_DEBUG("Setting queued drm header after session construction");
+                setDrmHeader(m_queuedDrmHeader);
+                m_queuedDrmHeader.clear();
+            }
         }
 
         if ((checkForOcdmErrors("generateRequest")) && (MediaKeyErrorStatus::OK == status))

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -109,6 +109,7 @@ MediaKeySession::~MediaKeySession()
 }
 
 MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, const std::vector<uint8_t> &initData,
+                                                     const std::vector<uint8_t> &cdmData,
                                                      const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
@@ -129,7 +130,12 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
     {
         initOcdmErrorChecking();
 
-        status = m_ocdmSession->constructSession(m_kSessionType, initDataType, &initData[0], initData.size());
+        const std::vector<uint8_t> &cdmDataToUse = cdmData.empty() ? m_queuedDrmHeader : cdmData;
+        const uint8_t *cdmDataPtr = cdmDataToUse.empty() ? nullptr : cdmDataToUse.data();
+        const uint32_t cdmDataSize = cdmDataToUse.size();
+
+        status = m_ocdmSession->constructSession(m_kSessionType, initDataType, &initData[0], initData.size(), cdmDataPtr,
+                                                 cdmDataSize);
         if (MediaKeyErrorStatus::OK != status)
         {
             RIALTO_SERVER_LOG_ERROR("Failed to construct the key session");
@@ -138,12 +144,7 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
         else
         {
             m_isSessionConstructed = true;
-            if (!m_queuedDrmHeader.empty())
-            {
-                RIALTO_SERVER_LOG_DEBUG("Setting queued drm header after session construction");
-                setDrmHeader(m_queuedDrmHeader);
-                m_queuedDrmHeader.clear();
-            }
+            m_queuedDrmHeader.clear();
         }
 
         if ((checkForOcdmErrors("generateRequest")) && (MediaKeyErrorStatus::OK == status))

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -113,11 +113,12 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
                                                      const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
-     if (LimitedDurationLicense::NOT_SPECIFIED != ldlState)
+    if (LimitedDurationLicense::NOT_SPECIFIED != ldlState)
     {
         m_extendedInterfaceInUse = true;
     }
-    else    {
+    else
+    {
         // Set the request flag for the onLicenseRequest callback
         m_licenseRequested = true;
     }

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -130,12 +130,8 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
     {
         initOcdmErrorChecking();
 
-        const uint8_t *initDataPtr = initData.empty() ? nullptr : initData.data();
-        const uint8_t *cdmDataPtr = cdmData.empty() ? nullptr : cdmData.data();
-        const uint32_t cdmDataSize = cdmData.size();
-
-        status = m_ocdmSession->constructSession(m_kSessionType, initDataType, initDataPtr, initData.size(), cdmDataPtr,
-                                                 cdmDataSize);
+        status = m_ocdmSession->constructSession(m_kSessionType, initDataType, initData.data(), initData.size(),
+                                                 cdmData.data(), cdmData.size());
         if (MediaKeyErrorStatus::OK != status)
         {
             RIALTO_SERVER_LOG_ERROR("Failed to construct the key session");

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -113,7 +113,10 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
                                                      const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
-    if (LimitedDurationLicense::NOT_SPECIFIED != ldlState)
+    const bool kIsPersistentRestoreFlow = (m_kSessionType == KeySessionType::PERSISTENT_LICENCE) &&
+                                          (!cdmData.empty()) && (LimitedDurationLicense::NOT_SPECIFIED == ldlState);
+
+    if ((LimitedDurationLicense::NOT_SPECIFIED != ldlState) || !cdmData.empty())
     {
         m_extendedInterfaceInUse = true;
     }
@@ -154,7 +157,7 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
         }
     }
 
-    if (m_isSessionConstructed && m_extendedInterfaceInUse)
+    if (m_isSessionConstructed && m_extendedInterfaceInUse && !kIsPersistentRestoreFlow)
     {
         // Ocdm-playready does not notify onProcessChallenge when complete.
         // Fetch the challenge manually.
@@ -178,7 +181,7 @@ void MediaKeySession::getChallenge(const LimitedDurationLicense &ldlState)
             return;
         }
         std::vector<uint8_t> challenge(challengeSize, 0x00);
-        status = m_ocdmSession->getChallengeData(kIsLdl, &challenge[0], &challengeSize);
+        status = m_ocdmSession->getChallengeData(kIsLdl, challenge.data(), &challengeSize);
         if (MediaKeyErrorStatus::OK != status)
         {
             RIALTO_SERVER_LOG_ERROR("Failed to get the challenge data, no onLicenseRequest will be generated");
@@ -187,7 +190,7 @@ void MediaKeySession::getChallenge(const LimitedDurationLicense &ldlState)
 
         std::string url;
         m_licenseRequested = true;
-        onProcessChallenge(url.c_str(), &challenge[0], challengeSize);
+        onProcessChallenge(url.c_str(), challenge.data(), challengeSize);
     };
     m_mainThread->enqueueTask(m_mainThreadClientId, task);
 }
@@ -217,7 +220,7 @@ MediaKeyErrorStatus MediaKeySession::updateSession(const std::vector<uint8_t> &r
     MediaKeyErrorStatus status;
     if (m_extendedInterfaceInUse)
     {
-        status = m_ocdmSession->storeLicenseData(&responseData[0], responseData.size());
+        status = m_ocdmSession->storeLicenseData(responseData.data(), responseData.size());
         if (MediaKeyErrorStatus::OK != status)
         {
             RIALTO_SERVER_LOG_ERROR("Failed to store the license data for the key session");
@@ -225,7 +228,7 @@ MediaKeyErrorStatus MediaKeySession::updateSession(const std::vector<uint8_t> &r
     }
     else
     {
-        status = m_ocdmSession->update(&responseData[0], responseData.size());
+        status = m_ocdmSession->update(responseData.data(), responseData.size());
         if (MediaKeyErrorStatus::OK != status)
         {
             RIALTO_SERVER_LOG_ERROR("Failed to update the key session");
@@ -461,7 +464,7 @@ void MediaKeySession::onKeyUpdated(const uint8_t keyId[], const uint8_t keyIdLen
         std::shared_ptr<IMediaKeysClient> client = m_mediaKeysClient.lock();
         if (client)
         {
-            KeyStatus status = m_ocdmSession->getStatus(&keyIdVec[0], keyIdVec.size());
+            KeyStatus status = m_ocdmSession->getStatus(keyIdVec.data(), keyIdVec.size());
             m_updatedKeyStatuses.push_back(std::make_pair(keyIdVec, status));
         }
     };

--- a/media/server/main/source/MediaKeySession.cpp
+++ b/media/server/main/source/MediaKeySession.cpp
@@ -113,11 +113,10 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
                                                      const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
-    if (LimitedDurationLicense::NOT_SPECIFIED != ldlState)
-    {
-        m_extendedInterfaceInUse = true;
-    }
-    else
+    m_extendedInterfaceInUse = (LimitedDurationLicense::NOT_SPECIFIED != ldlState) || !cdmData.empty() ||
+                               !m_queuedDrmHeader.empty();
+
+    if (LimitedDurationLicense::NOT_SPECIFIED == ldlState)
     {
         // Set the request flag for the onLicenseRequest callback
         m_licenseRequested = true;
@@ -131,10 +130,11 @@ MediaKeyErrorStatus MediaKeySession::generateRequest(InitDataType initDataType, 
         initOcdmErrorChecking();
 
         const std::vector<uint8_t> &cdmDataToUse = cdmData.empty() ? m_queuedDrmHeader : cdmData;
+        const uint8_t *initDataPtr = initData.empty() ? nullptr : initData.data();
         const uint8_t *cdmDataPtr = cdmDataToUse.empty() ? nullptr : cdmDataToUse.data();
         const uint32_t cdmDataSize = cdmDataToUse.size();
 
-        status = m_ocdmSession->constructSession(m_kSessionType, initDataType, &initData[0], initData.size(), cdmDataPtr,
+        status = m_ocdmSession->constructSession(m_kSessionType, initDataType, initDataPtr, initData.size(), cdmDataPtr,
                                                  cdmDataSize);
         if (MediaKeyErrorStatus::OK != status)
         {

--- a/media/server/main/source/MediaKeysServerInternal.cpp
+++ b/media/server/main/source/MediaKeysServerInternal.cpp
@@ -245,12 +245,13 @@ MediaKeyErrorStatus MediaKeysServerInternal::createKeySessionInternal(KeySession
 
 MediaKeyErrorStatus MediaKeysServerInternal::generateRequest(int32_t keySessionId, InitDataType initDataType,
                                                              const std::vector<uint8_t> &initData,
+                                                             const std::vector<uint8_t> &cdmData,
                                                              const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("entry:");
 
     MediaKeyErrorStatus status;
-    auto task = [&]() { status = generateRequestInternal(keySessionId, initDataType, initData, ldlState); };
+    auto task = [&]() { status = generateRequestInternal(keySessionId, initDataType, initData, cdmData, ldlState); };
 
     m_mainThread->enqueueTaskAndWait(m_mainThreadClientId, task);
     return status;
@@ -258,6 +259,7 @@ MediaKeyErrorStatus MediaKeysServerInternal::generateRequest(int32_t keySessionI
 
 MediaKeyErrorStatus MediaKeysServerInternal::generateRequestInternal(int32_t keySessionId, InitDataType initDataType,
                                                                      const std::vector<uint8_t> &initData,
+                                                                     const std::vector<uint8_t> &cdmData,
                                                                      const LimitedDurationLicense &ldlState)
 {
     auto sessionIter = m_mediaKeySessions.find(keySessionId);
@@ -267,7 +269,7 @@ MediaKeyErrorStatus MediaKeysServerInternal::generateRequestInternal(int32_t key
         return MediaKeyErrorStatus::BAD_SESSION_ID;
     }
 
-    MediaKeyErrorStatus status = sessionIter->second->generateRequest(initDataType, initData, ldlState);
+    MediaKeyErrorStatus status = sessionIter->second->generateRequest(initDataType, initData, cdmData, ldlState);
     if (MediaKeyErrorStatus::OK != status)
     {
         RIALTO_SERVER_LOG_ERROR("Failed to generate request for the key session %d", keySessionId);

--- a/media/server/service/include/ICdmService.h
+++ b/media/server/service/include/ICdmService.h
@@ -50,11 +50,10 @@ public:
     virtual MediaKeyErrorStatus createKeySession(int mediaKeysHandle, KeySessionType sessionType,
                                                  const std::shared_ptr<IMediaKeysClient> &client,
                                                  int32_t &keySessionId) = 0;
-    virtual MediaKeyErrorStatus generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
-                                                const std::vector<uint8_t> &initData,
-                                                const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                                                const LimitedDurationLicense &ldlState =
-                                                    LimitedDurationLicense::NOT_SPECIFIED) = 0;
+    virtual MediaKeyErrorStatus
+    generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
+                    const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) = 0;
     virtual MediaKeyErrorStatus loadSession(int mediaKeysHandle, int32_t keySessionId) = 0;
     virtual MediaKeyErrorStatus updateSession(int mediaKeysHandle, int32_t keySessionId,
                                               const std::vector<uint8_t> &responseData) = 0;

--- a/media/server/service/include/ICdmService.h
+++ b/media/server/service/include/ICdmService.h
@@ -52,7 +52,9 @@ public:
                                                  int32_t &keySessionId) = 0;
     virtual MediaKeyErrorStatus generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
                                                 const std::vector<uint8_t> &initData,
-                                                const LimitedDurationLicense &ldlState) = 0;
+                                                const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                                const LimitedDurationLicense &ldlState =
+                                                    LimitedDurationLicense::NOT_SPECIFIED) = 0;
     virtual MediaKeyErrorStatus loadSession(int mediaKeysHandle, int32_t keySessionId) = 0;
     virtual MediaKeyErrorStatus updateSession(int mediaKeysHandle, int32_t keySessionId,
                                               const std::vector<uint8_t> &responseData) = 0;

--- a/media/server/service/source/CdmService.cpp
+++ b/media/server/service/source/CdmService.cpp
@@ -152,8 +152,7 @@ MediaKeyErrorStatus CdmService::createKeySession(int mediaKeysHandle, KeySession
 }
 
 MediaKeyErrorStatus CdmService::generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
-                                                const std::vector<uint8_t> &initData,
-                                                const std::vector<uint8_t> &cdmData,
+                                                const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
                                                 const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to generate request: %d", mediaKeysHandle);

--- a/media/server/service/source/CdmService.cpp
+++ b/media/server/service/source/CdmService.cpp
@@ -153,6 +153,7 @@ MediaKeyErrorStatus CdmService::createKeySession(int mediaKeysHandle, KeySession
 
 MediaKeyErrorStatus CdmService::generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
                                                 const std::vector<uint8_t> &initData,
+                                                const std::vector<uint8_t> &cdmData,
                                                 const LimitedDurationLicense &ldlState)
 {
     RIALTO_SERVER_LOG_DEBUG("CdmService requested to generate request: %d", mediaKeysHandle);
@@ -168,7 +169,7 @@ MediaKeyErrorStatus CdmService::generateRequest(int mediaKeysHandle, int32_t key
     {
         m_sessionInfo[keySessionId].isExtendedInterfaceUsed = true;
     }
-    return mediaKeysIter->second->generateRequest(keySessionId, initDataType, initData, ldlState);
+    return mediaKeysIter->second->generateRequest(keySessionId, initDataType, initData, cdmData, ldlState);
 }
 
 MediaKeyErrorStatus CdmService::loadSession(int mediaKeysHandle, int32_t keySessionId)

--- a/media/server/service/source/CdmService.cpp
+++ b/media/server/service/source/CdmService.cpp
@@ -165,8 +165,7 @@ MediaKeyErrorStatus CdmService::generateRequest(int mediaKeysHandle, int32_t key
         RIALTO_SERVER_LOG_ERROR("Media keys handle: %d does not exists", mediaKeysHandle);
         return MediaKeyErrorStatus::FAIL;
     }
-    if (((LimitedDurationLicense::NOT_SPECIFIED != ldlState) || !cdmData.empty()) &&
-        m_sessionInfo.find(keySessionId) != m_sessionInfo.end())
+    if (LimitedDurationLicense::NOT_SPECIFIED != ldlState && m_sessionInfo.find(keySessionId) != m_sessionInfo.end())
     {
         m_sessionInfo[keySessionId].isExtendedInterfaceUsed = true;
     }

--- a/media/server/service/source/CdmService.cpp
+++ b/media/server/service/source/CdmService.cpp
@@ -165,7 +165,8 @@ MediaKeyErrorStatus CdmService::generateRequest(int mediaKeysHandle, int32_t key
         RIALTO_SERVER_LOG_ERROR("Media keys handle: %d does not exists", mediaKeysHandle);
         return MediaKeyErrorStatus::FAIL;
     }
-    if (LimitedDurationLicense::NOT_SPECIFIED != ldlState && m_sessionInfo.find(keySessionId) != m_sessionInfo.end())
+    if (((LimitedDurationLicense::NOT_SPECIFIED != ldlState) || !cdmData.empty()) &&
+        m_sessionInfo.find(keySessionId) != m_sessionInfo.end())
     {
         m_sessionInfo[keySessionId].isExtendedInterfaceUsed = true;
     }

--- a/media/server/service/source/CdmService.h
+++ b/media/server/service/source/CdmService.h
@@ -55,11 +55,10 @@ public:
     bool destroyMediaKeys(int mediaKeysHandle) override;
     MediaKeyErrorStatus createKeySession(int mediaKeysHandle, KeySessionType sessionType,
                                          const std::shared_ptr<IMediaKeysClient> &client, int32_t &keySessionId) override;
-    MediaKeyErrorStatus generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
-                                        const std::vector<uint8_t> &initData,
-                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                                        const LimitedDurationLicense &ldlState =
-                                            LimitedDurationLicense::NOT_SPECIFIED) override;
+    MediaKeyErrorStatus
+    generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
+                    const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                    const LimitedDurationLicense &ldlState = LimitedDurationLicense::NOT_SPECIFIED) override;
     MediaKeyErrorStatus loadSession(int mediaKeysHandle, int32_t keySessionId) override;
     MediaKeyErrorStatus updateSession(int mediaKeysHandle, int32_t keySessionId,
                                       const std::vector<uint8_t> &responseData) override;

--- a/media/server/service/source/CdmService.h
+++ b/media/server/service/source/CdmService.h
@@ -57,7 +57,9 @@ public:
                                          const std::shared_ptr<IMediaKeysClient> &client, int32_t &keySessionId) override;
     MediaKeyErrorStatus generateRequest(int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
                                         const std::vector<uint8_t> &initData,
-                                        const LimitedDurationLicense &ldlState) override;
+                                        const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                        const LimitedDurationLicense &ldlState =
+                                            LimitedDurationLicense::NOT_SPECIFIED) override;
     MediaKeyErrorStatus loadSession(int mediaKeysHandle, int32_t keySessionId) override;
     MediaKeyErrorStatus updateSession(int mediaKeysHandle, int32_t keySessionId,
                                       const std::vector<uint8_t> &responseData) override;

--- a/proto/mediakeysmodule.proto
+++ b/proto/mediakeysmodule.proto
@@ -204,6 +204,7 @@ message CreateKeySessionResponse {
  * @param[in] key_session_id    The key session id for the session.
  * @param[in] init_data_type    The init data type.
  * @param[in] init_data         The init data.
+ * @param[in] cdm_data          Optional CDM data.
  * @param[in]  ldlState         The Limited Duration License state. Most of key systems do not need this parameter,
  *                              so the default value is NOT_SPECIFIED.
  *
@@ -229,6 +230,7 @@ message GenerateRequestRequest {
   optional InitDataType init_data_type = 3;
   repeated uint32 init_data = 4;
   optional LimitedDurationLicense ldl_state = 5 [default = NOT_SPECIFIED];
+  repeated uint32 cdm_data = 6;
 }
 message GenerateRequestResponse {
   optional ProtoMediaKeyErrorStatus error_status = 1 [default = FAIL];

--- a/tests/common/externalLibraryMocks/OcdmSessionMock.h
+++ b/tests/common/externalLibraryMocks/OcdmSessionMock.h
@@ -31,7 +31,8 @@ class OcdmSessionMock : public IOcdmSession
 {
 public:
     MOCK_METHOD(MediaKeyErrorStatus, constructSession,
-                (KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize),
+                (KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize,
+                 const uint8_t cdmData[], uint32_t cdmDataSize),
                 (override));
     MOCK_METHOD(MediaKeyErrorStatus, getChallengeData, (bool isLDL, uint8_t *challenge, uint32_t *challengeSize),
                 (override));

--- a/tests/componenttests/server/tests/mediaKeys/MediaKeysTest.cpp
+++ b/tests/componenttests/server/tests/mediaKeys/MediaKeysTest.cpp
@@ -46,7 +46,8 @@ public:
 
 void MediaKeysTest::willGenerateRequestFail()
 {
-    EXPECT_CALL(m_ocdmSessionMock, constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size()))
+    EXPECT_CALL(m_ocdmSessionMock,
+                constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::FAIL));
 }
 

--- a/tests/componenttests/server/tests/mediaKeys/MediaKeysTestMethods.cpp
+++ b/tests/componenttests/server/tests/mediaKeys/MediaKeysTestMethods.cpp
@@ -90,8 +90,8 @@ void MediaKeysTestMethods::willGenerateRequestPlayready()
     EXPECT_CALL(m_ocdmSessionMock,
                 constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size(), _, _))
         .WillOnce(testing::Invoke(
-            [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
-                uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
+            [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize,
+                const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
             {
                 for (uint32_t i = 0; i < initDataSize; ++i)
                 {

--- a/tests/componenttests/server/tests/mediaKeys/MediaKeysTestMethods.cpp
+++ b/tests/componenttests/server/tests/mediaKeys/MediaKeysTestMethods.cpp
@@ -87,10 +87,11 @@ void MediaKeysTestMethods::ocdmSessionWillBeCreated()
 
 void MediaKeysTestMethods::willGenerateRequestPlayready()
 {
-    EXPECT_CALL(m_ocdmSessionMock, constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size()))
+    EXPECT_CALL(m_ocdmSessionMock,
+                constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size(), _, _))
         .WillOnce(testing::Invoke(
             [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
-                uint32_t initDataSize) -> MediaKeyErrorStatus
+                uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
             {
                 for (uint32_t i = 0; i < initDataSize; ++i)
                 {

--- a/tests/componenttests/server/tests/mediaKeys/SessionReadyForDecryptionTest.cpp
+++ b/tests/componenttests/server/tests/mediaKeys/SessionReadyForDecryptionTest.cpp
@@ -65,8 +65,8 @@ void SessionReadyForDecryptionTest::willGenerateRequestWidevine()
     EXPECT_CALL(m_ocdmSessionMock,
                 constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size(), _, _))
         .WillOnce(testing::Invoke(
-            [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
-                uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
+            [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize,
+                const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
             {
                 for (uint32_t i = 0; i < initDataSize; ++i)
                 {
@@ -114,8 +114,8 @@ void SessionReadyForDecryptionTest::willGenerateRequestNetflix()
     EXPECT_CALL(m_ocdmSessionMock,
                 constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size(), _, _))
         .WillOnce(testing::Invoke(
-            [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
-                uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
+            [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize,
+                const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
             {
                 for (uint32_t i = 0; i < initDataSize; ++i)
                 {

--- a/tests/componenttests/server/tests/mediaKeys/SessionReadyForDecryptionTest.cpp
+++ b/tests/componenttests/server/tests/mediaKeys/SessionReadyForDecryptionTest.cpp
@@ -62,10 +62,11 @@ public:
 
 void SessionReadyForDecryptionTest::willGenerateRequestWidevine()
 {
-    EXPECT_CALL(m_ocdmSessionMock, constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size()))
+    EXPECT_CALL(m_ocdmSessionMock,
+                constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size(), _, _))
         .WillOnce(testing::Invoke(
             [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
-                uint32_t initDataSize) -> MediaKeyErrorStatus
+                uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
             {
                 for (uint32_t i = 0; i < initDataSize; ++i)
                 {
@@ -110,10 +111,11 @@ void SessionReadyForDecryptionTest::processChallengeWidevine()
 
 void SessionReadyForDecryptionTest::willGenerateRequestNetflix()
 {
-    EXPECT_CALL(m_ocdmSessionMock, constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size()))
+    EXPECT_CALL(m_ocdmSessionMock,
+                constructSession(KeySessionType::TEMPORARY, InitDataType::CENC, _, m_kInitData.size(), _, _))
         .WillOnce(testing::Invoke(
             [&](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
-                uint32_t initDataSize) -> MediaKeyErrorStatus
+                uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize) -> MediaKeyErrorStatus
             {
                 for (uint32_t i = 0; i < initDataSize; ++i)
                 {

--- a/tests/unittests/media/client/main/mediaKeys/KeySessionTest.cpp
+++ b/tests/unittests/media/client/main/mediaKeys/KeySessionTest.cpp
@@ -81,12 +81,14 @@ TEST_F(RialtoClientMediaKeysKeySessionTest, GenerateRequest)
 {
     InitDataType initDataType = InitDataType::KEY_IDS;
     std::vector<uint8_t> initData{7, 8, 9};
+    std::vector<uint8_t> cdmData;
     LimitedDurationLicense ldlState{LimitedDurationLicense::NOT_SPECIFIED};
 
-    EXPECT_CALL(*m_mediaKeysIpcMock, generateRequest(m_kKeySessionId, initDataType, initData, ldlState))
+    EXPECT_CALL(*m_mediaKeysIpcMock, generateRequest(m_kKeySessionId, initDataType, initData, cdmData, ldlState))
         .WillOnce(Return(m_mediaKeyErrorStatus));
 
-    EXPECT_EQ(m_mediaKeys->generateRequest(m_kKeySessionId, initDataType, initData, ldlState), m_mediaKeyErrorStatus);
+    EXPECT_EQ(m_mediaKeys->generateRequest(m_kKeySessionId, initDataType, initData, cdmData, ldlState),
+              m_mediaKeyErrorStatus);
 }
 
 /**

--- a/tests/unittests/media/interface/mocks/MediaKeysMock.h
+++ b/tests/unittests/media/interface/mocks/MediaKeysMock.h
@@ -40,7 +40,7 @@ public:
                 (KeySessionType sessionType, std::weak_ptr<IMediaKeysClient> client, int32_t &keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, generateRequest,
                 (int32_t keySessionId, InitDataType initDataType, const std::vector<uint8_t> &initData,
-                 const LimitedDurationLicense &ldlState),
+                 const std::vector<uint8_t> &cdmData, const LimitedDurationLicense &ldlState),
                 (override));
     MOCK_METHOD(MediaKeyErrorStatus, loadSession, (int32_t keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, updateSession, (int32_t keySessionId, const std::vector<uint8_t> &responseData),

--- a/tests/unittests/media/server/ipc/mediaKeysModuleService/MediaKeysModuleServiceTestsFixture.cpp
+++ b/tests/unittests/media/server/ipc/mediaKeysModuleService/MediaKeysModuleServiceTestsFixture.cpp
@@ -158,7 +158,8 @@ void MediaKeysModuleServiceTests::cdmServiceWillGenerateRequest()
 {
     expectRequestSuccess();
     EXPECT_CALL(m_cdmServiceMock,
-                generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData, kLdlState))
+        generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                std::vector<uint8_t>{}, kLdlState))
         .WillOnce(Return(firebolt::rialto::MediaKeyErrorStatus::OK));
 }
 
@@ -166,7 +167,8 @@ void MediaKeysModuleServiceTests::cdmServiceWillFailToGenerateRequest()
 {
     expectRequestSuccess();
     EXPECT_CALL(m_cdmServiceMock,
-                generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData, kLdlState))
+        generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                std::vector<uint8_t>{}, kLdlState))
         .WillOnce(Return(kErrorStatus));
 }
 

--- a/tests/unittests/media/server/ipc/mediaKeysModuleService/MediaKeysModuleServiceTestsFixture.cpp
+++ b/tests/unittests/media/server/ipc/mediaKeysModuleService/MediaKeysModuleServiceTestsFixture.cpp
@@ -157,18 +157,16 @@ void MediaKeysModuleServiceTests::cdmServiceWillFailToCreateKeySession()
 void MediaKeysModuleServiceTests::cdmServiceWillGenerateRequest()
 {
     expectRequestSuccess();
-    EXPECT_CALL(m_cdmServiceMock,
-        generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
-                std::vector<uint8_t>{}, kLdlState))
+    EXPECT_CALL(m_cdmServiceMock, generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                                                  std::vector<uint8_t>{}, kLdlState))
         .WillOnce(Return(firebolt::rialto::MediaKeyErrorStatus::OK));
 }
 
 void MediaKeysModuleServiceTests::cdmServiceWillFailToGenerateRequest()
 {
     expectRequestSuccess();
-    EXPECT_CALL(m_cdmServiceMock,
-        generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
-                std::vector<uint8_t>{}, kLdlState))
+    EXPECT_CALL(m_cdmServiceMock, generateRequest(kHardcodedMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                                                  std::vector<uint8_t>{}, kLdlState))
         .WillOnce(Return(kErrorStatus));
 }
 

--- a/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
+++ b/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
@@ -47,6 +47,52 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessNoneNetflix)
 }
 
 /**
+ * Test that GenerateRequest forwards non-empty cdmData to constructSession and engages the extended interface path.
+ */
+TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithNonEmptyCdmDataUsesExtendedInterface)
+{
+    createKeySession(kWidevineKeySystem);
+
+    const std::vector<uint8_t> kCdmData{7, 8, 9};
+    const std::vector<uint8_t> kResponseData{4, 5, 6};
+
+    EXPECT_CALL(*m_ocdmSessionMock, constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
+        .WillOnce(Invoke(
+            [&kCdmData](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
+                        uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize)
+            {
+                EXPECT_NE(cdmData, nullptr);
+                EXPECT_EQ(cdmDataSize, kCdmData.size());
+                EXPECT_TRUE(std::equal(cdmData, cdmData + cdmDataSize, kCdmData.begin()));
+
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    // Extended interface path triggers a manual challenge retrieval.
+    mainThreadWillEnqueueTask();
+    EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, nullptrMatcher(), _))
+        .WillOnce(DoAll(SetArgPointee<2>(m_kChallenge.size()), Return(MediaKeyErrorStatus::OK)));
+    EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, notNullptrMatcher(), _))
+        .WillOnce(DoAll(memcpyChallenge(m_kChallenge), Return(MediaKeyErrorStatus::OK)));
+    mainThreadWillEnqueueTask();
+    EXPECT_CALL(*m_mediaKeysClientMock, onLicenseRequest(m_kKeySessionId, m_kChallenge, _));
+
+    EXPECT_EQ(MediaKeyErrorStatus::OK,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, kCdmData, m_kLdlState));
+
+    EXPECT_CALL(*m_ocdmSessionMock, update(_, _)).Times(0);
+    EXPECT_CALL(*m_ocdmSessionMock, storeLicenseData(&kResponseData[0], kResponseData.size()))
+        .WillOnce(Return(MediaKeyErrorStatus::OK));
+
+    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->updateSession(kResponseData));
+
+    // Extended interface path closes via challenge cancellation and decrypt context cleanup.
+    EXPECT_CALL(*m_ocdmSessionMock, cancelChallengeData()).WillOnce(Return(MediaKeyErrorStatus::OK));
+    EXPECT_CALL(*m_ocdmSessionMock, cleanDecryptContext()).WillOnce(Return(MediaKeyErrorStatus::OK));
+    EXPECT_CALL(*m_ocdmSessionMock, destructSession()).WillOnce(Return(MediaKeyErrorStatus::OK));
+}
+
+/**
  * Test that GenerateRequest can generate request successfully for a netflix keysystem.
  */
 TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessNetflix)

--- a/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
+++ b/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
@@ -103,9 +103,9 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithQueuedDrmHeade
 }
 
 /**
- * Test that GenerateRequest forwards non-empty cdmData to constructSession and engages the extended interface path.
+ * Test that non-empty cdmData (without LDL) engages the extended interface path.
  */
-TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithNonEmptyCdmDataUsesExtendedInterface)
+TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithNonEmptyCdmDataUsesExtendedInterfaceWithoutLdl)
 {
     createKeySession(kWidevineKeySystem);
 
@@ -135,15 +135,55 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithNonEmptyCdmDat
     EXPECT_CALL(*m_mediaKeysClientMock, onLicenseRequest(m_kKeySessionId, m_kChallenge, _));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, kCdmData,
-                                                                          LimitedDurationLicense::DISABLED));
+                                                                          LimitedDurationLicense::NOT_SPECIFIED));
 
     EXPECT_CALL(*m_ocdmSessionMock, update(_, _)).Times(0);
-    EXPECT_CALL(*m_ocdmSessionMock, storeLicenseData(&kResponseData[0], kResponseData.size()))
+    EXPECT_CALL(*m_ocdmSessionMock, storeLicenseData(kResponseData.data(), kResponseData.size()))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->updateSession(kResponseData));
 
     // Extended interface path closes via challenge cancellation and decrypt context cleanup.
+    EXPECT_CALL(*m_ocdmSessionMock, cancelChallengeData()).WillOnce(Return(MediaKeyErrorStatus::OK));
+    EXPECT_CALL(*m_ocdmSessionMock, cleanDecryptContext()).WillOnce(Return(MediaKeyErrorStatus::OK));
+    EXPECT_CALL(*m_ocdmSessionMock, destructSession()).WillOnce(Return(MediaKeyErrorStatus::OK));
+}
+
+/**
+ * Test that persistent license restore flow (non-empty cdmData with no LDL) does not fetch challenge data.
+ */
+TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessPersistentRestoreWithCdmDataDoesNotGenerateChallenge)
+{
+    m_keySessionType = KeySessionType::PERSISTENT_LICENCE;
+    createKeySession(kWidevineKeySystem);
+
+    const std::vector<uint8_t> kCdmData{7, 8, 9};
+    const std::vector<uint8_t> kResponseData{4, 5, 6};
+
+    EXPECT_CALL(*m_ocdmSessionMock,
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
+        .WillOnce(Invoke(
+            [&kCdmData](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
+                        uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize)
+            {
+                EXPECT_NE(cdmData, nullptr);
+                EXPECT_EQ(cdmDataSize, kCdmData.size());
+                EXPECT_TRUE(std::equal(cdmData, cdmData + cdmDataSize, kCdmData.begin()));
+
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(_, _, _)).Times(0);
+    EXPECT_CALL(*m_mediaKeysClientMock, onLicenseRequest(_, _, _)).Times(0);
+
+    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, kCdmData,
+                                                                          LimitedDurationLicense::NOT_SPECIFIED));
+
+    EXPECT_CALL(*m_ocdmSessionMock, update(_, _)).Times(0);
+    EXPECT_CALL(*m_ocdmSessionMock, storeLicenseData(kResponseData.data(), kResponseData.size()))
+        .WillOnce(Return(MediaKeyErrorStatus::OK));
+    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->updateSession(kResponseData));
+
     EXPECT_CALL(*m_ocdmSessionMock, cancelChallengeData()).WillOnce(Return(MediaKeyErrorStatus::OK));
     EXPECT_CALL(*m_ocdmSessionMock, cleanDecryptContext()).WillOnce(Return(MediaKeyErrorStatus::OK));
     EXPECT_CALL(*m_ocdmSessionMock, destructSession()).WillOnce(Return(MediaKeyErrorStatus::OK));

--- a/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
+++ b/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
@@ -36,10 +36,11 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessNoneNetflix)
     createKeySession(kWidevineKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
 
-    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, m_kLdlState));
+    EXPECT_EQ(MediaKeyErrorStatus::OK,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{}, m_kLdlState));
 
     // Close ocdm before destroying
     expectCloseKeySession(kWidevineKeySystem);
@@ -79,14 +80,14 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, FailNetflixWhenChallengeD
     createKeySession(kNetflixKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
     mainThreadWillEnqueueTask();
     EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, nullptrMatcher(), _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK,
-              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{},
                                                  firebolt::rialto::LimitedDurationLicense::DISABLED));
 
     // Close ocdm before destroying
@@ -101,7 +102,7 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, FailNetflixWhenGettingCha
     createKeySession(kNetflixKeySystem);
 
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
     mainThreadWillEnqueueTask();
     EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, nullptrMatcher(), _))
@@ -110,7 +111,7 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, FailNetflixWhenGettingCha
         .WillOnce(DoAll(memcpyChallenge(m_kChallenge), Return(MediaKeyErrorStatus::FAIL)));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK,
-              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{},
                                                  firebolt::rialto::LimitedDurationLicense::DISABLED));
 
     // Close ocdm before destroying
@@ -125,12 +126,14 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SessionAlreadyConstructed
     // Generate inital request
     createKeySession(kWidevineKeySystem);
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
-    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, m_kLdlState));
+    EXPECT_EQ(MediaKeyErrorStatus::OK,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{}, m_kLdlState));
 
     // Generate request again should just return OK
-    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, m_kLdlState));
+    EXPECT_EQ(MediaKeyErrorStatus::OK,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{}, m_kLdlState));
 
     // OcdmSession will be closed on destruction
     expectCloseKeySession(kWidevineKeySystem);
@@ -143,10 +146,10 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, OcdmSessionFailure)
 {
     createKeySession(kWidevineKeySystem);
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::NOT_SUPPORTED));
     EXPECT_EQ(MediaKeyErrorStatus::NOT_SUPPORTED,
-              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, m_kLdlState));
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{}, m_kLdlState));
 }
 
 /**
@@ -156,15 +159,17 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, OnErrorFailure)
 {
     createKeySession(kWidevineKeySystem);
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Invoke(
-            [this](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[], uint32_t initDataSize)
+            [this](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
+                   uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize)
             {
                 m_mediaKeySession->onError("Failure");
                 return MediaKeyErrorStatus::OK;
             }));
 
-    EXPECT_EQ(MediaKeyErrorStatus::FAIL, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, m_kLdlState));
+    EXPECT_EQ(MediaKeyErrorStatus::FAIL,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{}, m_kLdlState));
 
     // OcdmSession will be closed on destruction
     expectCloseKeySession(kWidevineKeySystem);

--- a/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
+++ b/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
@@ -47,6 +47,62 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessNoneNetflix)
 }
 
 /**
+ * Test that queued drm header is consumed after construction, non-empty cdmData is forwarded to constructSession,
+ * and the extended interface path is used.
+ */
+TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithQueuedDrmHeaderAndNonEmptyCdmDataUsesExtendedInterface)
+{
+    createKeySession(kWidevineKeySystem);
+
+    const std::vector<uint8_t> kDrmHeader{3, 2, 1};
+    const std::vector<uint8_t> kCdmData{7, 8, 9};
+
+    // Session is not constructed yet, so header is queued and extended interface is enabled.
+    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->setDrmHeader(kDrmHeader));
+
+    EXPECT_CALL(*m_ocdmSessionMock,
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
+        .WillOnce(Invoke(
+            [&kCdmData](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
+                        uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize)
+            {
+                EXPECT_NE(cdmData, nullptr);
+                EXPECT_EQ(cdmDataSize, kCdmData.size());
+                EXPECT_TRUE(std::equal(cdmData, cdmData + cdmDataSize, kCdmData.begin()));
+
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    EXPECT_CALL(*m_ocdmSessionMock, setDrmHeader(_, kDrmHeader.size()))
+        .WillOnce(Invoke(
+            [&kDrmHeader](const uint8_t drmHeader[], uint32_t drmHeaderSize)
+            {
+                EXPECT_NE(drmHeader, nullptr);
+                EXPECT_EQ(drmHeaderSize, kDrmHeader.size());
+                EXPECT_TRUE(std::equal(drmHeader, drmHeader + drmHeaderSize, kDrmHeader.begin()));
+
+                return MediaKeyErrorStatus::OK;
+            }));
+
+    // Extended interface path triggers a manual challenge retrieval.
+    mainThreadWillEnqueueTask();
+    EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, nullptrMatcher(), _))
+        .WillOnce(DoAll(SetArgPointee<2>(m_kChallenge.size()), Return(MediaKeyErrorStatus::OK)));
+    EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, notNullptrMatcher(), _))
+        .WillOnce(DoAll(memcpyChallenge(m_kChallenge), Return(MediaKeyErrorStatus::OK)));
+    mainThreadWillEnqueueTask();
+    EXPECT_CALL(*m_mediaKeysClientMock, onLicenseRequest(m_kKeySessionId, m_kChallenge, _));
+
+    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, kCdmData,
+                                                                          LimitedDurationLicense::NOT_SPECIFIED));
+
+    // Extended interface path closes via challenge cancellation and decrypt context cleanup.
+    EXPECT_CALL(*m_ocdmSessionMock, cancelChallengeData()).WillOnce(Return(MediaKeyErrorStatus::OK));
+    EXPECT_CALL(*m_ocdmSessionMock, cleanDecryptContext()).WillOnce(Return(MediaKeyErrorStatus::OK));
+    EXPECT_CALL(*m_ocdmSessionMock, destructSession()).WillOnce(Return(MediaKeyErrorStatus::OK));
+}
+
+/**
  * Test that GenerateRequest forwards non-empty cdmData to constructSession and engages the extended interface path.
  */
 TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithNonEmptyCdmDataUsesExtendedInterface)

--- a/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
+++ b/tests/unittests/media/server/main/mediaKeySession/GenerateRequestTest.cpp
@@ -56,7 +56,8 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithNonEmptyCdmDat
     const std::vector<uint8_t> kCdmData{7, 8, 9};
     const std::vector<uint8_t> kResponseData{4, 5, 6};
 
-    EXPECT_CALL(*m_ocdmSessionMock, constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
+    EXPECT_CALL(*m_ocdmSessionMock,
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Invoke(
             [&kCdmData](KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
                         uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize)
@@ -77,8 +78,8 @@ TEST_F(RialtoServerMediaKeySessionGenerateRequestTest, SuccessWithNonEmptyCdmDat
     mainThreadWillEnqueueTask();
     EXPECT_CALL(*m_mediaKeysClientMock, onLicenseRequest(m_kKeySessionId, m_kChallenge, _));
 
-    EXPECT_EQ(MediaKeyErrorStatus::OK,
-              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, kCdmData, m_kLdlState));
+    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, kCdmData,
+                                                                          LimitedDurationLicense::DISABLED));
 
     EXPECT_CALL(*m_ocdmSessionMock, update(_, _)).Times(0);
     EXPECT_CALL(*m_ocdmSessionMock, storeLicenseData(&kResponseData[0], kResponseData.size()))

--- a/tests/unittests/media/server/main/mediaKeySession/base/MediaKeySessionTestBase.cpp
+++ b/tests/unittests/media/server/main/mediaKeySession/base/MediaKeySessionTestBase.cpp
@@ -71,16 +71,18 @@ void MediaKeySessionTestBase::generateRequest()
     InitDataType m_initDataType = InitDataType::CENC;
     std::vector<uint8_t> m_initData{1, 2, 3};
 
-    EXPECT_CALL(*m_ocdmSessionMock, constructSession(m_keySessionType, m_initDataType, &m_initData[0], m_initData.size()))
+    EXPECT_CALL(*m_ocdmSessionMock,
+                constructSession(m_keySessionType, m_initDataType, &m_initData[0], m_initData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
 
-    EXPECT_EQ(MediaKeyErrorStatus::OK, m_mediaKeySession->generateRequest(m_initDataType, m_initData, m_kLdlState));
+    EXPECT_EQ(MediaKeyErrorStatus::OK,
+              m_mediaKeySession->generateRequest(m_initDataType, m_initData, std::vector<uint8_t>{}, m_kLdlState));
 }
 
 void MediaKeySessionTestBase::generateRequestPlayready()
 {
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
     mainThreadWillEnqueueTask();
     EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, nullptrMatcher(), _))
@@ -91,18 +93,18 @@ void MediaKeySessionTestBase::generateRequestPlayready()
     EXPECT_CALL(*m_mediaKeysClientMock, onLicenseRequest(m_kKeySessionId, m_kChallenge, _));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK,
-              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{},
                                                  firebolt::rialto::LimitedDurationLicense::DISABLED));
 }
 
 void MediaKeySessionTestBase::generateRequestPlayreadyWithTwoCalls()
 {
     EXPECT_CALL(*m_ocdmSessionMock,
-                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size()))
+                constructSession(m_keySessionType, m_kInitDataType, &m_kInitData[0], m_kInitData.size(), _, _))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK,
-              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{},
                                                  firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED));
     mainThreadWillEnqueueTask();
     EXPECT_CALL(*m_ocdmSessionMock, getChallengeData(m_isLDL, nullptrMatcher(), _))
@@ -113,7 +115,7 @@ void MediaKeySessionTestBase::generateRequestPlayreadyWithTwoCalls()
     EXPECT_CALL(*m_mediaKeysClientMock, onLicenseRequest(m_kKeySessionId, m_kChallenge, _));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK,
-              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData,
+              m_mediaKeySession->generateRequest(m_kInitDataType, m_kInitData, std::vector<uint8_t>{},
                                                  firebolt::rialto::LimitedDurationLicense::DISABLED));
 }
 

--- a/tests/unittests/media/server/main/mediaKeys/GenerateRequestTest.cpp
+++ b/tests/unittests/media/server/main/mediaKeys/GenerateRequestTest.cpp
@@ -24,6 +24,7 @@ class RialtoServerMediaKeysGenerateRequestTest : public MediaKeysTestBase
 protected:
     InitDataType m_initDataType = InitDataType::CENC;
     std::vector<uint8_t> m_initData{1, 2, 3};
+    std::vector<uint8_t> m_cdmData;
     LimitedDurationLicense m_ldlState{LimitedDurationLicense::NOT_SPECIFIED};
 
     RialtoServerMediaKeysGenerateRequestTest()
@@ -40,11 +41,11 @@ protected:
 TEST_F(RialtoServerMediaKeysGenerateRequestTest, Success)
 {
     mainThreadWillEnqueueTaskAndWait();
-    EXPECT_CALL(*m_mediaKeySessionMock, generateRequest(m_initDataType, m_initData, m_ldlState))
+    EXPECT_CALL(*m_mediaKeySessionMock, generateRequest(m_initDataType, m_initData, m_cdmData, m_ldlState))
         .WillOnce(Return(MediaKeyErrorStatus::OK));
 
     EXPECT_EQ(MediaKeyErrorStatus::OK,
-              m_mediaKeys->generateRequest(m_kKeySessionId, m_initDataType, m_initData, m_ldlState));
+              m_mediaKeys->generateRequest(m_kKeySessionId, m_initDataType, m_initData, m_cdmData, m_ldlState));
 }
 
 /**
@@ -54,7 +55,7 @@ TEST_F(RialtoServerMediaKeysGenerateRequestTest, SessionDoesNotExistFailure)
 {
     mainThreadWillEnqueueTaskAndWait();
     EXPECT_EQ(MediaKeyErrorStatus::BAD_SESSION_ID,
-              m_mediaKeys->generateRequest(m_kKeySessionId + 1, m_initDataType, m_initData, m_ldlState));
+              m_mediaKeys->generateRequest(m_kKeySessionId + 1, m_initDataType, m_initData, m_cdmData, m_ldlState));
 }
 
 /**
@@ -63,9 +64,9 @@ TEST_F(RialtoServerMediaKeysGenerateRequestTest, SessionDoesNotExistFailure)
 TEST_F(RialtoServerMediaKeysGenerateRequestTest, SessionFailure)
 {
     mainThreadWillEnqueueTaskAndWait();
-    EXPECT_CALL(*m_mediaKeySessionMock, generateRequest(m_initDataType, m_initData, m_ldlState))
+    EXPECT_CALL(*m_mediaKeySessionMock, generateRequest(m_initDataType, m_initData, m_cdmData, m_ldlState))
         .WillOnce(Return(MediaKeyErrorStatus::NOT_SUPPORTED));
 
     EXPECT_EQ(MediaKeyErrorStatus::NOT_SUPPORTED,
-              m_mediaKeys->generateRequest(m_kKeySessionId, m_initDataType, m_initData, m_ldlState));
+              m_mediaKeys->generateRequest(m_kKeySessionId, m_initDataType, m_initData, m_cdmData, m_ldlState));
 }

--- a/tests/unittests/media/server/mocks/main/MediaKeySessionMock.h
+++ b/tests/unittests/media/server/mocks/main/MediaKeySessionMock.h
@@ -31,7 +31,8 @@ class MediaKeySessionMock : public IMediaKeySession
 {
 public:
     MOCK_METHOD(MediaKeyErrorStatus, generateRequest,
-                (InitDataType initDataType, const std::vector<uint8_t> &initData, const LimitedDurationLicense &ldlState),
+                (InitDataType initDataType, const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
+                 const LimitedDurationLicense &ldlState),
                 (override));
     MOCK_METHOD(MediaKeyErrorStatus, loadSession, (), (override));
     MOCK_METHOD(MediaKeyErrorStatus, updateSession, (const std::vector<uint8_t> &responseData), (override));

--- a/tests/unittests/media/server/mocks/main/MediaKeysServerInternalMock.h
+++ b/tests/unittests/media/server/mocks/main/MediaKeysServerInternalMock.h
@@ -40,7 +40,7 @@ public:
                 (KeySessionType sessionType, std::weak_ptr<IMediaKeysClient> client, int32_t &keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, generateRequest,
                 (int32_t keySessionId, InitDataType initDataType, const std::vector<uint8_t> &initData,
-                 const LimitedDurationLicense &ldlState),
+                 const std::vector<uint8_t> &cdmData, const LimitedDurationLicense &ldlState),
                 (override));
     MOCK_METHOD(MediaKeyErrorStatus, loadSession, (int32_t keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, updateSession, (int32_t keySessionId, const std::vector<uint8_t> &responseData),

--- a/tests/unittests/media/server/mocks/service/CdmServiceMock.h
+++ b/tests/unittests/media/server/mocks/service/CdmServiceMock.h
@@ -41,7 +41,8 @@ public:
                 (override));
     MOCK_METHOD(MediaKeyErrorStatus, generateRequest,
                 (int mediaKeysHandle, int32_t keySessionId, InitDataType initDataType,
-                 const std::vector<uint8_t> &initData, const LimitedDurationLicense &ldlState),
+                 const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
+                 const LimitedDurationLicense &ldlState),
                 (override));
     MOCK_METHOD(MediaKeyErrorStatus, loadSession, (int mediaKeysHandle, int32_t keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, updateSession,

--- a/tests/unittests/media/server/service/cdmService/CdmServiceTests.cpp
+++ b/tests/unittests/media/server/service/cdmService/CdmServiceTests.cpp
@@ -138,6 +138,19 @@ TEST_F(CdmServiceTests, shouldGenerateRequestWithLdlEnabled)
     destroyMediaKeysShouldSucceed();
 }
 
+TEST_F(CdmServiceTests, shouldGenerateRequestWithCdmDataAndMarkExtendedInterface)
+{
+    triggerSwitchToActiveSuccess();
+    mediaKeysFactoryWillCreateMediaKeys();
+    createMediaKeysShouldSucceed();
+    mediaKeysWillCreateKeySessionWithStatus(firebolt::rialto::MediaKeyErrorStatus::OK);
+    createKeySessionShouldSucceed();
+    mediaKeysWillGenerateRequestWithCdmDataWithStatus(firebolt::rialto::MediaKeyErrorStatus::OK);
+    generateRequestWithCdmDataShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus::OK);
+    isExtendedInterfaceUsedShouldReturn(true);
+    destroyMediaKeysShouldSucceed();
+}
+
 TEST_F(CdmServiceTests, shouldFailToGenerateRequestWhenNoMediaKeys)
 {
     triggerSwitchToActiveSuccess();

--- a/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.cpp
+++ b/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.cpp
@@ -145,13 +145,15 @@ void CdmServiceTests::mediaKeysWillCreateKeySessionWithStatus(firebolt::rialto::
 
 void CdmServiceTests::mediaKeysWillGenerateRequestWithStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_CALL(m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kInitData, kLdlState))
+    EXPECT_CALL(m_mediaKeysMock,
+                generateRequest(kKeySessionId, kInitDataType, kInitData, std::vector<uint8_t>{}, kLdlState))
         .WillOnce(Return(status));
 }
 
 void CdmServiceTests::mediaKeysWillGenerateRequestLdlEnabledWithStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_CALL(m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kInitData, kLdlStateEnabled))
+    EXPECT_CALL(m_mediaKeysMock,
+                generateRequest(kKeySessionId, kInitDataType, kInitData, std::vector<uint8_t>{}, kLdlStateEnabled))
         .WillOnce(Return(status));
 }
 
@@ -288,12 +290,16 @@ void CdmServiceTests::createKeySessionShouldFailWithReturnStatus(firebolt::rialt
 
 void CdmServiceTests::generateRequestShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_EQ(status, m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData, kLdlState));
+    EXPECT_EQ(status,
+              m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                                    std::vector<uint8_t>{}, kLdlState));
 }
 
 void CdmServiceTests::generateRequestWithLdlEnabledShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_EQ(status, m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData, kLdlStateEnabled));
+    EXPECT_EQ(status,
+              m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                                    std::vector<uint8_t>{}, kLdlStateEnabled));
 }
 
 void CdmServiceTests::loadSessionShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)

--- a/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.cpp
+++ b/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.cpp
@@ -160,7 +160,7 @@ void CdmServiceTests::mediaKeysWillGenerateRequestLdlEnabledWithStatus(firebolt:
 
 void CdmServiceTests::mediaKeysWillGenerateRequestWithCdmDataWithStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_CALL(m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kInitData, kCdmData, kLdlState))
+    EXPECT_CALL(m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kInitData, kCdmData, kLdlStateEnabled))
         .WillOnce(Return(status));
 }
 
@@ -297,22 +297,20 @@ void CdmServiceTests::createKeySessionShouldFailWithReturnStatus(firebolt::rialt
 
 void CdmServiceTests::generateRequestShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_EQ(status,
-              m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
-                                    std::vector<uint8_t>{}, kLdlState));
+    EXPECT_EQ(status, m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                                            std::vector<uint8_t>{}, kLdlState));
 }
 
 void CdmServiceTests::generateRequestWithLdlEnabledShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_EQ(status,
-              m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
-                                    std::vector<uint8_t>{}, kLdlStateEnabled));
+    EXPECT_EQ(status, m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
+                                            std::vector<uint8_t>{}, kLdlStateEnabled));
 }
 
 void CdmServiceTests::generateRequestWithCdmDataShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)
 {
-    EXPECT_EQ(status,
-              m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData, kCdmData, kLdlState));
+    EXPECT_EQ(status, m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData, kCdmData,
+                                            kLdlStateEnabled));
 }
 
 void CdmServiceTests::loadSessionShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)

--- a/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.cpp
+++ b/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.cpp
@@ -45,6 +45,7 @@ const uint32_t kSubSampleCount{2};
 constexpr uint32_t kInitWithLast15{1};
 constexpr firebolt::rialto::LimitedDurationLicense kLdlState{firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED};
 constexpr firebolt::rialto::LimitedDurationLicense kLdlStateEnabled{firebolt::rialto::LimitedDurationLicense::ENABLED};
+const std::vector<std::uint8_t> kCdmData{5, 1, 9};
 const std::vector<std::string> kRobustnessLevels{"HW_SECURE_ALL", "SW_SECURE_CRYPTO"};
 } // namespace
 
@@ -154,6 +155,12 @@ void CdmServiceTests::mediaKeysWillGenerateRequestLdlEnabledWithStatus(firebolt:
 {
     EXPECT_CALL(m_mediaKeysMock,
                 generateRequest(kKeySessionId, kInitDataType, kInitData, std::vector<uint8_t>{}, kLdlStateEnabled))
+        .WillOnce(Return(status));
+}
+
+void CdmServiceTests::mediaKeysWillGenerateRequestWithCdmDataWithStatus(firebolt::rialto::MediaKeyErrorStatus status)
+{
+    EXPECT_CALL(m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kInitData, kCdmData, kLdlState))
         .WillOnce(Return(status));
 }
 
@@ -300,6 +307,12 @@ void CdmServiceTests::generateRequestWithLdlEnabledShouldReturnStatus(firebolt::
     EXPECT_EQ(status,
               m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData,
                                     std::vector<uint8_t>{}, kLdlStateEnabled));
+}
+
+void CdmServiceTests::generateRequestWithCdmDataShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)
+{
+    EXPECT_EQ(status,
+              m_sut.generateRequest(kMediaKeysHandle, kKeySessionId, kInitDataType, kInitData, kCdmData, kLdlState));
 }
 
 void CdmServiceTests::loadSessionShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status)

--- a/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.h
+++ b/tests/unittests/media/server/service/cdmService/CdmServiceTestsFixture.h
@@ -46,6 +46,7 @@ public:
     void mediaKeysWillCreateKeySessionWithStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void mediaKeysWillGenerateRequestWithStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void mediaKeysWillGenerateRequestLdlEnabledWithStatus(firebolt::rialto::MediaKeyErrorStatus status);
+    void mediaKeysWillGenerateRequestWithCdmDataWithStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void mediaKeysWillLoadSessionWithStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void mediaKeysWillUpdateSessionWithStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void mediaKeysWillCloseKeySessionWithStatus(firebolt::rialto::MediaKeyErrorStatus status);
@@ -88,6 +89,7 @@ public:
     void createKeySessionShouldFailWithReturnStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void generateRequestShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void generateRequestWithLdlEnabledShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status);
+    void generateRequestWithCdmDataShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void loadSessionShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void updateSessionShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status);
     void closeKeySessionShouldReturnStatus(firebolt::rialto::MediaKeyErrorStatus status);

--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -112,6 +112,8 @@ target_include_directories(
         include
         ${GStreamerApp_INCLUDE_DIRS}
         $<TARGET_PROPERTY:RialtoPlayerPublic,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:RialtoClientCommon,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:RialtoLogging,INTERFACE_INCLUDE_DIRECTORIES>
         ${WRAPPER_INCLUDES}
     )
 
@@ -121,6 +123,7 @@ target_link_libraries (
         PRIVATE
         ${WRAPPER_LIBS}
         ${GStreamerApp_LIBRARIES}
+        RialtoLogging
     )
 
 if( RIALTO_ENABLE_CONFIG_FILE )

--- a/wrappers/include/OcdmSession.h
+++ b/wrappers/include/OcdmSession.h
@@ -48,7 +48,8 @@ public:
     virtual ~OcdmSession();
 
     MediaKeyErrorStatus constructSession(KeySessionType sessionType, InitDataType initDataType,
-                                         const uint8_t initData[], uint32_t initDataSize) override;
+                                         const uint8_t initData[], uint32_t initDataSize,
+                                         const uint8_t cdmData[], uint32_t cdmDataSize) override;
 
     MediaKeyErrorStatus getChallengeData(bool isLDL, uint8_t *challenge, uint32_t *challengeSize) override;
 

--- a/wrappers/include/OcdmSession.h
+++ b/wrappers/include/OcdmSession.h
@@ -47,9 +47,8 @@ public:
      */
     virtual ~OcdmSession();
 
-    MediaKeyErrorStatus constructSession(KeySessionType sessionType, InitDataType initDataType,
-                                         const uint8_t initData[], uint32_t initDataSize,
-                                         const uint8_t cdmData[], uint32_t cdmDataSize) override;
+    MediaKeyErrorStatus constructSession(KeySessionType sessionType, InitDataType initDataType, const uint8_t initData[],
+                                         uint32_t initDataSize, const uint8_t cdmData[], uint32_t cdmDataSize) override;
 
     MediaKeyErrorStatus getChallengeData(bool isLDL, uint8_t *challenge, uint32_t *challengeSize) override;
 

--- a/wrappers/interface/IOcdmSession.h
+++ b/wrappers/interface/IOcdmSession.h
@@ -46,14 +46,14 @@ public:
      * @param[in]  initDataType : The init data type.
      * @param[in]  initData     : The init data pointer.
      * @param[in]  initDataSize : The size of the init data pointed to by initData.
-    * @param[in]  cdmData      : Optional CDM data pointer.
-    * @param[in]  cdmDataSize  : The size of cdmData.
+     * @param[in]  cdmData      : Optional CDM data pointer.
+     * @param[in]  cdmDataSize  : The size of cdmData.
      *
      * @retval the return status.
      */
     virtual MediaKeyErrorStatus constructSession(KeySessionType sessionType, InitDataType initDataType,
-                                        const uint8_t initData[], uint32_t initDataSize,
-                                        const uint8_t cdmData[], uint32_t cdmDataSize) = 0;
+                                                 const uint8_t initData[], uint32_t initDataSize,
+                                                 const uint8_t cdmData[], uint32_t cdmDataSize) = 0;
 
     /**
      * @brief Gets challenge data for session.

--- a/wrappers/interface/IOcdmSession.h
+++ b/wrappers/interface/IOcdmSession.h
@@ -46,11 +46,14 @@ public:
      * @param[in]  initDataType : The init data type.
      * @param[in]  initData     : The init data pointer.
      * @param[in]  initDataSize : The size of the init data pointed too by initData.
+    * @param[in]  cdmData      : Optional CDM data pointer.
+    * @param[in]  cdmDataSize  : The size of cdmData.
      *
      * @retval the return status.
      */
     virtual MediaKeyErrorStatus constructSession(KeySessionType sessionType, InitDataType initDataType,
-                                                 const uint8_t initData[], uint32_t initDataSize) = 0;
+                                        const uint8_t initData[], uint32_t initDataSize,
+                                        const uint8_t cdmData[], uint32_t cdmDataSize) = 0;
 
     /**
      * @brief Gets challenge data for session.

--- a/wrappers/interface/IOcdmSession.h
+++ b/wrappers/interface/IOcdmSession.h
@@ -45,7 +45,7 @@ public:
      * @param[in]  sessionType  : The session type.
      * @param[in]  initDataType : The init data type.
      * @param[in]  initData     : The init data pointer.
-     * @param[in]  initDataSize : The size of the init data pointed too by initData.
+     * @param[in]  initDataSize : The size of the init data pointed to by initData.
     * @param[in]  cdmData      : Optional CDM data pointer.
     * @param[in]  cdmDataSize  : The size of cdmData.
      *

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -141,7 +141,8 @@ OcdmSession::OcdmSession(struct OpenCDMSystem *systemHandle, IOcdmSessionClient 
 OcdmSession::~OcdmSession() {}
 
 MediaKeyErrorStatus OcdmSession::constructSession(KeySessionType sessionType, InitDataType initDataType,
-                                                  const uint8_t initData[], uint32_t initDataSize)
+                                                  const uint8_t initData[], uint32_t initDataSize,
+                                                  const uint8_t cdmData[], uint32_t cdmDataSize)
 {
     if (m_session)
     {
@@ -149,8 +150,8 @@ MediaKeyErrorStatus OcdmSession::constructSession(KeySessionType sessionType, In
     }
 
     OpenCDMError status = opencdm_construct_session(m_systemHandle, convertLicenseType(sessionType),
-                                                    convertInitDataType(initDataType), initData, initDataSize, nullptr,
-                                                    0, &m_ocdmCallbacks, this, &m_session);
+                                                    convertInitDataType(initDataType), initData, initDataSize, cdmData,
+                                                    cdmDataSize, &m_ocdmCallbacks, this, &m_session);
     return convertOpenCdmError(status);
 }
 

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -23,7 +23,9 @@
 #include "opencdm/open_cdm_ext.h"
 #include <dlfcn.h>
 #include <mutex>
+#include <sstream>
 #include <vector>
+#include "RialtoClientLogging.h"
 namespace
 {
 LicenseType convertLicenseType(const firebolt::rialto::KeySessionType &sessionType)
@@ -147,6 +149,21 @@ MediaKeyErrorStatus OcdmSession::constructSession(KeySessionType sessionType, In
     if (m_session)
     {
         return MediaKeyErrorStatus::OK;
+    }
+    if (cdmData && cdmDataSize > 0)
+    {
+        std::ostringstream oss;
+        for (uint32_t i = 0; i < cdmDataSize; ++i)
+        {
+            oss << std::hex << static_cast<int>(cdmData[i]);
+            if (i + 1 < cdmDataSize)
+                oss << " ";
+        }
+        RIALTO_CLIENT_LOG_ERROR("VRN cdmData is valid: size=%u, bytes=%s", cdmDataSize, oss.str().c_str());
+    }
+    else
+    {
+        RIALTO_CLIENT_LOG_ERROR("VRN cdmData is NULL or empty");
     }
 
     OpenCDMError status = opencdm_construct_session(m_systemHandle, convertLicenseType(sessionType),

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -19,13 +19,13 @@
 
 #include "OcdmSession.h"
 #include "OcdmCommon.h"
+#include "RialtoClientLogging.h"
 #include "opencdm/open_cdm_adapter.h"
 #include "opencdm/open_cdm_ext.h"
 #include <dlfcn.h>
 #include <mutex>
 #include <sstream>
 #include <vector>
-#include "RialtoClientLogging.h"
 namespace
 {
 LicenseType convertLicenseType(const firebolt::rialto::KeySessionType &sessionType)

--- a/wrappers/source/OcdmSession.cpp
+++ b/wrappers/source/OcdmSession.cpp
@@ -150,21 +150,6 @@ MediaKeyErrorStatus OcdmSession::constructSession(KeySessionType sessionType, In
     {
         return MediaKeyErrorStatus::OK;
     }
-    if (cdmData && cdmDataSize > 0)
-    {
-        std::ostringstream oss;
-        for (uint32_t i = 0; i < cdmDataSize; ++i)
-        {
-            oss << std::hex << static_cast<int>(cdmData[i]);
-            if (i + 1 < cdmDataSize)
-                oss << " ";
-        }
-        RIALTO_CLIENT_LOG_ERROR("VRN cdmData is valid: size=%u, bytes=%s", cdmDataSize, oss.str().c_str());
-    }
-    else
-    {
-        RIALTO_CLIENT_LOG_ERROR("VRN cdmData is NULL or empty");
-    }
 
     OpenCDMError status = opencdm_construct_session(m_systemHandle, convertLicenseType(sessionType),
                                                     convertInitDataType(initDataType), initData, initDataSize, cdmData,


### PR DESCRIPTION
RDKEMW-22812: Add persistent DRM session support in Rialto

Reason for change: Implement persistent-license session support in Rialto-OCDM for Widevine and PlayReady DRM. This enables applications to create, store, restore, and reuse persistent DRM sessions across application restarts in compliance with EME persistent-license requirements.
Test Procedure: Verify persistent-license session creation for Widevine & PlayReady DRM