### PR TITLE
Fix sending additional GST segment after back to back flush calls

### DIFF
--- a/media/server/gstplayer/source/GstGenericPlayer.cpp
+++ b/media/server/gstplayer/source/GstGenericPlayer.cpp
@@ -1584,7 +1584,7 @@ void GstGenericPlayer::pushAdditionalSegmentIfRequired(GstElement *source)
     {
         return;
     }
-    if (initialPosition->second.size() == 1 && initialPosition->second.back().resetTime &&
+    if (!initialPosition->second.empty() && initialPosition->second.back().resetTime &&
         currentPosition->second == initialPosition->second.back())
     {
         RIALTO_SERVER_LOG_INFO("Adding additional segment with reset_time = false");


### PR DESCRIPTION
Summary: Fix sending additional GST segment after back to back flush calls.
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-23475