### PR TITLE
RDKDEV-1509: Fix for native build - boilerplate removed

### DIFF
--- a/stubs/wpeframework-com/CMakeLists.txt
+++ b/stubs/wpeframework-com/CMakeLists.txt
@@ -77,19 +77,3 @@ target_include_directories(
     INTERFACE
     third-party/Source
 )
-
-set_target_properties(
-    WPEFrameworkCOM
-        PROPERTIES SOVERSION  ${PROJECT_VERSION_MAJOR}
-                   VERSION    ${CMAKE_PROJECT_VERSION}
-        )
-
-install(FILES "${PROJECT_CONFIG_FILE}"
-  DESTINATION ${CMAKE_MODULE_PATH}
-  COMPONENT wpeframeworkcom
-)
-
-install (
-        TARGETS WPEFrameworkCOM LIBRARY
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)


### PR DESCRIPTION
RDKDEV-1509: Fix for native build - biolerplate removed

Reason for change:
Remove left over boilerplate (looks like a copy-paste from stubs/wpeframework-core/CMakeLists.txt, which creates real SHARED library - .cpp files are present there).
WPEFrameworkCOM here is INTERFACE-only (no .cpp files) - setting SOVERSION/VERSION on an INTERFACE target and installing it produces no installed artifacts at all — it's a no-op.
It might be silently accepted in some environments, but might also result in compile error.
The error I get in Ubuntu 20 env with gcc 9.4.0 and cmake 3.16.3 is:
CMake Error at stubs/wpeframework-com/CMakeLists.txt:81 (set_target_properties):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "VERSION" is not allowed.
  
Test Procedure: Rialto CI